### PR TITLE
Reset env->invalid_error before executing a translation block.

### DIFF
--- a/qemu/cpu-exec.c
+++ b/qemu/cpu-exec.c
@@ -92,6 +92,7 @@ int cpu_exec(struct uc_struct *uc, CPUArchState *env)   // qq
 
     cc->cpu_exec_enter(cpu);
     cpu->exception_index = -1;
+    env->invalid_error = UC_ERR_OK;
 
     /* prepare setjmp context for exception handling */
     for(;;) {

--- a/uc.c
+++ b/uc.c
@@ -606,26 +606,6 @@ static uc_err mem_map(uc_engine *uc, uint64_t address, size_t size, uint32_t per
 {
     MemoryRegion **regions;
 
-    if (size == 0)
-        // invalid memory mapping
-        return UC_ERR_ARG;
-
-    // address cannot wrapp around
-    if (address + size - 1 < address)
-        return UC_ERR_ARG;
-
-    // address must be aligned to uc->target_page_size
-    if ((address & uc->target_page_align) != 0)
-        return UC_ERR_ARG;
-
-    // size must be multiple of uc->target_page_size
-    if ((size & uc->target_page_align) != 0)
-        return UC_ERR_ARG;
-
-    // check for only valid permissions
-    if ((perms & ~UC_PROT_ALL) != 0)
-        return UC_ERR_ARG;
-
     // this area overlaps existing mapped regions?
     if (memory_overlap(uc, address, size))
         return UC_ERR_MAP;
@@ -654,6 +634,26 @@ uc_err uc_mem_map(uc_engine *uc, uint64_t address, size_t size, uint32_t perms)
     if (uc->mem_redirect) {
         address = uc->mem_redirect(address);
     }
+
+    if (size == 0)
+        // invalid memory mapping
+        return UC_ERR_ARG;
+
+    // address cannot wrapp around
+    if (address + size - 1 < address)
+        return UC_ERR_ARG;
+
+    // address must be aligned to uc->target_page_size
+    if ((address & uc->target_page_align) != 0)
+        return UC_ERR_ARG;
+
+    // size must be multiple of uc->target_page_size
+    if ((size & uc->target_page_align) != 0)
+        return UC_ERR_ARG;
+
+    // check for only valid permissions
+    if ((perms & ~UC_PROT_ALL) != 0)
+        return UC_ERR_ARG;
 
     return mem_map(uc, address, size, perms, uc->memory_map(uc, address, size, perms));
 }


### PR DESCRIPTION
Should remove the INVALID memory error when re-using an instance. Should fix issue #351 and a fix for issue #369 