### PR TITLE
python README.TXT: clarify working directories

### DIFF
--- a/bindings/python/README.TXT
+++ b/bindings/python/README.TXT
@@ -6,12 +6,12 @@ from source.
 
    Follow README in the root directory to compile & install the core.
 
-   On *nix, this can simply done by:
+   On *nix, this can simply be done by (project root directory):
 
         $ sudo ./make.sh install
 
 
-1. To install pure Python binding on *nix, run the command below:
+1. To install pure Python binding on *nix, run the command below in the Python bindings directory:
 
 		$ sudo make install
 


### PR DESCRIPTION
clarify in which directory to build the core project and install the python bindings. when i went to install the python bindings, i was momentarily confused why the root Makefile didn't have an `install3` target.