### PR TITLE
added bad_ram regress

### DIFF
--- a/tests/regress/bad_ram.py
+++ b/tests/regress/bad_ram.py
@@ -9,21 +9,18 @@ import regress
 class Hang(regress.RegressTest):
 
     def runTest(self):
+        PAGE_SIZE = 0x5000
         CODE_ADDR = 0x400000
         RSP_ADDR =  0x200000
         binary1 = "\xCA\x24\x5D" # retf 0x5d24
         mu = Uc(UC_ARCH_X86, UC_MODE_64)
 
-        mu.mem_map(CODE_ADDR, 0x5000)
-        mu.mem_map(RSP_ADDR, 0x5000)
+        mu.mem_map(CODE_ADDR, PAGE_SIZE)
+        mu.mem_map(RSP_ADDR, PAGE_SIZE)
 
-        # write machine code to be emulated to memory
         mu.mem_write(CODE_ADDR, binary1)
-
         mu.reg_write(UC_X86_REG_RSP, RSP_ADDR)
-
-        # emu for maximum 1 sec.
-        mu.emu_start(CODE_ADDR, 0x400000 + 0x5000, 0)
+        mu.emu_start(CODE_ADDR, CODE_ADDR + PAGE_SIZE, 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I found a condition where unicorn would call abort and exit if RSP is mapped with all nulls and a retf 0xADDR happens:

```
% python tests/regress/bad_ram.py      
Bad ram pointer 0x7f25ee400000
[1]    32327 abort (core dumped)  python tests/regress/bad_ram.py
```

Effected code: 

``` C
static ram_addr_t qemu_ram_addr_from_host_nofail(struct uc_struct *uc, void *ptr)
{
    ram_addr_t ram_addr;

    if (qemu_ram_addr_from_host(uc, ptr, &ram_addr) == NULL) {
        fprintf(stderr, "Bad ram pointer %p\n", ptr);
        abort();
    }
    return ram_addr;
}
```
