### PR TITLE
python bindings: use relative paths for imports to support py3

### DIFF
--- a/bindings/python/unicorn/__init__.py
+++ b/bindings/python/unicorn/__init__.py
@@ -1,4 +1,4 @@
 # Unicorn Python bindings, by Nguyen Anh Quynnh <aquynh@gmail.com>
 from . import arm_const, arm64_const, mips_const, sparc_const, m68k_const, x86_const
-from unicorn_const import *
-from unicorn import Uc, uc_version, uc_arch_supported, version_bind, debug, UcError
+from .unicorn_const import *
+from .unicorn import Uc, uc_version, uc_arch_supported, version_bind, debug, UcError

--- a/bindings/python/unicorn/unicorn.py
+++ b/bindings/python/unicorn/unicorn.py
@@ -4,7 +4,7 @@ _python2 = sys.version_info[0] < 3
 if _python2:
     range = xrange
 from . import arm_const, arm64_const, mips_const, sparc_const, m68k_const, x86_const
-from unicorn_const import *
+from .unicorn_const import *
 
 import ctypes, ctypes.util, sys
 from platform import system


### PR DESCRIPTION
closes #235.

works on test scripts on my system. please double check bindings continue to work for you under py2.