### PR TITLE
static -> dynamic code buffer, and shrink 32M->8M

### DIFF
--- a/qemu/translate-all.c
+++ b/qemu/translate-all.c
@@ -63,8 +63,6 @@
 
 #include "uc_priv.h"
 
-#define USE_STATIC_CODE_GEN_BUFFER
-
 //#define DEBUG_TB_INVALIDATE
 //#define DEBUG_FLUSH
 /* make various TB consistency checks */
@@ -501,7 +499,7 @@ static inline PageDesc *page_find(struct uc_struct *uc, tb_page_addr_t index)
 # define MAX_CODE_GEN_BUFFER_SIZE  ((size_t)-1)
 #endif
 
-#define DEFAULT_CODE_GEN_BUFFER_SIZE_1 (32u * 1024 * 1024)
+#define DEFAULT_CODE_GEN_BUFFER_SIZE_1 (8 * 1024 * 1024)
 
 #define DEFAULT_CODE_GEN_BUFFER_SIZE \
   (DEFAULT_CODE_GEN_BUFFER_SIZE_1 < MAX_CODE_GEN_BUFFER_SIZE \
@@ -520,7 +518,7 @@ static inline size_t size_code_gen_buffer(struct uc_struct *uc, size_t tb_size)
         /* ??? If we relax the requirement that CONFIG_USER_ONLY use the
            static buffer, we could size this on RESERVED_VA, on the text
            segment size of the executable, or continue to use the default.  */
-        tb_size = (unsigned long)(uc->ram_size / 4);
+        tb_size = (unsigned long)DEFAULT_CODE_GEN_BUFFER_SIZE;
 #endif
     }
     if (tb_size < MIN_CODE_GEN_BUFFER_SIZE) {


### PR DESCRIPTION
should fix #487

The size shrink is just for the default size. It will grow automatically.

The code gen buffer is stored in `uc->tcg_ctx` already.