### PR TITLE
added the sparc64 crash regression

### DIFF
--- a/regress/sparc64.py
+++ b/regress/sparc64.py
@@ -1,0 +1,11 @@
+#!/usr/bin/python
+
+from unicorn import *
+from unicorn.sparc_const import *
+
+uc = Uc(UC_ARCH_SPARC, UC_MODE_64)
+uc.reg_write(UC_SPARC_REG_SP, 100)
+uc.reg_write(UC_SPARC_REG_FP, 100)
+print 'writing sp = 100, fp = 100'
+print 'sp =', uc.reg_read(UC_SPARC_REG_SP)
+print 'fp =', uc.reg_read(UC_SPARC_REG_FP)


### PR DESCRIPTION
It appears to crash due to a null ptr to a struct:

```
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff393d696 in sparc_reg_reset_sparc64 (uc=0x601010) at /home/user/unicorn/qemu/target-sparc/unicorn64.c:20
20      CPUArchState *env = first_cpu->env_ptr;
(gdb) bt
#0  0x00007ffff393d696 in sparc_reg_reset_sparc64 (uc=0x601010) at /home/user/unicorn/qemu/target-sparc/unicorn64.c:20
#1  0x00007ffff3976d91 in uc_open (arch=UC_ARCH_SPARC mode=UC_MODE_64, result=0x7fffffffe2b8) at ../uc.c:244
#2  0x0000000000400859 in test_sparc () at ./sparc_reg.c:14
#3  0x000000000040081f in main (argc=1, argv=0x7fffffffe3d8, envp=0x7fffffffe3e8) at ./sparc_reg.c:33
```
