### PR TITLE
Regression test for MIPS kernel mode execution

### DIFF
--- a/tests/regress/mips_kernel_mmu.py
+++ b/tests/regress/mips_kernel_mmu.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python
+
+from unicorn import *
+from unicorn.mips_const import *
+
+import regress
+
+class MipsSyscall(regress.RegressTest):
+    def test(self):
+        addr = 0x80000000
+        code = '34213456'.decode('hex') # ori $at, $at, 0x3456
+
+        uc = Uc(UC_ARCH_MIPS, UC_MODE_MIPS32 + UC_MODE_BIG_ENDIAN)
+        uc.mem_map(addr, 0x1000)
+        uc.mem_write(addr, code)
+        uc.reg_write(UC_MIPS_REG_AT, 0)
+
+        uc.emu_start(addr, addr + len(code))
+
+        #self.assertEqual(addr + len(code), uc.reg_read(UC_MIPS_REG_PC))
+        self.assertEqual(uc.reg_read(UC_MIPS_REG_AT), 0x3456)
+
+
+if __name__ == '__main__':
+    regress.main()

--- a/tests/regress/mips_kernel_mmu.py
+++ b/tests/regress/mips_kernel_mmu.py
@@ -17,7 +17,6 @@ class MipsSyscall(regress.RegressTest):
 
         uc.emu_start(addr, addr + len(code))
 
-        #self.assertEqual(addr + len(code), uc.reg_read(UC_MIPS_REG_PC))
         self.assertEqual(uc.reg_read(UC_MIPS_REG_AT), 0x3456)
 
 


### PR DESCRIPTION
Created a regression test as requested in Issue #343. This test passes when the base address is less than KSEG0 (0x80000000) and currently fails when greater than or equal to KSEG0.