### PR TITLE
Fix FS and GS segments size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ test_multihook
 test_pc_change
 mem_fuzz
 test_x86_soft_paging
+fs_gs_size
 
 
 #################

--- a/qemu/target-i386/unicorn.c
+++ b/qemu/target-i386/unicorn.c
@@ -156,10 +156,10 @@ int x86_reg_read(struct uc_struct *uc, unsigned int regid, void *value)
                     *(int16_t *)value = X86_CPU(uc, mycpu)->env.segs[R_DS].selector;
                     return 0;
                 case UC_X86_REG_FS:
-                    *(int16_t *)value = X86_CPU(uc, mycpu)->env.segs[R_FS].selector;
+                    *(int16_t *)value = X86_CPU(uc, mycpu)->env.segs[R_FS].base;
                     return 0;
                 case UC_X86_REG_GS:
-                    *(int16_t *)value = X86_CPU(uc, mycpu)->env.segs[R_GS].selector;
+                    *(int16_t *)value = X86_CPU(uc, mycpu)->env.segs[R_GS].base;
                     return 0;
             }
             // fall-thru
@@ -267,10 +267,10 @@ int x86_reg_read(struct uc_struct *uc, unsigned int regid, void *value)
                     *(int16_t *)value = (uint16_t)X86_CPU(uc, mycpu)->env.segs[R_ES].selector;
                     break;
                 case UC_X86_REG_FS:
-                    *(int32_t *)value = (uint32_t)X86_CPU(uc, mycpu)->env.segs[R_FS].selector;
+                    *(int32_t *)value = (uint32_t)X86_CPU(uc, mycpu)->env.segs[R_FS].base;
                     break;
                 case UC_X86_REG_GS:
-                    *(int32_t *)value = (uint32_t)X86_CPU(uc, mycpu)->env.segs[R_GS].selector;
+                    *(int32_t *)value = (uint32_t)X86_CPU(uc, mycpu)->env.segs[R_GS].base;
                     break;
                 case UC_X86_REG_IDTR:
                     ((uc_x86_mmr *)value)->limit = (uint16_t)X86_CPU(uc, mycpu)->env.idt.limit;
@@ -439,10 +439,10 @@ int x86_reg_read(struct uc_struct *uc, unsigned int regid, void *value)
                     *(int16_t *)value = (uint16_t)X86_CPU(uc, mycpu)->env.segs[R_ES].selector;
                     break;
                 case UC_X86_REG_FS:
-                    *(int64_t *)value = (uint64_t)X86_CPU(uc, mycpu)->env.segs[R_FS].selector;
+                    *(int64_t *)value = READ_QWORD(X86_CPU(uc, mycpu)->env.segs[R_FS].base);
                     break;
                 case UC_X86_REG_GS:
-                    *(int64_t *)value = (uint64_t)X86_CPU(uc, mycpu)->env.segs[R_GS].selector;
+                    *(int64_t *)value = READ_QWORD(X86_CPU(uc, mycpu)->env.segs[R_GS].base);
                     break;
                 case UC_X86_REG_R8:
                     *(int64_t *)value = READ_QWORD(X86_CPU(uc, mycpu)->env.regs[8]);
@@ -590,10 +590,10 @@ int x86_reg_write(struct uc_struct *uc, unsigned int regid, const void *value)
                     X86_CPU(uc, mycpu)->env.segs[R_DS].selector = *(uint16_t *)value;
                     return 0;
                 case UC_X86_REG_FS:
-                    X86_CPU(uc, mycpu)->env.segs[R_FS].selector = *(uint16_t *)value;
+                    X86_CPU(uc, mycpu)->env.segs[R_FS].base = *(uint16_t *)value;
                     return 0;
                 case UC_X86_REG_GS:
-                    X86_CPU(uc, mycpu)->env.segs[R_GS].selector = *(uint16_t *)value;
+                    X86_CPU(uc, mycpu)->env.segs[R_GS].base = *(uint16_t *)value;
                     return 0;
             }
             // fall-thru
@@ -708,10 +708,10 @@ int x86_reg_write(struct uc_struct *uc, unsigned int regid, const void *value)
                     X86_CPU(uc, mycpu)->env.segs[R_ES].selector = *(uint16_t *)value;
                     break;
                 case UC_X86_REG_FS:
-                    X86_CPU(uc, mycpu)->env.segs[R_FS].selector = *(uint32_t *)value;
+                    X86_CPU(uc, mycpu)->env.segs[R_FS].base = *(uint32_t *)value;
                     break;
                 case UC_X86_REG_GS:
-                    X86_CPU(uc, mycpu)->env.segs[R_GS].selector = *(uint32_t *)value;
+                    X86_CPU(uc, mycpu)->env.segs[R_GS].base = *(uint32_t *)value;
                     break;
                 case UC_X86_REG_IDTR:
                     X86_CPU(uc, mycpu)->env.idt.limit = (uint16_t)((uc_x86_mmr *)value)->limit;
@@ -890,10 +890,10 @@ int x86_reg_write(struct uc_struct *uc, unsigned int regid, const void *value)
                     X86_CPU(uc, mycpu)->env.segs[R_ES].selector = *(uint16_t *)value;
                     break;
                 case UC_X86_REG_FS:
-                    X86_CPU(uc, mycpu)->env.segs[R_FS].selector = *(uint64_t *)value;
+                    X86_CPU(uc, mycpu)->env.segs[R_FS].base = *(uint64_t *)value;
                     break;
                 case UC_X86_REG_GS:
-                    X86_CPU(uc, mycpu)->env.segs[R_GS].selector = *(uint64_t *)value;
+                    X86_CPU(uc, mycpu)->env.segs[R_GS].base = *(uint64_t *)value;
                     break;
                 case UC_X86_REG_R8:
                     X86_CPU(uc, mycpu)->env.regs[8] = *(uint64_t *)value;

--- a/qemu/target-i386/unicorn.c
+++ b/qemu/target-i386/unicorn.c
@@ -267,10 +267,10 @@ int x86_reg_read(struct uc_struct *uc, unsigned int regid, void *value)
                     *(int16_t *)value = (uint16_t)X86_CPU(uc, mycpu)->env.segs[R_ES].selector;
                     break;
                 case UC_X86_REG_FS:
-                    *(int16_t *)value = (uint16_t)X86_CPU(uc, mycpu)->env.segs[R_FS].selector;
+                    *(int32_t *)value = (uint32_t)X86_CPU(uc, mycpu)->env.segs[R_FS].selector;
                     break;
                 case UC_X86_REG_GS:
-                    *(int16_t *)value = (uint16_t)X86_CPU(uc, mycpu)->env.segs[R_GS].selector;
+                    *(int32_t *)value = (uint32_t)X86_CPU(uc, mycpu)->env.segs[R_GS].selector;
                     break;
                 case UC_X86_REG_IDTR:
                     ((uc_x86_mmr *)value)->limit = (uint16_t)X86_CPU(uc, mycpu)->env.idt.limit;
@@ -439,10 +439,10 @@ int x86_reg_read(struct uc_struct *uc, unsigned int regid, void *value)
                     *(int16_t *)value = (uint16_t)X86_CPU(uc, mycpu)->env.segs[R_ES].selector;
                     break;
                 case UC_X86_REG_FS:
-                    *(int16_t *)value = (uint16_t)X86_CPU(uc, mycpu)->env.segs[R_FS].selector;
+                    *(int64_t *)value = (uint64_t)X86_CPU(uc, mycpu)->env.segs[R_FS].selector;
                     break;
                 case UC_X86_REG_GS:
-                    *(int16_t *)value = (uint16_t)X86_CPU(uc, mycpu)->env.segs[R_GS].selector;
+                    *(int64_t *)value = (uint64_t)X86_CPU(uc, mycpu)->env.segs[R_GS].selector;
                     break;
                 case UC_X86_REG_R8:
                     *(int64_t *)value = READ_QWORD(X86_CPU(uc, mycpu)->env.regs[8]);
@@ -708,10 +708,10 @@ int x86_reg_write(struct uc_struct *uc, unsigned int regid, const void *value)
                     X86_CPU(uc, mycpu)->env.segs[R_ES].selector = *(uint16_t *)value;
                     break;
                 case UC_X86_REG_FS:
-                    X86_CPU(uc, mycpu)->env.segs[R_FS].selector = *(uint16_t *)value;
+                    X86_CPU(uc, mycpu)->env.segs[R_FS].selector = *(uint32_t *)value;
                     break;
                 case UC_X86_REG_GS:
-                    X86_CPU(uc, mycpu)->env.segs[R_GS].selector = *(uint16_t *)value;
+                    X86_CPU(uc, mycpu)->env.segs[R_GS].selector = *(uint32_t *)value;
                     break;
                 case UC_X86_REG_IDTR:
                     X86_CPU(uc, mycpu)->env.idt.limit = (uint16_t)((uc_x86_mmr *)value)->limit;
@@ -890,10 +890,10 @@ int x86_reg_write(struct uc_struct *uc, unsigned int regid, const void *value)
                     X86_CPU(uc, mycpu)->env.segs[R_ES].selector = *(uint16_t *)value;
                     break;
                 case UC_X86_REG_FS:
-                    X86_CPU(uc, mycpu)->env.segs[R_FS].selector = *(uint16_t *)value;
+                    X86_CPU(uc, mycpu)->env.segs[R_FS].selector = *(uint64_t *)value;
                     break;
                 case UC_X86_REG_GS:
-                    X86_CPU(uc, mycpu)->env.segs[R_GS].selector = *(uint16_t *)value;
+                    X86_CPU(uc, mycpu)->env.segs[R_GS].selector = *(uint64_t *)value;
                     break;
                 case UC_X86_REG_R8:
                     X86_CPU(uc, mycpu)->env.regs[8] = *(uint64_t *)value;

--- a/tests/regress/Makefile
+++ b/tests/regress/Makefile
@@ -38,6 +38,7 @@ TESTS += hook_extrainvoke
 TESTS += sysenter_hook_x86
 TESTS += emu_clear_errors
 TESTS += mem_fuzz
+TESTS += fs_gs_size
 
 all: $(TESTS)
 

--- a/tests/regress/fs_gs_size.c
+++ b/tests/regress/fs_gs_size.c
@@ -1,0 +1,140 @@
+#include <unicorn/unicorn.h>
+
+#define GS16_VALUE 0x1122
+#define FS16_VALUE 0x3344
+#define GS32_VALUE 0x11223344
+#define FS32_VALUE 0x55667788
+#define GS64_VALUE 0x9900112233445566
+#define FS64_VALUE 0x7788990011223344
+
+int test_reg16_value (uc_engine *uc, int regid, uint16_t value, uint16_t expected) {
+  
+  uc_err err;
+
+  err = x86_reg_write(uc, regid, &value);
+  if (err != UC_ERR_OK) {
+    printf("Failed on x86_reg_write() with error returned: %u\n", err);
+    return -1;
+  }
+
+  err = x86_reg_read(uc, regid, &value);
+  if (err != UC_ERR_OK) {
+    printf("Failed on x86_reg_read() with error returned: %u\n", err);
+    return -1;
+  }
+
+  if (value != expected) {
+    printf("Error : Wrong reg value in UC_MODE_16. (Got %#x, expected %#x)\n", value, expected);
+    return -1;
+  }
+
+  return 0;
+}
+
+int test_reg32_value (uc_engine *uc, int regid, uint32_t value, uint32_t expected) {
+  
+  uc_err err;
+
+  err = x86_reg_write(uc, regid, &value);
+  if (err != UC_ERR_OK) {
+    printf("Failed on x86_reg_write() with error returned: %u\n", err);
+    return -1;
+  }
+
+  err = x86_reg_read(uc, regid, &value);
+  if (err != UC_ERR_OK) {
+    printf("Failed on x86_reg_read() with error returned: %u\n", err);
+    return -1;
+  }
+
+  if (value != expected) {
+    printf("Error : Wrong reg value in UC_MODE_32. (Got %#x, expected %#x)\n", value, expected);
+    return -1;
+  }
+
+  return 0;
+}
+
+int test_reg64_value (uc_engine *uc, int regid, uint64_t value, uint64_t expected) {
+  
+  uc_err err;
+
+  if ((err = x86_reg_write(uc, regid, &value)) != UC_ERR_OK) {
+    printf("Failed on x86_reg_write() with error returned: %u\n", err);
+    return -1;
+  }
+
+  if ((err = x86_reg_read(uc, regid, &value)) != UC_ERR_OK) {
+    printf("Failed on x86_reg_read() with error returned: %u\n", err);
+    return -1;
+  }
+
+  if (value != expected) {
+    printf("Error : Wrong reg value in UC_MODE_64. (Got %#llx, expected %#llx)\n", value, expected);
+    return -1;
+  }
+
+  return 0;
+}
+
+int main(int argc, char **argv, char **envp)
+{
+  uc_engine *uc;
+  uc_err err;
+  uint16_t gs16 = GS16_VALUE;
+  uint16_t fs16 = FS16_VALUE;
+  uint32_t gs32 = GS32_VALUE;
+  uint32_t fs32 = FS32_VALUE;
+  uint64_t gs64 = GS64_VALUE;
+  uint64_t fs64 = FS64_VALUE;
+
+  // ====== Test UC_MODE_16 ======
+  err = uc_open(UC_ARCH_X86, UC_MODE_16, &uc);
+  if (err != UC_ERR_OK) {
+    printf("Failed on uc_open() with error returned: %u\n", err);
+    return -1;
+  }
+  if (test_reg16_value(uc, UC_X86_REG_FS, fs16, FS16_VALUE) < 0) {
+    printf("Failed on test_reg16_value() for FS in UC_MODE_16.\n");
+    return -1;
+  }
+  if (test_reg16_value(uc, UC_X86_REG_GS, gs16, GS16_VALUE) < 0) {
+    printf("Failed on test_reg16_value() for GS in UC_MODE_16.\n");
+    return -1;
+  }
+  uc_close(uc);
+
+  // ====== Test UC_MODE_32 ======
+  err = uc_open(UC_ARCH_X86, UC_MODE_32, &uc);
+  if (err != UC_ERR_OK) {
+    printf("Failed on uc_open() with error returned: %u\n", err);
+    return -1;
+  }
+  if (test_reg32_value(uc, UC_X86_REG_FS, fs32, FS32_VALUE) < 0) {
+    printf("Failed on test_reg32_value() for FS in UC_MODE_32.\n");
+    return -1;
+  }
+  if (test_reg32_value(uc, UC_X86_REG_GS, gs32, GS32_VALUE) < 0) {
+    printf("Failed on test_reg32_value() for GS in UC_MODE_32.\n");
+    return -1;
+  }
+  uc_close(uc);
+
+  // ====== Test UC_MODE_64 ======
+  err = uc_open(UC_ARCH_X86, UC_MODE_64, &uc);
+  if (err != UC_ERR_OK) {
+    printf("Failed on uc_open() with error returned: %u\n", err);
+    return -1;
+  }
+  if (test_reg64_value(uc, UC_X86_REG_FS, fs64, FS64_VALUE) < 0) {
+    printf("Failed on test_reg64_value() for FS in UC_MODE_64.\n");
+    return -1;
+  }
+  if (test_reg64_value(uc, UC_X86_REG_GS, gs64, GS64_VALUE) < 0) {
+    printf("Failed on test_reg64_value() for GS in UC_MODE_64.\n");
+    return -1;
+  }
+  uc_close(uc);
+
+  return 0;
+}


### PR DESCRIPTION
The segments FS and GS sizes have been changed recently and shouldn't have been modified. Those segments are supposed to be able to contain far pointers, thus must be 64 bits sized so it can support UC_MODE_64.

Faulty commits : 
https://github.com/unicorn-engine/unicorn/commit/f3dc2522a090e1f8467f5a67571dc3e1bef49786
https://github.com/unicorn-engine/unicorn/commit/4cb43be5bf5a7dee090a6c0c337e1ae0573a679f
