### PR TITLE
test case: x86 guest paging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,356 +1,41 @@
-# Unicorn Emulator Engine
-# By Dang Hoang Vu <dang.hvu -at- gmail.com>, 2015
 
+CFLAGS += -Wall -Werror -Wno-unused-function -g
+CFLAGS += -L ../../
+CFLAGS += -lcmocka -lunicorn
+CFLAGS += -I ../../include
 
-.PHONY: all clean install uninstall dist header
+ALL_TESTS = test_sanity test_x86 test_mem_map test_mem_high test_mem_map_ptr \
+	test_tb_x86 test_multihook test_pc_change test_x86_soft_paging
 
-include config.mk
-include pkgconfig.mk	# package version
+.PHONY: all
+all: ${ALL_TESTS}
 
-LIBNAME = unicorn
-
-GENOBJ = $(shell find qemu/$(1) -name "*.o" 2>/dev/null) $(wildcard qemu/util/*.o) $(wildcard qemu/*.o) $(wildcard qemu/qom/*.o)\
-		 $(wildcard qemu/hw/core/*.o) $(wildcard qemu/qapi/*.o) $(wildcard qemu/qobject/*.o)
-
-ifneq (,$(findstring x86,$(UNICORN_ARCHS)))
-	UC_TARGET_OBJ += $(call GENOBJ,x86_64-softmmu)
-	UNICORN_CFLAGS += -DUNICORN_HAS_X86
-	UNICORN_TARGETS += x86_64-softmmu,
-endif
-ifneq (,$(findstring arm,$(UNICORN_ARCHS)))
-	UC_TARGET_OBJ += $(call GENOBJ,arm-softmmu)
-	UNICORN_CFLAGS += -DUNICORN_HAS_ARM
-	UNICORN_TARGETS += arm-softmmu,
-endif
-ifneq (,$(findstring m68k,$(UNICORN_ARCHS)))
-	UC_TARGET_OBJ += $(call GENOBJ,m68k-softmmu)
-	UNICORN_CFLAGS += -DUNICORN_HAS_M68K
-	UNICORN_TARGETS += m68k-softmmu,
-endif
-ifneq (,$(findstring aarch64,$(UNICORN_ARCHS)))
-	UC_TARGET_OBJ += $(call GENOBJ,aarch64-softmmu)
-	UNICORN_CFLAGS += -DUNICORN_HAS_ARM64
-	UNICORN_TARGETS += aarch64-softmmu,
-endif
-ifneq (,$(findstring mips,$(UNICORN_ARCHS)))
-	UC_TARGET_OBJ += $(call GENOBJ,mips-softmmu)
-	UC_TARGET_OBJ += $(call GENOBJ,mipsel-softmmu)
-	UC_TARGET_OBJ += $(call GENOBJ,mips64-softmmu)
-	UC_TARGET_OBJ += $(call GENOBJ,mips64el-softmmu)
-	UNICORN_CFLAGS += -DUNICORN_HAS_MIPS
-	UNICORN_CFLAGS += -DUNICORN_HAS_MIPSEL
-	UNICORN_CFLAGS += -DUNICORN_HAS_MIPS64
-	UNICORN_CFLAGS += -DUNICORN_HAS_MIPS64EL
-	UNICORN_TARGETS += mips-softmmu,
-	UNICORN_TARGETS += mipsel-softmmu,
-	UNICORN_TARGETS += mips64-softmmu,
-	UNICORN_TARGETS += mips64el-softmmu,
-endif
-ifneq (,$(findstring sparc,$(UNICORN_ARCHS)))
-	UC_TARGET_OBJ += $(call GENOBJ,sparc-softmmu)
-	UC_TARGET_OBJ += $(call GENOBJ,sparc64-softmmu)
-	UNICORN_CFLAGS += -DUNICORN_HAS_SPARC
-	UNICORN_TARGETS += sparc-softmmu,sparc64-softmmu,
-endif
-
-UNICORN_CFLAGS += -fPIC
-
-# Verbose output?
-V ?= 0
-
-ifeq ($(UNICORN_DEBUG),yes)
-CFLAGS += -g
-else
-CFLAGS += -O3
-endif
-
-ifeq ($(CROSS),)
-CC ?= cc
-AR ?= ar
-RANLIB ?= ranlib
-STRIP ?= strip
-else
-CC = $(CROSS)-gcc
-AR = $(CROSS)-ar
-RANLIB = $(CROSS)-ranlib
-STRIP = $(CROSS)-strip
-GLIB = "-L/usr/$(CROSS)/lib/ -lglib-2.0"
-endif
-
-# Find GLIB
-ifndef GLIB
-GLIB = `pkg-config --libs glib-2.0`
-endif
-
-ifeq ($(PKG_EXTRA),)
-PKG_VERSION = $(PKG_MAJOR).$(PKG_MINOR)
-else
-PKG_VERSION = $(PKG_MAJOR).$(PKG_MINOR).$(PKG_EXTRA)
-endif
-
-API_MAJOR=$(shell echo `grep -e UC_API_MAJOR include/unicorn/unicorn.h | grep -v = | awk '{print $$3}'` | awk '{print $$1}')
-VERSION_EXT =
-
-BIN_EXT =
-
-IS_APPLE := $(shell $(CC) -dM -E - < /dev/null | grep -cm 1 -e __apple_build_version__ -e __APPLE_CC__)
-ifeq ($(IS_APPLE),1)
-EXT = dylib
-VERSION_EXT = $(API_MAJOR).$(EXT)
-$(LIBNAME)_LDFLAGS += -dynamiclib -install_name lib$(LIBNAME).$(VERSION_EXT) -current_version $(PKG_MAJOR).$(PKG_MINOR).$(PKG_EXTRA) -compatibility_version $(PKG_MAJOR).$(PKG_MINOR)
-AR_EXT = a
-UNICORN_CFLAGS += -fvisibility=hidden
-else
-# Cygwin?
-IS_CYGWIN := $(shell $(CC) -dumpmachine | grep -i cygwin | wc -l)
-ifeq ($(IS_CYGWIN),1)
-EXT = dll
-AR_EXT = a
-BIN_EXT = .exe
-UNICORN_CFLAGS := $(UNICORN_CFLAGS:-fPIC=)
-#UNICORN_QEMU_FLAGS += --disable-stack-protector
-else
-# mingw?
-IS_MINGW := $(shell $(CC) --version | grep -i mingw | wc -l)
-ifeq ($(IS_MINGW),1)
-EXT = dll
-AR_EXT = lib
-BIN_EXT = .exe
-else
-# Linux, *BSD
-EXT = so
-VERSION_EXT = $(EXT).$(API_MAJOR)
-AR_EXT = a
-$(LIBNAME)_LDFLAGS += -Wl,-Bsymbolic-functions,-soname,lib$(LIBNAME).$(VERSION_EXT)
-UNICORN_CFLAGS += -fvisibility=hidden
-endif
-endif
-endif
-
-ifeq ($(UNICORN_SHARED),yes)
-ifeq ($(IS_MINGW),1)
-LIBRARY = $(BLDIR)/$(LIBNAME).$(EXT)
-else ifeq ($(IS_CYGWIN),1)
-LIBRARY = $(BLDIR)/cyg$(LIBNAME).$(EXT)
-LIBRARY_DLLA = $(BLDIR)/lib$(LIBNAME).$(EXT).$(AR_EXT)
-$(LIBNAME)_LDFLAGS += -Wl,--out-implib=$(LIBRARY_DLLA)
-$(LIBNAME)_LDFLAGS += -lssp
-else	# *nix
-LIBRARY = $(BLDIR)/lib$(LIBNAME).$(VERSION_EXT)
-LIBRARY_SYMLINK = $(BLDIR)/lib$(LIBNAME).$(EXT)
-endif
-endif
-
-ifeq ($(UNICORN_STATIC),yes)
-ifeq ($(IS_MINGW),1)
-ARCHIVE = $(BLDIR)/$(LIBNAME).$(AR_EXT)
-else ifeq ($(IS_CYGWIN),1)
-ARCHIVE = $(BLDIR)/lib$(LIBNAME).$(AR_EXT)
-else
-ARCHIVE = $(BLDIR)/lib$(LIBNAME).$(AR_EXT)
-endif
-endif
-
-INSTALL_BIN ?= install
-INSTALL_DATA ?= $(INSTALL_BIN) -m0644
-INSTALL_LIB ?= $(INSTALL_BIN) -m0755
-PKGCFGF = $(LIBNAME).pc
-PREFIX ?= /usr
-DESTDIR ?=
-BLDIR = .
-OBJDIR = .
-UNAME_S := $(shell uname -s)
-
-LIBDIRARCH ?= lib
-# Uncomment the below line to installs x86_64 libs to lib64/ directory.
-# Or better, pass 'LIBDIRARCH=lib64' to 'make install/uninstall' via 'make.sh'.
-#LIBDIRARCH ?= lib64
-
-LIBDIR ?= $(PREFIX)/$(LIBDIRARCH)
-INCDIR ?= $(PREFIX)/include
-BINDIR ?= $(PREFIX)/bin
-
-LIBDATADIR ?= $(LIBDIR)
-
-# Don't redefine $LIBDATADIR when global environment variable
-# USE_GENERIC_LIBDATADIR is set. This is used by the pkgsrc framework.
-
-ifndef USE_GENERIC_LIBDATADIR
-ifeq ($(UNAME_S), FreeBSD)
-LIBDATADIR = $(DESTDIR)$(PREFIX)/libdata
-endif
-ifeq ($(UNAME_S), DragonFly)
-LIBDATADIR = $(DESTDIR)$(PREFIX)/libdata
-endif
-endif
-
-ifeq ($(PKG_EXTRA),)
-PKGCFGDIR = $(LIBDATADIR)/pkgconfig
-else
-PKGCFGDIR ?= $(LIBDATADIR)/pkgconfig
-endif
-
-all: compile_lib
-ifeq (,$(findstring yes,$(UNICORN_BUILD_CORE_ONLY)))
-ifeq ($(UNICORN_SHARED),yes)
-ifeq ($(V),0)
-	@$(INSTALL_LIB) $(LIBRARY) $(BLDIR)/samples/
-else
-	$(INSTALL_LIB) $(LIBRARY) $(BLDIR)/samples/
-endif
-endif
-
-ifndef BUILDDIR
-	@cd samples && $(MAKE)
-else
-	@cd samples && $(MAKE) BUILDDIR=$(BLDIR)
-endif
-endif
-
-config:
-	if [ "$(UNICORN_ARCHS)" != "`cat config.log`" ]; then $(MAKE) clean; fi
-
-qemu/config-host.h-timestamp:
-ifeq ($(UNICORN_DEBUG),yes)
-	cd qemu && \
-	./configure --extra-cflags="$(UNICORN_CFLAGS)" --target-list="$(UNICORN_TARGETS)" ${UNICORN_QEMU_FLAGS}
-	printf "$(UNICORN_ARCHS)" > config.log
-else
-	cd qemu && \
-	./configure --disable-debug-info --extra-cflags="$(UNICORN_CFLAGS)" --target-list="$(UNICORN_TARGETS)" ${UNICORN_QEMU_FLAGS}
-	printf "$(UNICORN_ARCHS)" > config.log
-endif
-
-compile_lib: config qemu/config-host.h-timestamp
-	rm -rf lib$(LIBNAME)* $(LIBNAME)*.lib $(LIBNAME)*.dll cyg$(LIBNAME)*.dll && cd qemu && $(MAKE) -j 4
-	$(MAKE) unicorn
-	cd samples && $(MAKE) clean
-
-unicorn: $(LIBRARY) $(ARCHIVE)
-
-$(LIBRARY): $(UC_TARGET_OBJ) uc.o list.o
-ifeq ($(UNICORN_SHARED),yes)
-ifeq ($(V),0)
-	$(call log,GEN,$(LIBRARY))
-	@$(CC) $(CFLAGS) -shared $^ -o $(LIBRARY) $(GLIB) -lm $($(LIBNAME)_LDFLAGS)
-else
-	$(CC) $(CFLAGS) -shared $^ -o $(LIBRARY) $(GLIB) -lm $($(LIBNAME)_LDFLAGS)
-endif
-ifneq (,$(LIBRARY_SYMLINK))
-	@ln -sf $(LIBRARY) $(LIBRARY_SYMLINK)
-endif
-endif
-
-$(ARCHIVE): $(UC_TARGET_OBJ) uc.o list.o
-ifeq ($(UNICORN_STATIC),yes)
-ifeq ($(V),0)
-	$(call log,GEN,$(ARCHIVE))
-	@$(create-archive)
-else
-	$(create-archive)
-endif
-endif
-
-
-$(PKGCFGF):
-ifeq ($(V),0)
-	$(call log,GEN,$(@:$(BLDIR)/%=%))
-	@$(generate-pkgcfg)
-else
-	$(generate-pkgcfg)
-endif
-
+.PHONY: clean
+clean:
+	rm -rf ${ALL_TESTS}
 
 .PHONY: test
-test: all
-	$(MAKE) -C tests/unit test
+test: export LD_LIBRARY_PATH=../../
+test: ${ALL_TESTS}
+	./test_sanity
+	./test_x86
+	./test_mem_map
+	./test_mem_map_ptr
+	./test_mem_high
+	./test_tb_x86
+	./test_multihook
+	./test_pc_change
+	./test_x86_soft_paging
 
+test_sanity: test_sanity.c
+test_x86: test_x86.c
+test_mem_map: test_mem_map.c
+test_mem_map_ptr: test_mem_map_ptr.c
+test_mem_high: test_mem_high.c
+test_tb_x86: test_tb_x86.c
+test_multihook: test_multihook.c
+test_pc_change: test_pc_change.c
+test_x86_soft_paging: test_x86_soft_paging.c
 
-install: all $(PKGCFGF)
-	mkdir -p $(DESTDIR)$(LIBDIR)
-ifeq ($(UNICORN_SHARED),yes)
-ifeq ($(IS_CYGWIN),1)
-	$(INSTALL_LIB) $(LIBRARY) $(DESTDIR)$(BINDIR)
-	$(INSTALL_DATA) $(LIBRARY_DLLA) $(DESTDIR)$(LIBDIR)
-else
-	$(INSTALL_LIB) $(LIBRARY) $(DESTDIR)$(LIBDIR)
-endif
-ifneq ($(VERSION_EXT),)
-	cd $(DESTDIR)$(LIBDIR) && \
-	ln -sf lib$(LIBNAME).$(VERSION_EXT) lib$(LIBNAME).$(EXT)
-endif
-endif
-ifeq ($(UNICORN_STATIC),yes)
-	$(INSTALL_DATA) $(ARCHIVE) $(DESTDIR)$(LIBDIR)
-endif
-	mkdir -p $(DESTDIR)$(INCDIR)/$(LIBNAME)
-	$(INSTALL_DATA) include/unicorn/*.h $(DESTDIR)$(INCDIR)/$(LIBNAME)
-	mkdir -p $(DESTDIR)$(PKGCFGDIR)
-	$(INSTALL_DATA) $(PKGCFGF) $(DESTDIR)$(PKGCFGDIR)/
-
-
-TAG ?= HEAD
-ifeq ($(TAG), HEAD)
-DIST_VERSION = latest
-else
-DIST_VERSION = $(TAG)
-endif
-
-dist:
-	git archive --format=tar.gz --prefix=unicorn-$(DIST_VERSION)/ $(TAG) > unicorn-$(DIST_VERSION).tgz
-	git archive --format=zip --prefix=unicorn-$(DIST_VERSION)/ $(TAG) > unicorn-$(DIST_VERSION).zip
-
-
-header: FORCE
-	$(eval TARGETS := m68k arm aarch64 mips mipsel mips64 mips64el\
-		powerpc sparc sparc64 x86_64)
-	$(foreach var,$(TARGETS),\
-		$(shell python qemu/header_gen.py $(var) > qemu/$(var).h;))
-	@echo "Generated headers for $(TARGETS)."
-
-
-uninstall:
-	rm -rf $(INCDIR)/$(LIBNAME)
-	rm -f $(LIBDIR)/lib$(LIBNAME).*
-	rm -f $(BINDIR)/cyg$(LIBNAME).*
-	rm -f $(PKGCFGDIR)/$(LIBNAME).pc
-
-
-clean:
-	$(MAKE) -C qemu clean
-	rm -rf *.d *.o
-	rm -rf lib$(LIBNAME)* $(LIBNAME)*.lib $(LIBNAME)*.dll cyg$(LIBNAME)*.dll
-ifeq (,$(findstring yes,$(UNICORN_BUILD_CORE_ONLY)))
-	cd samples && $(MAKE) clean
-	rm -f $(BLDIR)/samples/lib$(LIBNAME).$(EXT)
-endif
-	$(MAKE) -C tests/unit clean
-
-ifdef BUILDDIR
-	rm -rf $(BUILDDIR)
-endif
-
-
-define generate-pkgcfg
-	echo 'Name: unicorn' > $(PKGCFGF)
-	echo 'Description: Unicorn emulator engine' >> $(PKGCFGF)
-	echo 'Version: $(PKG_VERSION)' >> $(PKGCFGF)
-	echo 'libdir=$(LIBDIR)' >> $(PKGCFGF)
-	echo 'includedir=$(INCDIR)' >> $(PKGCFGF)
-	echo 'archive=$${libdir}/libunicorn.a' >> $(PKGCFGF)
-	echo 'Libs: -L$${libdir} -lunicorn' >> $(PKGCFGF)
-	echo 'Cflags: -I$${includedir}' >> $(PKGCFGF)
-endef
-
-
-define log
-	@printf "  %-7s %s\n" "$(1)" "$(2)"
-endef
-
-
-define create-archive
-	$(AR) q $(ARCHIVE) $^
-	$(RANLIB) $(ARCHIVE)
-endef
-
-FORCE:
+${ALL_TESTS}:
+	${CC} ${CFLAGS} -o $@ $^

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -5,7 +5,7 @@ CFLAGS += -lcmocka -lunicorn
 CFLAGS += -I ../../include
 
 ALL_TESTS = test_sanity test_x86 test_mem_map test_mem_high test_mem_map_ptr \
-	test_tb_x86 test_multihook test_pc_change
+	test_tb_x86 test_multihook test_pc_change test_x86_soft_paging
 
 .PHONY: all
 all: ${ALL_TESTS}
@@ -25,6 +25,7 @@ test: ${ALL_TESTS}
 	./test_tb_x86
 	./test_multihook
 	./test_pc_change
+	./test_x86_soft_paging
 
 test_sanity: test_sanity.c
 test_x86: test_x86.c
@@ -34,6 +35,7 @@ test_mem_high: test_mem_high.c
 test_tb_x86: test_tb_x86.c
 test_multihook: test_multihook.c
 test_pc_change: test_pc_change.c
+test_x86_soft_paging: test_x86_soft_paging.c
 
 ${ALL_TESTS}:
 	${CC} ${CFLAGS} -o $@ $^

--- a/tests/unit/test_x86_soft_paging.c
+++ b/tests/unit/test_x86_soft_paging.c
@@ -1,0 +1,210 @@
+#include "unicorn_test.h"
+#include <inttypes.h>
+
+/*
+    Two tests here for software paging
+    Low paging: Test paging using virtual addresses already mapped by Unicorn
+    High paging: Test paging using virtual addresses not mapped by Unicorn
+*/
+
+static void test_low_paging(void **state) {
+    uc_engine *uc;
+    uc_err err;
+    int r_eax;
+    
+    /*  The following x86 code will map emulated physical memory
+        to virtual memory using pages and attempt
+        to read/write from virtual memory 
+        
+        Specifically, the virtual memory address range
+        has been mapped by Unicorn (0x7FF000 - 0x7FFFFF)
+        
+        Memory area purposes:
+        0x1000 = page directory
+        0x2000 = page table (identity map first 4 MiB)
+        0x3000 = page table (0x007FF000 -> 0x00004000)
+        0x4000 = data area (0xBEEF)
+    */
+    const uint8_t code[] = {
+        /* Zero memory for page directories and page tables */
+        0xBF, 0x00, 0x10, 0x00, 0x00, /* MOV EDI, 0x1000 */
+        0xB9, 0x00, 0x10, 0x00, 0x00, /* MOV ECX, 0x1000 */
+        0x31, 0xC0,                   /* XOR EAX, EAX */
+        0xF3, 0xAB,                   /* REP STOSD */
+        
+        /* Load DWORD [0x4000] with 0xDEADBEEF to retrieve later */
+        0xBF, 0x00, 0x40, 0x00, 0x00, /* MOV EDI, 0x4000 */
+        0xB8, 0xEF, 0xBE, 0x00, 0x00, /* MOV EAX, 0xBEEF */
+        0x89, 0x07,                   /* MOV [EDI], EAX */
+        
+        /* Identity map the first 4MiB of memory */
+        0xB9, 0x00, 0x04, 0x00, 0x00, /* MOV ECX, 0x400 */
+        0xBF, 0x00, 0x20, 0x00, 0x00, /* MOV EDI, 0x2000 */
+        0xB8, 0x03, 0x00, 0x00, 0x00, /* MOV EAX, 3 */
+                                      /* aLoop: */
+        0xAB,                         /* STOSD */
+        0x05, 0x00, 0x10, 0x00, 0x00, /* ADD EAX, 0x1000 */
+        0xE2, 0xF8,                   /* LOOP aLoop */
+        
+        /* Map physical address 0x4000 to virtual address 0x7FF000 */
+        0xBF, 0xFC, 0x3F, 0x00, 0x00, /* MOV EDI, 0x3FFC */
+        0xB8, 0x03, 0x40, 0x00, 0x00, /* MOV EAX, 0x4003 */
+        0x89, 0x07,                   /* MOV [EDI], EAX */
+        
+        /* Add page tables into page directory */
+        0xBF, 0x00, 0x10, 0x00, 0x00, /* MOV EDI, 0x1000 */
+        0xB8, 0x03, 0x20, 0x00, 0x00, /* MOV EAX, 0x2003 */
+        0x89, 0x07,                   /* MOV [EDI], EAX */
+        0xBF, 0x04, 0x10, 0x00, 0x00, /* MOV EDI, 0x1004 */
+        0xB8, 0x03, 0x30, 0x00, 0x00, /* MOV EAX, 0x3003 */
+        0x89, 0x07,                   /* MOV [EDI], EAX */
+        
+        /* Load the page directory register */
+        0xB8, 0x00, 0x10, 0x00, 0x00, /* MOV EAX, 0x1000 */
+        0x0F, 0x22, 0xD8,             /* MOV CR3, EAX */
+        
+        /* Enable paging */
+        0x0F, 0x20, 0xC0,             /* MOV EAX, CR0 */
+        0x0D, 0x00, 0x00, 0x00, 0x80, /* OR EAX, 0x80000000 */
+        0x0F, 0x22, 0xC0,             /* MOV CR0, EAX */
+        
+        /* Clear EAX */
+        0x31, 0xC0,                   /* XOR EAX, EAX */
+        
+        /* Load using virtual memory address; EAX = 0xBEEF */
+        0xBE, 0x00, 0xF0, 0x7F, 0x00, /* MOV ESI, 0x7FF000 */
+        0x8B, 0x06,                   /* MOV EAX, [ESI] */
+        0xF4,                         /* HLT */
+    };
+    
+    /* Initialise X86-32bit mode */
+    err = uc_open(UC_ARCH_X86, UC_MODE_32, &uc);
+    uc_assert_success(err);
+    
+    /* Map 8MB of memory at base address 0 */
+    err = uc_mem_map(uc, 0, (8 * 1024 * 1024), UC_PROT_ALL);
+    uc_assert_success(err);
+    
+    /* Write code into memory at address 0 */
+    err = uc_mem_write(uc, 0, code, sizeof(code));
+    uc_assert_success(err);
+    
+    /* Start emulation */
+    err = uc_emu_start(uc, 0, sizeof(code), 0, 0);
+    uc_assert_success(err);
+    
+    /* The code should have loaded 0xBEEF into EAX */
+    uc_reg_read(uc, UC_X86_REG_EAX, &r_eax);
+    assert_int_equal(r_eax, 0xBEEF);
+    
+    uc_close(uc);
+}
+
+
+/****************************************************************************/
+
+
+static void test_high_paging(void **state) {
+    uc_engine *uc;
+    uc_err err;
+    int r_eax;
+    
+    /*  The following x86 code will map emulated physical memory
+        to virtual memory using pages and attempt
+        to read/write from virtual memory 
+        
+        Specifically, the virtual memory address range
+        has not been mapped by UC (0xFFFFF000 - 0xFFFFFFFF)
+        
+        Memory area purposes:
+        0x1000 = page directory
+        0x2000 = page table (identity map first 4 MiB)
+        0x3000 = page table (0xFFFFF000 -> 0x00004000)
+        0x4000 = data area (0xDEADBEEF)
+    */
+    const uint8_t code[] = {
+        /* Zero memory for page directories and page tables */
+        0xBF, 0x00, 0x10, 0x00, 0x00, /* MOV EDI, 0x1000 */
+        0xB9, 0x00, 0x10, 0x00, 0x00, /* MOV ECX, 0x1000 */
+        0x31, 0xC0,                   /* XOR EAX, EAX */
+        0xF3, 0xAB,                   /* REP STOSD */
+        
+        /* Load DWORD [0x4000] with 0xDEADBEEF to retrieve later */
+        0xBF, 0x00, 0x40, 0x00, 0x00, /* MOV EDI, 0x4000 */
+        0xB8, 0xEF, 0xBE, 0x00, 0x00, /* MOV EAX, 0xBEEF */
+        0x89, 0x07,                   /* MOV [EDI], EAX */
+        
+        /* Identity map the first 4MiB of memory */
+        0xB9, 0x00, 0x04, 0x00, 0x00, /* MOV ECX, 0x400 */
+        0xBF, 0x00, 0x20, 0x00, 0x00, /* MOV EDI, 0x2000 */
+        0xB8, 0x03, 0x00, 0x00, 0x00, /* MOV EAX, 3 */
+                                      /* aLoop: */
+        0xAB,                         /* STOSD */
+        0x05, 0x00, 0x10, 0x00, 0x00, /* ADD EAX, 0x1000 */
+        0xE2, 0xF8,                   /* LOOP aLoop */
+        
+        /* Map physical address 0x4000 to virtual address 0xFFFFF000 */
+        0xBF, 0xFC, 0x3F, 0x00, 0x00, /* MOV EDI, 0x3FFC */
+        0xB8, 0x03, 0x40, 0x00, 0x00, /* MOV EAX, 0x4003 */
+        0x89, 0x07,                   /* MOV [EDI], EAX */
+        
+        /* Add page tables into page directory */
+        0xBF, 0x00, 0x10, 0x00, 0x00, /* MOV EDI, 0x1000 */
+        0xB8, 0x03, 0x20, 0x00, 0x00, /* MOV EAX, 0x2003 */
+        0x89, 0x07,                   /* MOV [EDI], EAX */
+        0xBF, 0xFC, 0x1F, 0x00, 0x00, /* MOV EDI, 0x1FFC */
+        0xB8, 0x03, 0x30, 0x00, 0x00, /* MOV EAX, 0x3003 */
+        0x89, 0x07,                   /* MOV [EDI], EAX */
+        
+        /* Load the page directory register */
+        0xB8, 0x00, 0x10, 0x00, 0x00, /* MOV EAX, 0x1000 */
+        0x0F, 0x22, 0xD8,             /* MOV CR3, EAX */
+        
+        /* Enable paging */
+        0x0F, 0x20, 0xC0,             /* MOV EAX, CR0 */
+        0x0D, 0x00, 0x00, 0x00, 0x80, /* OR EAX, 0x80000000 */
+        0x0F, 0x22, 0xC0,             /* MOV CR0, EAX */
+        
+        /* Clear EAX */
+        0x31, 0xC0,                   /* XOR EAX, EAX */
+        
+        /* Load using virtual memory address; EAX = 0xBEEF */
+        0xBE, 0x00, 0xF0, 0xFF, 0xFF, /* MOV ESI, 0xFFFFF000 */
+        0x8B, 0x06,                   /* MOV EAX, [ESI] */
+        0xF4,                         /* HLT */
+    };
+    
+    /* Initialise X86-32bit mode */
+    err = uc_open(UC_ARCH_X86, UC_MODE_32, &uc);
+    uc_assert_success(err);
+    
+    /* Map 4MB of memory at base address 0 */
+    err = uc_mem_map(uc, 0, (4 * 1024 * 1024), UC_PROT_ALL);
+    uc_assert_success(err);
+    
+    /* Write code into memory at address 0 */
+    err = uc_mem_write(uc, 0, code, sizeof(code));
+    uc_assert_success(err);
+    
+    /* Start emulation */
+    err = uc_emu_start(uc, 0, sizeof(code), 0, 0);
+    uc_assert_success(err);
+    
+    /* The code should have loaded 0xBEEF into EAX */
+    uc_reg_read(uc, UC_X86_REG_EAX, &r_eax);
+    assert_int_equal(r_eax, 0xBEEF);
+    
+    uc_close(uc);
+}
+
+
+/****************************************************************************/
+
+
+int main(void) {
+    const struct CMUnitTests tests[] = {
+        cmocka_unit_test(test_low_paging),
+        cmocka_unit_test(test_high_paging),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Test case for x86 paging using virtual addresses mapped by Unicorn, as well as unmapped.

Attempting to read/write from virtual address ranges unmapped by Unicorn wrongly causes protection faults, even when the virtual address points to read/write regions of Unicorn memory.