### PR TITLE
Fixed restoring of eflags after helper call

### DIFF
--- a/qemu/target-i386/translate.c
+++ b/qemu/target-i386/translate.c
@@ -4721,6 +4721,17 @@ static void sync_eflags(DisasContext *s, TCGContext *tcg_ctx)
     tcg_gen_st_tl(tcg_ctx, *cpu_T[0], cpu_env, offsetof(CPUX86State, eflags));
 }
 
+static void restore_eflags(DisasContext *s, TCGContext *tcg_ctx)
+{
+    TCGv **cpu_T = (TCGv **)tcg_ctx->cpu_T;
+    TCGv_ptr cpu_env = tcg_ctx->cpu_env;
+
+    tcg_gen_ld_tl(tcg_ctx, *cpu_T[0], cpu_env, offsetof(CPUX86State, eflags));
+    gen_helper_write_eflags(tcg_ctx, cpu_env, *cpu_T[0], 
+            tcg_const_i32(tcg_ctx, (TF_MASK | AC_MASK | ID_MASK | NT_MASK) & 0xffff));
+    set_cc_op(s, CC_OP_EFLAGS);
+}
+
 /* convert one instruction. s->is_jmp is set if the translation must
    be stopped. Return the next pc value */
 static target_ulong disas_insn(CPUX86State *env, DisasContext *s,
@@ -4773,6 +4784,7 @@ static target_ulong disas_insn(CPUX86State *env, DisasContext *s,
             changed_cc_op = true;
         }
         gen_uc_tracecode(tcg_ctx, 0xf1f1f1f1, UC_HOOK_CODE_IDX, env->uc, pc_start);
+        restore_eflags(s, tcg_ctx);
         // the callback might want to stop emulation immediately
         check_exit_request(tcg_ctx);
     }


### PR DESCRIPTION
If the value of the eflags register is changed inside the uc_tracecode helper, the previously computed value from helpers is used nevertheless, and the change is not taken into account. This patch forces a reload of the condition temporary from the eflags register value after each helper call.