### PR TITLE
Added stdint include to x86.h

### DIFF
--- a/include/unicorn/x86.h
+++ b/include/unicorn/x86.h
@@ -8,6 +8,8 @@
 extern "C" {
 #endif
 
+#include <stdint.h>
+
 // Memory-Management Register for instructions IDTR, GDTR, LDTR, TR.
 // Borrow from SegmentCache in qemu/target-i386/cpu.h
 typedef struct uc_x86_mmr {


### PR DESCRIPTION
include/unicorn/x86.h referenced types defined in stdint.h (e.g. uint16_t, etc.), but didn't actually include stdint.h