### PR TITLE
SPARC64 update

### DIFF
--- a/qemu/hw/sparc64/sun4u.c
+++ b/qemu/hw/sparc64/sun4u.c
@@ -33,19 +33,23 @@
 static void sun4u_init(struct uc_struct *uc, MachineState *machine)
 {
     const char *cpu_model = machine->cpu_model;
+    SPARCCPU *cpu;
 
     if (cpu_model == NULL)
-        cpu_model = "sun4uv";
+        cpu_model = "Sun UltraSparc IV";
 
-    if (cpu_sparc_init(uc, cpu_model) == NULL) {
+    cpu = cpu_sparc_init(uc, cpu_model);
+    if (cpu == NULL) {
         fprintf(stderr, "Unable to find Sparc CPU definition\n");
         exit(1);
     }
+
+    cpu_sparc_set_id(&cpu->env, 0);
 }
 
 void sun4u_machine_init(struct uc_struct *uc)
 {
-    QEMUMachine sun4u_machine = {
+    static QEMUMachine sun4u_machine = {
         .name = "sun4u",
         .init = sun4u_init,
         .max_cpus = 1, // XXX for now

--- a/regress/sparc64.py
+++ b/regress/sparc64.py
@@ -3,9 +3,22 @@
 from unicorn import *
 from unicorn.sparc_const import *
 
+PAGE_SIZE = 1 * 1024 * 1024
+
 uc = Uc(UC_ARCH_SPARC, UC_MODE_64)
 uc.reg_write(UC_SPARC_REG_SP, 100)
-uc.reg_write(UC_SPARC_REG_FP, 100)
-print 'writing sp = 100, fp = 100'
+print 'writing sp = 100, %%i0 = 2000'
+
+   # 0:	b0 06 20 01 	inc  %i0
+   # 4:	b2 06 60 01 	inc  %i1
+
+CODE =  "\xb0\x06\x20\x01" \
+		"\xb2\x06\x60\x01"
+
+uc.mem_map(0, PAGE_SIZE)
+uc.mem_write(0, CODE)
+uc.emu_start(0, len(CODE), 0, 2)
+
 print 'sp =', uc.reg_read(UC_SPARC_REG_SP)
-print 'fp =', uc.reg_read(UC_SPARC_REG_FP)
+print 'i0 =', uc.reg_read(UC_SPARC_REG_I0)
+print 'i1 =', uc.reg_read(UC_SPARC_REG_I1)


### PR DESCRIPTION
Changed some of how sun4u.c works to better match the the code in leon3.c.
Fixed the SEGV in the init code for SPARC64, it was caused by the CPU model not being found because the string sun4u is not in the sparc_defs[] array in cpu.c.  Changed the CPU model to Sun UltraSparc IV,  I hope this is a close match but I am not 100% on that. 

Updated regress/sparc64.py with real code and it now correctly runs.

Fixes #138 
