### PR TITLE
added test for unmap of doubly mapped region

### DIFF
--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -29,4 +29,4 @@ test_mem_map_ptr: test_mem_map_ptr.c
 test_mem_high: test_mem_high.c
 
 ${ALL_TESTS}:
-	gcc ${CFLAGS} -o $@ $^
+	clang ${CFLAGS} -o $@ $^

--- a/tests/unit/test_mem_map.c
+++ b/tests/unit/test_mem_map.c
@@ -129,6 +129,18 @@ static void test_bad_unmap(void **state)
 }
 
 
+/* Try to unmap memory that has not been mapped twice*/
+static void test_unmap_double_map(void **state)
+{
+    uc_engine *uc = *state;
+
+    /* TODO: Which error should this return? */
+    uc_assert_success(uc_mem_map(uc, 0,      0x4000, 0));   /* 0x0000 - 0x1000 */
+    uc_assert_success(uc_mem_map(uc, 0x0000, 0x1000, 0));   /* 0x1000 - 0x2000 */
+
+    uc_assert_fail(uc_mem_unmap(uc, 0x2000, 0x2000));
+}
+
 int main(void) {
 #define test(x)     cmocka_unit_test_setup_teardown(x, setup, teardown)
     const struct CMUnitTest tests[] = {
@@ -137,6 +149,7 @@ int main(void) {
         //test(test_bad_write),
         test(test_bad_unmap),
         test(test_rw_across_boundaries),
+        test(test_unmap_double_map),
     };
 #undef test
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Crashes if a page is unmapped after another page was mapped twice. Its unclear if mapping twice should fail or unmap should succeed.
