### PR TITLE
create versioned library name and symlink unversioned name on *nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.o
 *.a
 *.dSYM
+*.so
+*.so.*
 
 qemu/config-all-devices.mak
 

--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,6 @@ ifeq ($(UNICORN_SHARED),yes)
 	$(INSTALL_LIB) $(LIBRARY) $(LIBDIR)
 ifneq ($(VERSION_EXT),)
 	cd $(LIBDIR) && \
-	mv lib$(LIBNAME).$(EXT) lib$(LIBNAME).$(VERSION_EXT) && \
 	ln -s lib$(LIBNAME).$(VERSION_EXT) lib$(LIBNAME).$(EXT)
 endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,8 @@ LIBRARY = $(BLDIR)/$(LIBNAME).$(EXT)
 else ifeq ($(IS_CYGWIN),1)
 LIBRARY = $(BLDIR)/$(LIBNAME).$(EXT)
 else	# *nix
-LIBRARY = $(BLDIR)/lib$(LIBNAME).$(EXT)
+LIBRARY = $(BLDIR)/lib$(LIBNAME).$(VERSION_EXT)
+LIBRARY_SYMLINK = $(BLDIR)/lib$(LIBNAME).$(EXT)
 endif
 endif
 
@@ -228,6 +229,9 @@ ifeq ($(V),0)
 	@$(CC) $(CFLAGS) $($(LIBNAME)_LDFLAGS) -shared $^ -o $(LIBRARY) $(GLIB) -lm
 else
 	$(CC) $(CFLAGS) $($(LIBNAME)_LDFLAGS) -shared $^ -o $(LIBRARY) $(GLIB) -lm
+endif
+ifneq (,$(LIBRARY_SYMLINK))
+	@ln -sf $(LIBRARY) $(LIBRARY_SYMLINK)
 endif
 endif
 


### PR DESCRIPTION
This fixes #205.

This change only affects *nix builds, and shouldn't affect `libunicorn.dll` on mingw, for example. However, it'd be nice if someone can build it to make sure. (It would be great if we had CI for this!)