### PR TITLE
fix compilation with capstone next

### DIFF
--- a/include/unicorn/m68k.h
+++ b/include/unicorn/m68k.h
@@ -16,7 +16,7 @@ extern "C" {
 #endif
 
 //> M68K registers
-typedef enum m68k_reg {
+typedef enum uc_m68k_reg {
 	UC_M68K_REG_INVALID = 0,
 
 	UC_M68K_REG_A0,
@@ -41,7 +41,7 @@ typedef enum m68k_reg {
 	UC_M68K_REG_PC,
 
 	UC_M68K_REG_ENDING,   // <-- mark the end of the list of registers
-} m68k_reg;
+} uc_m68k_reg;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fix this error:
```
In file included from ./unicorn_capstone.c:6:
In file included from /usr/include/capstone/capstone.h:242:
/usr/include/capstone/m68k.h:21:14: error: redefinition of 'm68k_reg'
typedef enum m68k_reg {
             ^
/usr/include/unicorn/m68k.h:19:14: note: previous definition is here
typedef enum m68k_reg {
             ^
In file included from ./unicorn_capstone.c:6:
In file included from /usr/include/capstone/capstone.h:242:
/usr/include/capstone/m68k.h:77:3: error: typedef redefinition with different
      types ('enum m68k_reg' (aka 'm68k_reg') vs 'enum m68k_reg')
} m68k_reg;
  ^
/usr/include/unicorn/m68k.h:44:3: note: previous definition is here
} m68k_reg;
  ^
2 errors generated.
```