### PR TITLE
SIGABRT issue

### DIFF
--- a/tests/regress/init.py
+++ b/tests/regress/init.py
@@ -1,0 +1,68 @@
+#!/usr/bin/python
+# By Mariano Graziano
+
+from unicorn import *
+from unicorn.x86_const import *
+
+import regress, struct
+
+mu = 0
+
+class Init(regress.RegressTest):
+
+    def init_unicorn(self, ip, sp, counter):
+        global mu
+        print "[+] Emulating IP: %x SP: %x - Counter: %x" % (ip, sp, counter)
+        mu = Uc(UC_ARCH_X86, UC_MODE_64)
+        mu.mem_map(0x1000000, 2 * 1024 * 1024)
+        mu.mem_write(0x1000000, "\x90")
+        mu.mem_map(0x8000000, 8 * 1024 * 1024)
+        mu.reg_write(UC_X86_REG_RSP, sp)
+        content = self.generate_value(counter)
+        mu.mem_write(sp, content)
+        self.set_hooks()
+   
+    def generate_value(self, counter):
+        start = 0xffff880026f02000
+        offset = counter * 8
+        address = start + offset
+        return struct.pack("<Q", address)
+ 
+    def set_hooks(self):
+        global mu
+        mu.hook_add(UC_HOOK_MEM_READ_UNMAPPED | UC_HOOK_MEM_WRITE_UNMAPPED, self.hook_mem_invalid)
+        mu.hook_add(UC_HOOK_MEM_FETCH_UNMAPPED, self.hook_mem_fetch_unmapped)
+    
+    def hook_mem_invalid(self, uc, access, address, size, value, user_data):
+        global mu
+        print "[ HOOK_MEM_INVALID - Address: %s ]" % hex(address)
+        if access == UC_MEM_WRITE_UNMAPPED:
+            print ">>> Missing memory is being WRITE at 0x%x, data size = %u, data value = 0x%x" %(address, size, value)
+            address_page = address & 0xFFFFFFFFFFFFF000
+            mu.mem_map(address_page, 2 * 1024 * 1024)
+            mu.mem_write(address, str(value))
+            return True
+        else:
+            return False
+
+    def hook_mem_fetch_unmapped(self, uc, access, address, size, value, user_data):
+        global mu
+        print "[ HOOK_MEM_FETCH - Address: %s ]" % hex(address).strip("L")
+        print "[ mem_fetch_unmapped: faulting address at %s ]" % hex(address).strip("L")
+        mu.mem_write(0x1000003, "\x90") 
+        mu.reg_write(UC_X86_REG_RIP, 0x1000001)
+        return True
+
+    def runTest(self):
+        global mu
+        ips = list(xrange(0x1000000, 0x1001000, 0x1))
+        sps = list(xrange(0x8000000, 0x8001000, 0x1))
+        j = 0
+        for i in ips:
+            j += 1
+            index = ips.index(i)
+            self.init_unicorn(i, sps[index], j)
+            mu.emu_start(0x1000000, 0x1000000 + 0x1)
+
+if __name__ == '__main__':
+    regress.main()


### PR DESCRIPTION
Machine:

                > uname -a
		Linux ubuntu 3.19.0-25-generic #26~14.04.1-Ubuntu SMP Fri Jul 24 21:16:20 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux

		> cat /etc/lsb-release 
		DISTRIB_ID=Ubuntu
		DISTRIB_RELEASE=14.04
		DISTRIB_CODENAME=trusty
		DISTRIB_DESCRIPTION="Ubuntu 14.04.3 LTS"

Output:

                [+] Emulating IP: 10004cd SP: 80004cd - Counter: 4ce
		[+] Emulating IP: 10004ce SP: 80004ce - Counter: 4cf
		[+] Emulating IP: 10004cf SP: 80004cf - Counter: 4d0
		[+] Emulating IP: 10004d0 SP: 80004d0 - Counter: 4d1
		[+] Emulating IP: 10004d1 SP: 80004d1 - Counter: 4d2
		Aborted (core dumped)


Backtrace:                

               12:09:41 emdel -> gdb -q /usr/bin/python core
		Reading symbols from /usr/bin/python...(no debugging symbols found)...done.

		warning: core file may not match specified executable file.
		[New LWP 56366]
		[New LWP 57600]
		[Thread debugging using libthread_db enabled]
		Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
		Core was generated by `python init.py'.
		Program terminated with signal SIGABRT, Aborted.
		#0  0x00007eff555f0cc9 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
		56      ../nptl/sysdeps/unix/sysv/linux/raise.c: No such file or directory.
		(gdb) bt
		#0  0x00007eff555f0cc9 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
		#1  0x00007eff555f40d8 in __GI_abort () at abort.c:89
		#2  0x00007eff3efd6472 in error_propagate (dst_errp=0x7eff41a27ad0 <error_abort>, local_err=0x7ef2d7c63460) at util/error.c:163
		#3  0x00007eff3ef2f817 in qemu_ram_alloc_from_ptr_x86_64 (size=8388608, host=0x0, mr=0x7ef2d7c66920, errp=0x7eff41a27ad0 <error_abort>)
		    at /home/emdel/projects/unicorn/qemu/exec.c:1105
		#4  0x00007eff3ef2f87c in qemu_ram_alloc_x86_64 (size=8388608, mr=0x7ef2d7c66920, errp=0x7eff41a27ad0 <error_abort>)
		    at /home/emdel/projects/unicorn/qemu/exec.c:1113
		#5  0x00007eff3efb674d in memory_region_init_ram_x86_64 (uc=0x7ef2d7c47bb0, mr=0x7ef2d7c66920, owner=0x0, name=0x7eff3f65a8b8 "pc.ram", 
		    size=8388608, perms=7, errp=0x7eff41a27ad0 <error_abort>) at /home/emdel/projects/unicorn/qemu/memory.c:1191
		#6  0x00007eff3efb1ee8 in memory_map_x86_64 (uc=0x7ef2d7c47bb0, begin=134217728, size=8388608, perms=7)
		    at /home/emdel/projects/unicorn/qemu/memory.c:38

