### PR TITLE
run_across_bb: test case showing single stepping across a BB boundary

### DIFF
--- a/tests/regress/run_across_bb.py
+++ b/tests/regress/run_across_bb.py
@@ -316,7 +316,11 @@ class RunAcrossBBTest(regress.RegressTest):
                 print("!!! about to bail due to bad fetch...")
 		showpc(mu)
                 print("here's the data at PC:")
-                print(binascii.hexlify(mu.mem_read(mu.reg_read(UC_X86_REG_EIP), 0x8)))
+		try:
+                    print(binascii.hexlify(mu.mem_read(mu.reg_read(UC_X86_REG_EIP), 0x8)))
+		except UcError:
+		    print("pc currently unmapped")
+
 
             self.assertFalse(True, "ERROR: %s @ 0x%x" % (e, mu.reg_read(UC_X86_REG_EIP)))
 

--- a/tests/regress/run_across_bb.py
+++ b/tests/regress/run_across_bb.py
@@ -27,6 +27,30 @@ CODE = binascii.unhexlify(b"".join([
   ]))
 
 
+class SingleStepper:
+    def __init__(self, emu, test):
+        self._emu = emu
+        self._hit_count = 0
+        self._test = test
+
+    def _stop_hook(self, uc, address, *args, **kwargs):
+        if self._hit_count == 0:
+            self._hit_count += 1
+        else:
+            self._test.assertEqual(1, self._hit_count, "HOOK_CODE invoked too many times")
+            uc.emu_stop()
+            self._hit_count += 1
+
+    def step(self):
+        self._hit_count = 0
+        h = self._emu.hook_add(UC_HOOK_CODE, self._stop_hook)
+        try:
+            pc = self._emu.reg_read(UC_X86_REG_RIP)
+            self._emu.emu_start(pc, pc+0x20)
+        finally:
+            self._emu.hook_del(h)
+
+
 def showpc(mu):
     pc = mu.reg_read(UC_X86_REG_EIP)
     print("pc: 0x%x" % (pc))
@@ -189,6 +213,113 @@ class RunAcrossBBTest(regress.RegressTest):
                 print(binascii.hexlify(mu.mem_read(mu.reg_read(UC_X86_REG_EIP), 0x8)))
 
             self.assertFalse(True, "ERROR: %s @ 0x%x" % (e, mu.reg_read(UC_X86_REG_EIP)))
+
+
+    def test_step_across_bb(self):
+        try:
+            #######################################################################
+            # emu SETUP
+            #######################################################################
+            print("\n---- test: step_across_bb ----")
+
+
+            mu = Uc(UC_ARCH_X86, UC_MODE_32)
+
+            def hook_code(uc, address, size, user_data):
+                print(">>> Tracing instruction at 0x%x, instruction size = %u" %(address, size))
+            mu.hook_add(UC_HOOK_CODE, hook_code)
+
+            # base of CODE
+            mu.mem_map(0x1000, 0x1000)
+            mu.mem_write(0x1000, CODE)
+
+            # stack
+            mu.mem_map(0x2000, 0x1000)
+
+            mu.reg_write(UC_X86_REG_EIP, 0x1000)
+            mu.reg_write(UC_X86_REG_ESP, 0x2800)
+            self.assertEqual(0x1000, mu.reg_read(UC_X86_REG_EIP), "unexpected PC")
+            self.assertEqual(0x2800, mu.reg_read(UC_X86_REG_ESP), "unexpected SP")
+            showpc(mu)
+
+
+            #######################################################################
+            # emu_run ONE:
+            #   exectue four instructions, until the last instruction in a BB
+            #######################################################################
+
+
+            mu.emu_start(0x1000, 0x100c)
+            # should exec the following four instructions:
+            # 1000: b8 00 00 00 00          mov    eax,0x0  <
+            # 1005: 40                      inc    eax      <
+            # 1006: 40                      inc    eax      <
+            # 1007: 68 10 10 00 00          push   0x1010   <
+
+            # should be at 0x100c, as requested
+            self.assertEqual(0x100c, mu.reg_read(UC_X86_REG_EIP), "unexpected PC (2)")
+
+            # single push, so stack diff is 0x4
+            TOP_OF_STACK = 0x2800-0x4
+            self.assertEqual(TOP_OF_STACK, mu.reg_read(UC_X86_REG_ESP), "unexpected SP (2)")
+
+            # top of stack should be 0x1010
+            self.assertEqual(0x1010, 
+                             struct.unpack("<I", mu.mem_read(TOP_OF_STACK, 0x4))[0],
+                             "unexpected stack value")
+            showpc(mu)
+
+
+            #######################################################################
+            # emu_run TWO
+            #   execute one instruction, via a HOOK_CODE callback, that jumps to a new BB
+            #######################################################################
+
+
+            stepper = SingleStepper(mu, self)
+	    stepper.step()
+            # should exec one instruction that jumps to 0x1010:
+            # 100c: c3                      ret   -----------+
+            # 100d: cc                      int3             |
+            # 100e: cc                      int3             |
+            # 100f: cc                      int3             |
+            # 1010: b8 00 00 00 00          mov    eax,0x0 <-+
+
+            # should be at 0x1010, as requested
+            self.assertEqual(0x1010, mu.reg_read(UC_X86_REG_EIP), "unexpected PC (3)")
+
+            # single pop, so stack back at base
+            self.assertEqual(0x2800, mu.reg_read(UC_X86_REG_ESP), "unexpected SP (3)")
+            showpc(mu)
+
+
+            #######################################################################
+            # emu_run THREE
+            #  execute three instructions to verify things work as expected
+            #######################################################################
+
+
+            mu.emu_start(0x1010, 0x1016)
+            # should exec the following three instructions:
+            # 1010: b8 00 00 00 00          mov    eax,0x0   <
+            # 1015: 40                      inc    eax       <
+            # 1016: 40                      inc    eax       <
+            self.assertEqual(0x1016, mu.reg_read(UC_X86_REG_EIP),
+	                     "unexpected PC (4): 0x%x vs 0x%x" % (
+				     0x1016, mu.reg_read(UC_X86_REG_EIP)))
+            showpc(mu)
+
+        except UcError as e:
+            if e.errno == UC_ERR_FETCH_UNMAPPED:
+                # during initial test dev, bad fetch at 0x1010, but the data is there,
+                #   and this proves it
+                print("!!! about to bail due to bad fetch...")
+		showpc(mu)
+                print("here's the data at PC:")
+                print(binascii.hexlify(mu.mem_read(mu.reg_read(UC_X86_REG_EIP), 0x8)))
+
+            self.assertFalse(True, "ERROR: %s @ 0x%x" % (e, mu.reg_read(UC_X86_REG_EIP)))
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds an additional test case to `run_across_bb.py` that shows the behavior when "single stepping" across a BB boundary. The "single step" is a code hook (via `HOOK_CODE`) that asks the emulator to stop after executing a single instruction.

The expected behavior is to emulate four instructions, single step across a BB boundary, and then emulate a few more instructions.

The observed behavior is that PC is set to 0x0 when emulating the "ret" (jump) instruction. This results in an invalid fetch, since the NULL page is not mapped.

Here is the current output:

```
[willi@hostname regress]$ python2 run_across_bb.py 

---- test: run_across_bb ----
pc: 0x1000
>>> Tracing instruction at 0x1000, instruction size = 5
>>> Tracing instruction at 0x1005, instruction size = 1
>>> Tracing instruction at 0x1006, instruction size = 1
>>> Tracing instruction at 0x1007, instruction size = 5
pc: 0x100c
>>> Tracing instruction at 0x100c, instruction size = 1
pc: 0x1010
>>> Tracing instruction at 0x1010, instruction size = 5
>>> Tracing instruction at 0x1015, instruction size = 1
pc: 0x1016
.
---- test: run_all ----
pc: 0x1000
>>> Tracing instruction at 0x1000, instruction size = 5
>>> Tracing instruction at 0x1005, instruction size = 1
>>> Tracing instruction at 0x1006, instruction size = 1
>>> Tracing instruction at 0x1007, instruction size = 5
>>> Tracing instruction at 0x100c, instruction size = 1
>>> Tracing instruction at 0x1010, instruction size = 5
>>> Tracing instruction at 0x1015, instruction size = 1
pc: 0x1016
.
---- test: step_across_bb ----
pc: 0x1000
>>> Tracing instruction at 0x1000, instruction size = 5
>>> Tracing instruction at 0x1005, instruction size = 1
>>> Tracing instruction at 0x1006, instruction size = 1
>>> Tracing instruction at 0x1007, instruction size = 5
pc: 0x100c
!!! about to bail due to bad fetch...
pc: 0x0
here's the data at PC:
pc currently unmapped
F
======================================================================
FAIL: test_step_across_bb (__main__.RunAcrossBBTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "run_across_bb.py", line 325, in test_step_across_bb
    self.assertFalse(True, "ERROR: %s @ 0x%x" % (e, mu.reg_read(UC_X86_REG_EIP)))
AssertionError: ERROR: Invalid memory fetch (UC_ERR_FETCH_UNMAPPED) @ 0x0

----------------------------------------------------------------------
Ran 3 tests in 0.007s

FAILED (failures=1)
```