### PR TITLE
tests: create libunicorn.so.0 symlink

### DIFF
--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -1,3 +1,5 @@
 test_x86
 test_mem_map
 test_sanity
+*.so
+*.so.*

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -14,7 +14,7 @@ clean:
 	rm -rf ${ALL_TESTS}
 
 .PHONY: test
-test: export LD_LIBRARY_PATH=../../
+test: export LD_LIBRARY_PATH=.
 test: ${ALL_TESTS}
 	./test_sanity
 	./test_x86
@@ -23,9 +23,12 @@ test: ${ALL_TESTS}
 test_sanity: test_sanity.c
 test_x86: test_x86.c
 test_mem_map: test_mem_map.c
+${ALL_TESTS}: libunicorn.so.0
 
 ${ALL_TESTS}:
 	gcc ${CFLAGS} -o $@ $^
 
+libunicorn.so.0:
+	ln -s ../../libunicorn.so $@
 
 


### PR DESCRIPTION
This hack allows the unit tests to link against libunicorn, after
the SONAME was added in 4860fdb3.

Becuase libunicorn.so has an SONAME of libunicorn.so.0, the linker uses
the SONAME for the DT_NEEDED entry of the tests. But because a library
with that name does not exist, they would fail to run. This symlink
works around that issue, without touching the toplevel Makefile.