### PR TITLE
improve Go binding safety

### DIFF
--- a/bindings/go/unicorn/unicorn.go
+++ b/bindings/go/unicorn/unicorn.go
@@ -72,10 +72,16 @@ func (u *Uc) RegRead(reg int) (uint64, error) {
 }
 
 func (u *Uc) MemWrite(addr uint64, data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	return errReturn(C.uc_mem_write(u.Handle, C.uint64_t(addr), (*C.uint8_t)(unsafe.Pointer(&data[0])), C.size_t(len(data))))
 }
 
 func (u *Uc) MemReadInto(dst []byte, addr uint64) error {
+	if len(dst) == 0 {
+		return nil
+	}
 	return errReturn(C.uc_mem_read(u.Handle, C.uint64_t(addr), (*C.uint8_t)(unsafe.Pointer(&dst[0])), C.size_t(len(dst))))
 }
 


### PR DESCRIPTION
This fixes a crash in Go if you try to write a zero byte buffer to unicorn memory.
