### PR TITLE
Fix for calling uc_open() and uc_emu_start() from different threads

### DIFF
--- a/include/uc_priv.h
+++ b/include/uc_priv.h
@@ -88,6 +88,7 @@ struct hook_struct {
 struct uc_struct {
     uc_arch arch;
     uc_mode mode;
+    bool lock_at_vm_start;
     QemuMutex qemu_global_mutex; // qemu/cpus.c
     QemuCond qemu_cpu_cond; // qemu/cpus.c
     QemuThread *tcg_cpu_thread; // qemu/cpus.c

--- a/qemu/cpus.c
+++ b/qemu/cpus.c
@@ -42,6 +42,11 @@ static void *qemu_tcg_cpu_thread_fn(void *arg);
 
 int vm_start(struct uc_struct* uc)
 {
+    if (uc->lock_at_vm_start) {
+        uc->lock_at_vm_start = false;
+        qemu_mutex_lock_iothread(uc);
+    }
+    
     if (resume_all_vcpus(uc)) {
         return -1;
     }

--- a/qemu/vl.c
+++ b/qemu/vl.c
@@ -93,6 +93,7 @@ int machine_initialize(struct uc_struct *uc)
 {
     MachineClass *machine_class;
     MachineState *current_machine;
+    int ret;
 
     module_call_init(uc, MODULE_INIT_QOM);
     register_types_object(uc);
@@ -127,7 +128,11 @@ int machine_initialize(struct uc_struct *uc)
 
     current_machine->cpu_model = NULL;
 
-    return machine_class->init(uc, current_machine);
+    ret = machine_class->init(uc, current_machine);
+    
+    qemu_mutex_unlock_iothread(uc);
+    uc->lock_at_vm_start = true;
+    return ret;
 }
 
 void qemu_system_reset_request(struct uc_struct* uc)


### PR DESCRIPTION
This is a fix attempt for calling uc_open() and uc_emu_start() from different threads as explained in issue #292 and regression test added in #320.

I have done various debug prints while trying fixes for this and it appears like this will be ok but perhaps someone with more experience with qemu internals can double check. Feel free to suggest other ways of doing this.
