### PR TITLE
Fix uc_mem_unmap memory leak and in uc_close.

### DIFF
--- a/qemu/memory.c
+++ b/qemu/memory.c
@@ -68,6 +68,11 @@ void memory_unmap(struct uc_struct *uc, MemoryRegion *mr)
             uc->mapped_block_count--;
             //shift remainder of array down over deleted pointer
             memcpy(&uc->mapped_blocks[i], &uc->mapped_blocks[i + 1], sizeof(MemoryRegion*) * (uc->mapped_block_count - i));
+            mr->destructor(mr);
+            if((char *)mr->name)
+                g_free((char *)mr->name);
+            if(mr->ioeventfds)
+                g_free(mr->ioeventfds);
             break;
         }
     }


### PR DESCRIPTION
It appears the problem is that we are not calling the memory region
destructor. After modifying memory_unmap to include the destructor call
for the memory region, the memory is freed.

Furthermore in uc_close we must explicitly free any blocks that were not
unmapped by the user to prevent leaks.

This should fix issue 305.