### PR TITLE
Fix segfault on emu_stop()

### DIFF
--- a/tests/regress/segfault_on_stop.py
+++ b/tests/regress/segfault_on_stop.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+import regress
+import unicorn
+
+
+class SegfaultOnStop(regress.RegressTest):
+    def test(self):
+        unicorn.Uc(unicorn.UC_ARCH_X86, unicorn.UC_MODE_64).emu_stop()
+        self.assertTrue(True, "If not reached, then we have a crashing bug.")
+
+if __name__ == '__main__':
+    regress.main()

--- a/uc.c
+++ b/uc.c
@@ -525,8 +525,10 @@ uc_err uc_emu_stop(uc_engine *uc)
         return UC_ERR_OK;
 
     uc->stop_request = true;
-    // exit the current TB
-    cpu_exit(uc->current_cpu);
+    if (uc->current_cpu) {
+        // exit the current TB
+        cpu_exit(uc->current_cpu);
+    }
 
     return UC_ERR_OK;
 }


### PR DESCRIPTION
Fix for the following segfault:

```python
unicorn.Uc(unicorn.UC_ARCH_X86, unicorn.UC_MODE_64).emu_stop()
...
python[23549]: segfault at ac ip 00007fc5395fe682 sp 00007fffb7093b90 error 6 in libunicorn.so.0[7fc5394cc000+915000]
```