### PR TITLE
COMPILE.TXT: fix trivial typo

### DIFF
--- a/COMPILE.TXT
+++ b/COMPILE.TXT
@@ -132,7 +132,7 @@ Unicorn requires few dependent packages as follows.
     /usr/include/unicorn/ppc.h
     /usr/include/unicorn/sparc.h
     /usr/include/unicorn/m68k.h
-    uusr/include/unicorn/platform.h
+    /usr/include/unicorn/platform.h
     /usr/lib/libunicorn.so (for Linux/*nix), or /usr/lib/libunicorn.dylib (OSX)
     /usr/lib/libunicorn.a
 


### PR DESCRIPTION
trivial typo fix to installation path