### PR TITLE
Add some fixes to mem_unmap and mem_nofree tests.

### DIFF
--- a/tests/regress/mem_nofree.c
+++ b/tests/regress/mem_nofree.c
@@ -5,8 +5,8 @@
 
 #include <unicorn/unicorn.h>
 
-#define ADDRESS1 0x1000000
-#define ADDRESS2 0x2000000
+#define ADDRESS1 0x10000000
+#define ADDRESS2 0x20000000
 #define SIZE (80 * 1024 * 1024)
 
 static void VM_exec()

--- a/tests/regress/mem_unmap.c
+++ b/tests/regress/mem_unmap.c
@@ -135,7 +135,7 @@ static bool hook_mem_invalid(uc_engine *uc, uc_mem_type type,
         default:
             printf("not ok %d - memory invalid type: %d at 0x%" PRIx64 "\n", log_num++, type, addr);
             return false;
-        case UC_MEM_WRITE:
+        case UC_MEM_WRITE_UNMAPPED:
             printf("# write to invalid memory at 0x%"PRIx64 ", data size = %u, data value = 0x%"PRIx64 "\n", addr, size, value);
 
             if (uc_mem_read(uc, addr, &testval, sizeof(testval)) != UC_ERR_OK) {


### PR DESCRIPTION
My mem_nofree test fails on the latest code as apparently my address and
sizes overlap each other.

The mem_unmap test failed as the invalid memory hook case was incorrect.

Additionally, if mem_map fails for some reason, the new allocated memory region is not stashed, and this creates a problem with my memory leak fixes.