### PR TITLE
Build for Cygwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.so
 *.so.*
 *.exe
+*.dll
 
 qemu/config-all-devices.mak
 

--- a/COMPILE.TXT
+++ b/COMPILE.TXT
@@ -62,6 +62,11 @@ Unicorn requires few dependent packages as follows.
                       $ pacman -S mingw-w64-x86_64-glib2
                       $ pacman -S mingw-w64-x86_64-toolchain
 
+- For Cygwin, "make", "gcc-core", "pkg-config", "libpcre-devel", "zlib-devel" and "libglib2.0-devel" are needed.
+  If apt-cyg is available, you can install these with:
+
+      $ apt-cyg install make gcc-core pkg-config libpcre-devel zlib-devel libglib2.0-devel
+
 
 
 [1] Tailor Unicorn to your need.
@@ -172,7 +177,30 @@ Unicorn requires few dependent packages as follows.
 
 
 
-[4] Cross-compile for Windows from *nix
+[4] Compile and install from source on Cygwin
+
+  To build Unicorn on Cygwin, run:
+
+    $ ./make.sh
+
+  After compiling, install Unicorn with:
+
+    $ ./make.sh install
+
+  Resulted files cygunicorn.dll, libunicorn.dll.a and libunicorn.a can be 
+  used on Cygwin but not native Windows.
+
+  NOTE: The core framework installed by "./make.sh install" consist of
+  following files:
+
+    /usr/include/unicorn/*.h
+    /usr/bin/cygunicorn.dll
+    /usr/lib/libunicorn.dll.a
+    /usr/lib/libunicorn.a
+
+
+
+[5] Cross-compile for Windows from *nix
 
   To cross-compile for Windows, Linux & gcc-mingw-w64-i686 (and also gcc-mingw-w64-x86-64
   for 64-bit binaries) are required.
@@ -205,7 +233,7 @@ Unicorn requires few dependent packages as follows.
 
 
 
-[5] Cross-compile for iOS from Mac OSX.
+[6] Cross-compile for iOS from Mac OSX.
 
   To cross-compile for iOS (iPhone/iPad/iPod), Mac OSX with XCode installed is required.
 
@@ -226,7 +254,7 @@ Unicorn requires few dependent packages as follows.
 
 
 
-[6] Cross-compile for Android
+[7] Cross-compile for Android
 
   To cross-compile for Android (smartphone/tablet), Android NDK is required.
   NOTE: Only ARM and ARM64 are currently supported.
@@ -240,7 +268,7 @@ Unicorn requires few dependent packages as follows.
 
 
 
-[7] By default, "cc" (default C compiler on the system) is used as compiler.
+[8] By default, "cc" (default C compiler on the system) is used as compiler.
 
     - To use "clang" compiler instead, run the command below:
 
@@ -252,20 +280,20 @@ Unicorn requires few dependent packages as follows.
 
 
 
-[8] To uninstall Unicorn, run the command below:
+[9] To uninstall Unicorn, run the command below:
 
         $ sudo ./make.sh uninstall
 
 
 
-[9] Language bindings
+[10] Language bindings
 
   Look for the bindings under directory bindings/, and refer to README file
   of corresponding languages.
 
 
 
-[10] Unit tests
+[11] Unit tests
 
   Automated unit tests use the cmocka unit testing framework (https://cmocka.org/).
   It can be installed in most Linux distros using the package manager, e.g.

--- a/qemu/configure
+++ b/qemu/configure
@@ -432,8 +432,7 @@ HOST_VARIANT_DIR=""
 
 case $targetos in
 CYGWIN*)
-  mingw32="yes"
-  QEMU_CFLAGS="-mno-cygwin $QEMU_CFLAGS"
+  linux="yes"
 ;;
 MINGW32*)
   mingw32="yes"

--- a/qemu/tcg/i386/tcg-target.c
+++ b/qemu/tcg/i386/tcg-target.c
@@ -65,7 +65,7 @@ static const int tcg_target_reg_alloc_order[] = {
 
 static const int tcg_target_call_iarg_regs[] = {
 #if TCG_TARGET_REG_BITS == 64
-#if defined(_WIN64)
+#if (defined(_WIN64)||defined(__CYGWIN__))
     TCG_REG_RCX,
     TCG_REG_RDX,
 #else
@@ -2191,7 +2191,7 @@ static int tcg_target_callee_save_regs[] = {
 #if TCG_TARGET_REG_BITS == 64
     TCG_REG_RBP,
     TCG_REG_RBX,
-#if defined(_WIN64)
+#if (defined(_WIN64)||defined(__CYGWIN__))
     TCG_REG_RDI,
     TCG_REG_RSI,
 #endif
@@ -2316,7 +2316,7 @@ static void tcg_target_init(TCGContext *s)
     tcg_regset_set_reg(s->tcg_target_call_clobber_regs, TCG_REG_EDX);
     tcg_regset_set_reg(s->tcg_target_call_clobber_regs, TCG_REG_ECX);
     if (TCG_TARGET_REG_BITS == 64) {
-#if !defined(_WIN64)
+#if !(defined(_WIN64)||defined(__CYGWIN__))
         tcg_regset_set_reg(s->tcg_target_call_clobber_regs, TCG_REG_RDI);
         tcg_regset_set_reg(s->tcg_target_call_clobber_regs, TCG_REG_RSI);
 #endif

--- a/qemu/tcg/i386/tcg-target.h
+++ b/qemu/tcg/i386/tcg-target.h
@@ -67,7 +67,7 @@ typedef enum {
 /* used for function call generation */
 #define TCG_REG_CALL_STACK TCG_REG_ESP 
 #define TCG_TARGET_STACK_ALIGN 16
-#if defined(_WIN64)
+#if defined(_WIN64) || (defined(__CYGWIN__)&&defined(__x86_64__))
 #define TCG_TARGET_CALL_STACK_OFFSET 32
 #else
 #define TCG_TARGET_CALL_STACK_OFFSET 0

--- a/qemu/util/oslib-posix.c
+++ b/qemu/util/oslib-posix.c
@@ -61,7 +61,9 @@ extern int daemon(int, int);
 #include <sys/signal.h>
 
 #ifdef CONFIG_LINUX
+#if !defined(__CYGWIN__)
 #include <sys/syscall.h>
+#endif
 #include <sys/vfs.h>
 #endif
 

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -48,8 +48,10 @@ AR_EXT = a
 IS_CYGWIN := $(shell $(CC) -dumpmachine | grep -i cygwin | wc -l)
 ifeq ($(IS_CYGWIN),1)
 CFLAGS := $(CFLAGS:-fPIC=)
+LDFLAGS += -lssp
+LDFLAGS_STATIC += -lssp
 BIN_EXT = .exe
-AR_EXT = lib
+AR_EXT = a
 else
 # mingw?
 IS_MINGW := $(shell $(CC) --version | grep -i mingw | wc -l)
@@ -64,7 +66,7 @@ ifeq ($(UNICORN_STATIC),yes)
 ifeq ($(IS_MINGW),1)
 ARCHIVE = $(LIBDIR)/$(LIBNAME).$(AR_EXT)
 else ifeq ($(IS_CYGWIN),1)
-ARCHIVE = $(LIBDIR)/$(LIBNAME).$(AR_EXT)
+ARCHIVE = $(LIBDIR)/lib$(LIBNAME).$(AR_EXT)
 else
 ARCHIVE = $(LIBDIR)/lib$(LIBNAME).$(AR_EXT)
 #ARCHIVE_X86 = $(LIBDIR)/lib$(LIBNAME)_x86.$(AR_EXT)


### PR DESCRIPTION
Unicorn can be built for Cygwin.

    $ apt-cyg install make gcc-core pkg-config libpcre-devel zlib-devel libglib2.0-devel
    $ ./make.sh install

--
Cygwin64

    $ uname -srvmo
    CYGWIN_NT-6.1 2.3.1(0.291/5/3) 2015-11-14 12:44 x86_64 Cygwin
    $ gcc -dumpversion; gcc -dumpmachine
    4.9.3
    x86_64-pc-cygwin

--
Cygwin32

    $ uname -srvmo
    CYGWIN_NT-6.1-WOW 2.3.1(0.291/5/3) 2015-11-14 12:42 i686 Cygwin
    $ gcc -dumpversion; gcc -dumpmachine
    4.9.3
    i686-pc-cygwin