### PR TITLE
add test case to run_across_bb.py

### DIFF
--- a/tests/regress/run_across_bb.py
+++ b/tests/regress/run_across_bb.py
@@ -176,7 +176,9 @@ class RunAcrossBBTest(regress.RegressTest):
             # 1010: b8 00 00 00 00          mov    eax,0x0   <
             # 1015: 40                      inc    eax       <
             # 1016: 40                      inc    eax       <
-            self.assertEqual(0x1016, mu.reg_read(UC_X86_REG_EIP), "unexpected PC (4)")
+            self.assertEqual(0x1016, mu.reg_read(UC_X86_REG_EIP),
+	                     "unexpected PC (4): 0x%x vs 0x%x" % (
+				     0x1016, mu.reg_read(UC_X86_REG_EIP)))
             showpc(mu)
 
         except UcError as e:

--- a/tests/regress/run_across_bb.py
+++ b/tests/regress/run_across_bb.py
@@ -38,7 +38,7 @@ class RunAcrossBBTest(regress.RegressTest):
             #######################################################################
             # emu SETUP
             #######################################################################
-	    print("\n---- test: run_all ----")
+            print("\n---- test: run_all ----")
 
 
             mu = Uc(UC_ARCH_X86, UC_MODE_32)
@@ -93,7 +93,7 @@ class RunAcrossBBTest(regress.RegressTest):
             #######################################################################
             # emu SETUP
             #######################################################################
-	    print("\n---- test: run_across_bb ----")
+            print("\n---- test: run_across_bb ----")
 
 
             mu = Uc(UC_ARCH_X86, UC_MODE_32)


### PR DESCRIPTION
demonstrates that calling `emu_start` from a BB start to another BB end works fine. its starting/stopping within a block that seems broken.

associated issue #263 