### PR TITLE
Update dependant libraries for OSX

### DIFF
--- a/COMPILE.TXT
+++ b/COMPILE.TXT
@@ -7,10 +7,10 @@ Linux, *BSD & Solaris. We also show steps to cross-compile for Microsoft Windows
 
 Unicorn requires few dependent packages as followings
 
-- For Mac OS X, "pkg-config" is needed.
-  Brew users can install "pkg-config" with:
+- For Mac OS X, "pkg-config" and "glib" are needed.
+  Brew users can install "pkg-config" and "glib" with:
 
-      $ brew install pkg-config
+      $ brew install pkg-config glib
 
 - For Linux, glib2-dev is needed.
   Ubuntu/Debian users can install this with:


### PR DESCRIPTION
"glib" was not installed by default and was required the QEMU parts to properly compile. The Linux part of COMPILE.TXT seems to suggest this - however the OSX version did not. This commit should fix that.
