### PR TITLE
Fix memory leaks (cpu thread)

### DIFF
--- a/qemu/unicorn_common.h
+++ b/qemu/unicorn_common.h
@@ -49,6 +49,7 @@ static void release_common(void *t)
     tcg_pool_reset(s);
     g_hash_table_destroy(s->helpers);
     g_free(uc->tcg_cpu_thread);
+    g_free(uc->tcg_halt_cond);
 
     // Clean memory.
     phys_mem_clean(uc);

--- a/qemu/unicorn_common.h
+++ b/qemu/unicorn_common.h
@@ -48,6 +48,7 @@ static void release_common(void *t)
     }
     tcg_pool_reset(s);
     g_hash_table_destroy(s->helpers);
+    g_free(uc->tcg_cpu_thread);
 
     // Clean memory.
     phys_mem_clean(uc);


### PR DESCRIPTION
This is a fix for one of memory leaks #258.

I added some codes which free `uc->tcg_cpu_thread` and `uc->tcg_halt_cond` to `release_common()`.

These leaks has been resolved.
```
$ valgrind --leak-check=yes ./mem_double_unmap
...
==18718== 8 bytes in 1 blocks are definitely lost in loss record 37 of 141
==18718==    at 0x15B34C70: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18718==    by 0x15D8D668: g_malloc0 (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0)
==18718==    by 0x5555E6: qemu_tcg_init_vcpu_x86_64 (cpus.c:188)
==18718==    by 0x555417: qemu_init_vcpu_x86_64 (cpus.c:122)
==18718==    by 0x5BF6ED: x86_cpu_realizefn (cpu.c:2309)
==18718==    by 0x438E6B: device_set_realized (qdev.c:184)
==18718==    by 0x437C4C: property_set_bool (object.c:1509)
==18718==    by 0x435FC5: object_property_set (object.c:829)
==18718==    by 0x438650: object_property_set_qobject (qom-qobject.c:24)
==18718==    by 0x43634C: object_property_set_bool (object.c:898)
==18718==    by 0x4155C1: pc_new_cpu (pc.c:107)
==18718==    by 0x41567A: pc_cpus_init (pc.c:132)
...
```

```
$ valgrind --leak-check=yes samples/sample_x86.static -32
...
==13358== 64 bytes in 8 blocks are definitely lost in loss record 116 of 254
==13358==    at 0x15B37C70: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==13358==    by 0x162B4668: g_malloc0 (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0)
==13358==    by 0x557354: qemu_tcg_init_vcpu_x86_64 (cpus.c:188)
==13358==    by 0x557185: qemu_init_vcpu_x86_64 (cpus.c:122)
==13358==    by 0x5C145B: x86_cpu_realizefn (cpu.c:2309)
==13358==    by 0x43ABD9: device_set_realized (qdev.c:184)
==13358==    by 0x4399BA: property_set_bool (object.c:1509)
==13358==    by 0x437D33: object_property_set (object.c:829)
==13358==    by 0x43A3BE: object_property_set_qobject (qom-qobject.c:24)
==13358==    by 0x4380BA: object_property_set_bool (object.c:898)
==13358==    by 0x41732F: pc_new_cpu (pc.c:107)
==13358==    by 0x4173E8: pc_cpus_init (pc.c:132)
...
==13358== 384 bytes in 8 blocks are definitely lost in loss record 218 of 254
==13358==    at 0x15B37C70: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==13358==    by 0x162B4668: g_malloc0 (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4002.0)
==13358==    by 0x557369: qemu_tcg_init_vcpu_x86_64 (cpus.c:189)
==13358==    by 0x557185: qemu_init_vcpu_x86_64 (cpus.c:122)
==13358==    by 0x5C145B: x86_cpu_realizefn (cpu.c:2309)
==13358==    by 0x43ABD9: device_set_realized (qdev.c:184)
==13358==    by 0x4399BA: property_set_bool (object.c:1509)
==13358==    by 0x437D33: object_property_set (object.c:829)
==13358==    by 0x43A3BE: object_property_set_qobject (qom-qobject.c:24)
==13358==    by 0x4380BA: object_property_set_bool (object.c:898)
==13358==    by 0x41732F: pc_new_cpu (pc.c:107)
==13358==    by 0x4173E8: pc_cpus_init (pc.c:132)
...
```