### PR TITLE
Fixed the list of required DLLs on Win32

### DIFF
--- a/COMPILE.TXT
+++ b/COMPILE.TXT
@@ -199,19 +199,19 @@ Unicorn requires few dependent packages as followings
 
   To run sample_x86.exe on Windows 32-bit, you need the following files:
    - unicorn.dll
-   - C:\msys32\mingw32\bin\libiconv-2.dll
-   - C:\msys32\mingw32\bin\libintl-8.dll
-   - C:\msys32\mingw32\bin\libglib-2.0-0.dll
-   - C:\msys32\mingw32\bin\libgcc_s_seh-1.dll
-   - C:\msys32\mingw32\bin\libwinpthread-1.dll
+   - %MSYS2%\mingw32\bin\libiconv-2.dll
+   - %MSYS2%\mingw32\bin\libintl-8.dll
+   - %MSYS2%\mingw32\bin\libglib-2.0-0.dll
+   - %MSYS2%\mingw32\bin\libgcc_s_dw2-1.dll
+   - %MSYS2%\mingw32\bin\libwinpthread-1.dll
 
   To run sample_x86.exe on Windows 64-bit, you need the following files:
    - unicorn.dll
-   - C:\msys64\mingw64\bin\libiconv-2.dll
-   - C:\msys64\mingw64\bin\libintl-8.dll
-   - C:\msys64\mingw64\bin\libglib-2.0-0.dll
-   - C:\msys64\mingw64\bin\libgcc_s_seh-1.dll
-   - C:\msys64\mingw64\bin\libwinpthread-1.dll
+   - %MSYS2%\mingw64\bin\libiconv-2.dll
+   - %MSYS2%\mingw64\bin\libintl-8.dll
+   - %MSYS2%\mingw64\bin\libglib-2.0-0.dll
+   - %MSYS2%\mingw64\bin\libgcc_s_seh-1.dll
+   - %MSYS2%\mingw64\bin\libwinpthread-1.dll
 
 
 [8] By default, "cc" (default C compiler on the system) is used as compiler.


### PR DESCRIPTION
Turns out that unicorn.dll is linked with different DLL on Win32: libgcc_s_dw2-1.dll vs libgcc_s_seh-1.dll
