### PR TITLE
fix WRITE_BYTE_H() macro

### DIFF
--- a/include/uc_priv.h
+++ b/include/uc_priv.h
@@ -22,6 +22,17 @@
 
 #define ARR_SIZE(a) (sizeof(a)/sizeof(a[0]))
 
+#define READ_QWORD(x) ((uint64)x)
+#define READ_DWORD(x) (x & 0xffffffff)
+#define READ_WORD(x) (x & 0xffff)
+#define READ_BYTE_H(x) ((x & 0xffff) >> 8)
+#define READ_BYTE_L(x) (x & 0xff)
+#define WRITE_DWORD(x, w) (x = (x & ~0xffffffff) | (w & 0xffffffff))
+#define WRITE_WORD(x, w) (x = (x & ~0xffff) | (w & 0xffff))
+#define WRITE_BYTE_H(x, b) (x = (x & ~0xff00) | ((b & 0xff) << 8))
+#define WRITE_BYTE_L(x, b) (x = (x & ~0xff) | (b & 0xff))
+
+
 QTAILQ_HEAD(CPUTailQ, CPUState);
 
 typedef struct ModuleEntry {

--- a/qemu/target-arm/unicorn_aarch64.c
+++ b/qemu/target-arm/unicorn_aarch64.c
@@ -3,21 +3,11 @@
 
 #include "hw/boards.h"
 #include "hw/arm/arm.h"
-
 #include "sysemu/cpus.h"
-
 #include "unicorn.h"
-
 #include "cpu.h"
-
 #include "unicorn_common.h"
-
-
-#define READ_QWORD(x) ((uint64)x)
-#define READ_DWORD(x) (x & 0xffffffff)
-#define READ_WORD(x) (x & 0xffff)
-#define READ_BYTE_H(x) ((x & 0xffff) >> 8)
-#define READ_BYTE_L(x) (x & 0xff)
+#include "uc_priv.h"
 
 
 static void arm64_set_pc(struct uc_struct *uc, uint64_t address)
@@ -59,11 +49,6 @@ int arm64_reg_read(struct uc_struct *uc, unsigned int regid, void *value)
 
     return 0;
 }
-
-#define WRITE_DWORD(x, w) (x = (x & ~0xffffffff) | (w & 0xffffffff))
-#define WRITE_WORD(x, w) (x = (x & ~0xffff) | (w & 0xffff))
-#define WRITE_BYTE_H(x, b) (x = (x & ~0xff00) | ((b & 0xff) << 8))
-#define WRITE_BYTE_L(x, b) (x = (x & ~0xff) | (b & 0xff))
 
 int arm64_reg_write(struct uc_struct *uc, unsigned int regid, const void *value)
 {

--- a/qemu/target-arm/unicorn_aarch64.c
+++ b/qemu/target-arm/unicorn_aarch64.c
@@ -62,7 +62,7 @@ int arm64_reg_read(struct uc_struct *uc, unsigned int regid, void *value)
 
 #define WRITE_DWORD(x, w) (x = (x & ~0xffffffff) | (w & 0xffffffff))
 #define WRITE_WORD(x, w) (x = (x & ~0xffff) | (w & 0xffff))
-#define WRITE_BYTE_H(x, b) (x = (x & ~0xff00) | (b & 0xff))
+#define WRITE_BYTE_H(x, b) (x = (x & ~0xff00) | ((b & 0xff) << 8))
 #define WRITE_BYTE_L(x, b) (x = (x & ~0xff) | (b & 0xff))
 
 int arm64_reg_write(struct uc_struct *uc, unsigned int regid, const void *value)

--- a/qemu/target-arm/unicorn_arm.c
+++ b/qemu/target-arm/unicorn_arm.c
@@ -69,7 +69,7 @@ int arm_reg_read(struct uc_struct *uc, unsigned int regid, void *value)
 
 #define WRITE_DWORD(x, w) (x = (x & ~0xffffffff) | (w & 0xffffffff))
 #define WRITE_WORD(x, w) (x = (x & ~0xffff) | (w & 0xffff))
-#define WRITE_BYTE_H(x, b) (x = (x & ~0xff00) | (b & 0xff))
+#define WRITE_BYTE_H(x, b) (x = (x & ~0xff00) | ((b & 0xff) << 8))
 #define WRITE_BYTE_L(x, b) (x = (x & ~0xff) | (b & 0xff))
 
 int arm_reg_write(struct uc_struct *uc, unsigned int regid, const void *value)

--- a/qemu/target-arm/unicorn_arm.c
+++ b/qemu/target-arm/unicorn_arm.c
@@ -3,20 +3,11 @@
 
 #include "hw/boards.h"
 #include "hw/arm/arm.h"
-
 #include "sysemu/cpus.h"
-
 #include "unicorn.h"
-
 #include "cpu.h"
 #include "unicorn_common.h"
-
-
-#define READ_QWORD(x) ((uint64)x)
-#define READ_DWORD(x) (x & 0xffffffff)
-#define READ_WORD(x) (x & 0xffff)
-#define READ_BYTE_H(x) ((x & 0xffff) >> 8)
-#define READ_BYTE_L(x) (x & 0xff)
+#include "uc_priv.h"
 
 
 static void arm_set_pc(struct uc_struct *uc, uint64_t address)
@@ -66,11 +57,6 @@ int arm_reg_read(struct uc_struct *uc, unsigned int regid, void *value)
 
     return 0;
 }
-
-#define WRITE_DWORD(x, w) (x = (x & ~0xffffffff) | (w & 0xffffffff))
-#define WRITE_WORD(x, w) (x = (x & ~0xffff) | (w & 0xffff))
-#define WRITE_BYTE_H(x, b) (x = (x & ~0xff00) | ((b & 0xff) << 8))
-#define WRITE_BYTE_L(x, b) (x = (x & ~0xff) | (b & 0xff))
 
 int arm_reg_write(struct uc_struct *uc, unsigned int regid, const void *value)
 {

--- a/qemu/target-i386/unicorn.c
+++ b/qemu/target-i386/unicorn.c
@@ -578,7 +578,7 @@ int x86_reg_read(struct uc_struct *uc, unsigned int regid, void *value)
 
 #define WRITE_DWORD(x, w) (x = (x & ~0xffffffff) | (w & 0xffffffff))
 #define WRITE_WORD(x, w) (x = (x & ~0xffff) | (w & 0xffff))
-#define WRITE_BYTE_H(x, b) (x = (x & ~0xff00) | (b & 0xff))
+#define WRITE_BYTE_H(x, b) (x = (x & ~0xff00) | ((b & 0xff) << 8))
 #define WRITE_BYTE_L(x, b) (x = (x & ~0xff) | (b & 0xff))
 
 int x86_reg_write(struct uc_struct *uc, unsigned int regid, const void *value)

--- a/qemu/target-i386/unicorn.c
+++ b/qemu/target-i386/unicorn.c
@@ -2,20 +2,14 @@
 /* By Nguyen Anh Quynh <aquynh@gmail.com>, 2015 */
 
 #include "hw/boards.h"
-#include "sysemu/cpus.h"
 #include "hw/i386/pc.h"
+#include "sysemu/cpus.h"
 #include "unicorn.h"
 #include "cpu.h"
 #include "tcg.h"
-
 #include "unicorn_common.h"
 #include <unicorn/x86.h>  /* needed for uc_x86_mmr */
-
-#define READ_QWORD(x) ((uint64)x)
-#define READ_DWORD(x) (x & 0xffffffff)
-#define READ_WORD(x) (x & 0xffff)
-#define READ_BYTE_H(x) ((x & 0xffff) >> 8)
-#define READ_BYTE_L(x) (x & 0xff)
+#include "uc_priv.h"
 
 
 static void x86_set_pc(struct uc_struct *uc, uint64_t address)
@@ -574,12 +568,6 @@ int x86_reg_read(struct uc_struct *uc, unsigned int regid, void *value)
 
     return 0;
 }
-
-
-#define WRITE_DWORD(x, w) (x = (x & ~0xffffffff) | (w & 0xffffffff))
-#define WRITE_WORD(x, w) (x = (x & ~0xffff) | (w & 0xffff))
-#define WRITE_BYTE_H(x, b) (x = (x & ~0xff00) | ((b & 0xff) << 8))
-#define WRITE_BYTE_L(x, b) (x = (x & ~0xff) | (b & 0xff))
 
 int x86_reg_write(struct uc_struct *uc, unsigned int regid, const void *value)
 {

--- a/qemu/target-m68k/unicorn.c
+++ b/qemu/target-m68k/unicorn.c
@@ -54,7 +54,7 @@ int m68k_reg_read(struct uc_struct *uc, unsigned int regid, void *value)
 
 #define WRITE_DWORD(x, w) (x = (x & ~0xffffffff) | (w & 0xffffffff))
 #define WRITE_WORD(x, w) (x = (x & ~0xffff) | (w & 0xffff))
-#define WRITE_BYTE_H(x, b) (x = (x & ~0xff00) | (b & 0xff))
+#define WRITE_BYTE_H(x, b) (x = (x & ~0xff00) | ((b & 0xff) << 8))
 #define WRITE_BYTE_L(x, b) (x = (x & ~0xff) | (b & 0xff))
 
 int m68k_reg_write(struct uc_struct *uc, unsigned int regid, const void *value)

--- a/qemu/target-m68k/unicorn.c
+++ b/qemu/target-m68k/unicorn.c
@@ -6,14 +6,8 @@
 #include "sysemu/cpus.h"
 #include "unicorn.h"
 #include "cpu.h"
-
 #include "unicorn_common.h"
-
-#define READ_QWORD(x) ((uint64)x)
-#define READ_DWORD(x) (x & 0xffffffff)
-#define READ_WORD(x) (x & 0xffff)
-#define READ_BYTE_H(x) ((x & 0xffff) >> 8)
-#define READ_BYTE_L(x) (x & 0xff)
+#include "uc_priv.h"
 
 
 static void m68k_set_pc(struct uc_struct *uc, uint64_t address)
@@ -50,12 +44,6 @@ int m68k_reg_read(struct uc_struct *uc, unsigned int regid, void *value)
 
     return 0;
 }
-
-
-#define WRITE_DWORD(x, w) (x = (x & ~0xffffffff) | (w & 0xffffffff))
-#define WRITE_WORD(x, w) (x = (x & ~0xffff) | (w & 0xffff))
-#define WRITE_BYTE_H(x, b) (x = (x & ~0xff00) | ((b & 0xff) << 8))
-#define WRITE_BYTE_L(x, b) (x = (x & ~0xff) | (b & 0xff))
 
 int m68k_reg_write(struct uc_struct *uc, unsigned int regid, const void *value)
 {

--- a/qemu/target-mips/unicorn.c
+++ b/qemu/target-mips/unicorn.c
@@ -67,7 +67,7 @@ int mips_reg_read(struct uc_struct *uc, unsigned int regid, void *value)
 
 #define WRITE_DWORD(x, w) (x = (x & ~0xffffffff) | (w & 0xffffffff))
 #define WRITE_WORD(x, w) (x = (x & ~0xffff) | (w & 0xffff))
-#define WRITE_BYTE_H(x, b) (x = (x & ~0xff00) | (b & 0xff))
+#define WRITE_BYTE_H(x, b) (x = (x & ~0xff00) | ((b & 0xff) << 8))
 #define WRITE_BYTE_L(x, b) (x = (x & ~0xff) | (b & 0xff))
 
 int mips_reg_write(struct uc_struct *uc, unsigned int regid, const void *value)

--- a/qemu/target-mips/unicorn.c
+++ b/qemu/target-mips/unicorn.c
@@ -6,15 +6,8 @@
 #include "sysemu/cpus.h"
 #include "unicorn.h"
 #include "cpu.h"
-
 #include "unicorn_common.h"
-
-
-#define READ_QWORD(x) ((uint64)x)
-#define READ_DWORD(x) (x & 0xffffffff)
-#define READ_WORD(x) (x & 0xffff)
-#define READ_BYTE_H(x) ((x & 0xffff) >> 8)
-#define READ_BYTE_L(x) (x & 0xff)
+#include "uc_priv.h"
 
 
 static uint64_t mips_mem_redirect(uint64_t address)
@@ -63,12 +56,6 @@ int mips_reg_read(struct uc_struct *uc, unsigned int regid, void *value)
 
     return 0;
 }
-
-
-#define WRITE_DWORD(x, w) (x = (x & ~0xffffffff) | (w & 0xffffffff))
-#define WRITE_WORD(x, w) (x = (x & ~0xffff) | (w & 0xffff))
-#define WRITE_BYTE_H(x, b) (x = (x & ~0xff00) | ((b & 0xff) << 8))
-#define WRITE_BYTE_L(x, b) (x = (x & ~0xff) | (b & 0xff))
 
 int mips_reg_write(struct uc_struct *uc, unsigned int regid, const void *value)
 {

--- a/qemu/target-sparc/unicorn.c
+++ b/qemu/target-sparc/unicorn.c
@@ -7,13 +7,7 @@
 #include "unicorn.h"
 #include "cpu.h"
 #include "unicorn_common.h"
-
-
-#define READ_QWORD(x) ((uint64)x)
-#define READ_DWORD(x) (x & 0xffffffff)
-#define READ_WORD(x) (x & 0xffff)
-#define READ_BYTE_H(x) ((x & 0xffff) >> 8)
-#define READ_BYTE_L(x) (x & 0xff)
+#include "uc_priv.h"
 
 
 static bool sparc_stop_interrupt(int intno)

--- a/qemu/target-sparc/unicorn64.c
+++ b/qemu/target-sparc/unicorn64.c
@@ -7,13 +7,7 @@
 #include "unicorn.h"
 #include "cpu.h"
 #include "unicorn_common.h"
-
-
-#define READ_QWORD(x) ((uint64)x)
-#define READ_DWORD(x) (x & 0xffffffff)
-#define READ_WORD(x) (x & 0xffff)
-#define READ_BYTE_H(x) ((x & 0xffff) >> 8)
-#define READ_BYTE_L(x) (x & 0xff)
+#include "uc_priv.h"
 
 
 static bool sparc_stop_interrupt(int intno)


### PR DESCRIPTION
`WRITE_BYTE_H()` macros in `qemu/target-*/unicorn*.c` are wrong, so `uc_reg_write()` doesn't work correctly for `UC_X86_REG_xH`.

```
$ ipython
In [1]: from unicorn import *
In [2]: from unicorn.x86_const import *

In [3]: mu = Uc(UC_ARCH_X86, UC_MODE_32)

In [4]: mu.reg_write(UC_X86_REG_EAX, 0x00000000)
In [5]: mu.reg_write(UC_X86_REG_AH, 0x12)
In [6]: '%08X' % mu.reg_read(UC_X86_REG_EAX)
Out[6]: '00000012' # expect '00001200'

In [7]: mu.reg_write(UC_X86_REG_EAX, 0xFFFFFFFF)
In [8]: mu.reg_write(UC_X86_REG_AH, 0x12)
In [9]: '%08X' % mu.reg_read(UC_X86_REG_EAX)
Out[9]: 'FFFF00FF' # expect 'FFFF12FF'
```