### PR TITLE
Small correction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ See [COMPILE.TXT](COMPILE.TXT) file for how to compile and install Unicorn.
 License
 -------
 
-This project is released under the GPL license.
+This project is released under the [GPL license][COPYING].

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Unicorn offers some unparalleled features:
 - High performance via Just-In-Time compilation
 - Support for fine-grained instrumentation at various levels
 - Thread-safety by design
-- Distributed under open source license GPL
+- Distributed under free software license GPLv2
 
 Further information is available at http://www.unicorn-engine.org
 

--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ See [COMPILE.TXT](COMPILE.TXT) file for how to compile and install Unicorn.
 License
 -------
 
-This project is released under the [GPL license][COPYING].
+This project is released under the [GPL license](COPYING).


### PR DESCRIPTION
- A little correction in the license. It was "open source" rather than "free software". I know it's not very important for some people, but other people care about that.
- Linked COPYING file to the "GPL license" at the end of the README.