### PR TITLE
Fixed the unicorn_dynload.c version of uc_hook_add() to handle UC_HOOK_MEM_*_PROT and UC_HOOK_MEM_*_UNMAPPED.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.dSYM
 *.so
 *.so.*
+*.exe
 
 qemu/config-all-devices.mak
 

--- a/bindings/msvc/unicorn_dynload.c
+++ b/bindings/msvc/unicorn_dynload.c
@@ -232,9 +232,17 @@ uc_err uc_hook_add(uc_engine *uc, uc_hook *hh, int type, void *callback, void *u
     va_start(valist, user_data);
 
     switch(type) {
+        // note this default case will capture any combinations of
+        // UC_HOOK_MEM_*_PROT and UC_HOOK_MEM_*_UNMAPPED
         default:
-            break;
         case UC_HOOK_INTR:
+        case UC_HOOK_MEM_READ_UNMAPPED:
+        case UC_HOOK_MEM_WRITE_UNMAPPED:
+        case UC_HOOK_MEM_FETCH_UNMAPPED:
+        case UC_HOOK_MEM_READ_PROT:
+        case UC_HOOK_MEM_WRITE_PROT:
+        case UC_HOOK_MEM_FETCH_PROT:
+        case UC_HOOK_MEM_FETCH:
             // 0 extra args
             ret = gp_uc_hook_add(uc, hh, type, callback, user_data);
             break;
@@ -248,7 +256,7 @@ uc_err uc_hook_add(uc_engine *uc, uc_hook *hh, int type, void *callback, void *u
         case UC_HOOK_MEM_READ:
         case UC_HOOK_MEM_WRITE:
         case UC_HOOK_MEM_READ | UC_HOOK_MEM_WRITE:
-            // 2 extra arg
+            // 2 extra args
             begin = va_arg(valist, uint64_t);
             end = va_arg(valist, uint64_t);
             ret = gp_uc_hook_add(uc, hh, type, callback, user_data, begin, end);

--- a/tests/regress/Makefile
+++ b/tests/regress/Makefile
@@ -1,5 +1,11 @@
-CFLAGS += -I../include
+
+CFLAGS += -I../../include
+
+ifeq (MING,$(findstring MING,$(shell uname -s)))
+LDFLAGS += ../../unicorn.lib $(shell pkg-config --libs glib-2.0) -lpthread -lm
+else
 LDFLAGS += ../../libunicorn.a $(shell pkg-config --libs glib-2.0) -lpthread -lm
+endif
 
 TESTS = map_crash map_write
 TESTS += sigill sigill2

--- a/tests/regress/mips_delay_slot_code_hook.c
+++ b/tests/regress/mips_delay_slot_code_hook.c
@@ -15,7 +15,7 @@ but that the code hook is just not occurring.
 #include <windows.h>
 #define PRIx64 "llX"
 #ifdef DYNLOAD
-#include <unicorn/unicorn_dynload.h>
+#include <unicorn_dynload.h>
 #else // DYNLOAD
 #include <unicorn/unicorn.h>
 #ifdef _WIN64

--- a/tests/regress/rw_hookstack.c
+++ b/tests/regress/rw_hookstack.c
@@ -49,32 +49,32 @@ int main(int argc, char *argv[])
     err = uc_open(UC_ARCH_X86, UC_MODE_32, &uc);
     if(err) {
         printf("Failed on uc_open() with error returned: %s\n", uc_strerror(err));
-        return;
+        return 1;
     }
 
     err = uc_mem_map(uc, ADDRESS, SIZE, UC_PROT_ALL);
     if(err != UC_ERR_OK) {
         printf("Failed to map memory %s\n", uc_strerror(err));
-        return;
+        return 1;
     }
 
     err = uc_mem_write(uc, ADDRESS, CODE32, sizeof(CODE32) - 1);
     if(err != UC_ERR_OK) {
         printf("Failed to write to memory %s\n", uc_strerror(err));
-        return;
+        return 1;
     }
 
 loop:
     err = uc_mem_map(uc, stkval, STACK_SIZE, UC_PROT_ALL);
     if(err != UC_ERR_OK) {
         printf("Failed to map memory %s\n", uc_strerror(err));
-        return;
+        return 1;
     }
 
     err = uc_mem_write(uc, ESP, &val, sizeof(val));
     if(err != UC_ERR_OK) {
         printf("Failed to write to memory %s\n", uc_strerror(err));
-        return;
+        return 1;
     }
 
 
@@ -88,7 +88,7 @@ loop:
         printf("Failed on uc_emu_start() with error returned %u: %s\n", err, uc_strerror(err));
 
         uc_close(uc);
-        return;
+        return 1;
     }
 
     uc_reg_read(uc, UC_X86_REG_EAX, &EAX);


### PR DESCRIPTION
Fixed the unicorn_dynload.c version of uc_hook_add() to handle UC_HOOK_MEM_*_PROT and UC_HOOK_MEM_*_UNMAPPED.