### PR TITLE
execute cpus in same thread as uc_emu_start()

### DIFF
--- a/qemu/vl.c
+++ b/qemu/vl.c
@@ -123,7 +123,6 @@ int machine_initialize(struct uc_struct *uc)
     configure_accelerator(current_machine);
 
     qemu_init_cpu_loop(uc);
-    qemu_mutex_lock_iothread(uc);
 
     current_machine->cpu_model = NULL;
 

--- a/uc.c
+++ b/uc.c
@@ -559,14 +559,13 @@ uc_err uc_emu_start(uc_engine* uc, uint64_t begin, uint64_t until, uint64_t time
 
     uc->addr_end = until;
 
+    if (timeout)
+        enable_emu_timer(uc, timeout * 1000);   // microseconds -> nanoseconds
+
     if (uc->vm_start(uc)) {
         return UC_ERR_RESOURCE;
     }
 
-    if (timeout)
-        enable_emu_timer(uc, timeout * 1000);   // microseconds -> nanoseconds
-
-    uc->pause_all_vcpus(uc);
     // emulation is done
     uc->emulation_done = true;
 


### PR DESCRIPTION
There's no change to samples_all.sh output, and all regression tests looked to pass the same.

note: I'm pretty sure this makes some dead code, but I wanted the least intrusive patch possible