### PR TITLE
Unmapped memory is not freed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ x86_16_segfault
 mips_invalid_read_of_size_4_when_tracing
 invalid_read_in_tb_flush_x86_64
 sparc_jump_to_zero
+mem_nofree
 
 
 #################

--- a/tests/regress/Makefile
+++ b/tests/regress/Makefile
@@ -23,6 +23,7 @@ TESTS += mips_invalid_read_of_size_4_when_tracing
 TESTS += invalid_read_in_tb_flush_x86_64
 TESTS += sparc_jump_to_zero
 TESTS += mips_delay_slot_code_hook
+TESTS += mem_nofree
 
 all: $(TESTS)
 

--- a/tests/regress/mem_nofree.c
+++ b/tests/regress/mem_nofree.c
@@ -1,0 +1,72 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <inttypes.h>
+
+#include <unicorn/unicorn.h>
+
+#define ADDRESS1 0x1000000
+#define ADDRESS2 0x2000000
+#define SIZE (80 * 1024 * 1024)
+
+static void VM_exec()
+{
+    int c;
+    uc_engine *uc;
+    uc_err err;
+
+    // Initialize emulator in X86-64bit mode
+    err = uc_open(UC_ARCH_X86, UC_MODE_32, &uc);
+    if(err)
+    {
+        printf("Failed on uc_open() with error returned: %s\n", uc_strerror(err));
+        return;
+    }
+
+repeat:
+    err = uc_mem_map(uc, ADDRESS1, SIZE, UC_PROT_ALL);
+    if(err != UC_ERR_OK)
+    {
+        printf("Failed to map memory %s\n", uc_strerror(err));
+        goto err;
+    }
+
+    err = uc_mem_map(uc, ADDRESS2, SIZE, UC_PROT_ALL);
+    if(err != UC_ERR_OK)
+    {
+        printf("Failed to map memory %s\n", uc_strerror(err));
+        goto err;
+    }
+
+    err = uc_mem_unmap(uc, ADDRESS1, SIZE);
+    if(err != UC_ERR_OK)
+    {
+        printf("Failed to unmap memory %s\n", uc_strerror(err));
+        goto err;
+    }
+
+    err = uc_mem_unmap(uc, ADDRESS2, SIZE);
+    if(err != UC_ERR_OK)
+    {
+        printf("Failed to unmap memory %s\n", uc_strerror(err));
+        goto err;
+    }
+
+    for(;;)
+    {
+        c = getchar(); //pause here and analyse memory usage before exiting with a program like VMMap;
+        if(c != 'e')
+            goto repeat;
+        else
+            break;
+    }
+
+err:
+    uc_close(uc);
+}
+
+int main(int argc, char *argv[])
+{
+    VM_exec();
+    return 0;
+}


### PR DESCRIPTION
While uc_mem_unmap does unmap memory regions from Unicorn, it does not
free the memory. It accumulates over time when reusing a single Unicorn instance.