### PR TITLE
Small improvements to align with hapstone (Haskell bindings for Capstone)

### DIFF
--- a/bindings/haskell/src/Unicorn/CPU/Arm.chs
+++ b/bindings/haskell/src/Unicorn/CPU/Arm.chs
@@ -24,6 +24,6 @@ import Unicorn.Internal.Core (Reg)
     omit (UC_ARM_REG_INVALID,
           UC_ARM_REG_ENDING)
     with prefix="UC_ARM_REG_"
-    deriving (Show, Eq) #}
+    deriving (Show, Eq, Bounded) #}
 
 instance Reg Register

--- a/bindings/haskell/src/Unicorn/CPU/Arm64.chs
+++ b/bindings/haskell/src/Unicorn/CPU/Arm64.chs
@@ -24,6 +24,6 @@ import Unicorn.Internal.Core (Reg)
     omit (UC_ARM64_REG_INVALID,
           UC_ARM64_REG_ENDING)
     with prefix="UC_ARM64_REG_"
-    deriving (Show, Eq) #}
+    deriving (Show, Eq, Bounded) #}
 
 instance Reg Register

--- a/bindings/haskell/src/Unicorn/CPU/M68k.chs
+++ b/bindings/haskell/src/Unicorn/CPU/M68k.chs
@@ -24,6 +24,6 @@ import Unicorn.Internal.Core (Reg)
     omit (UC_M68K_REG_INVALID,
           UC_M68K_REG_ENDING)
     with prefix="UC_M68K_REG_"
-    deriving (Show, Eq) #}
+    deriving (Show, Eq, Bounded) #}
 
 instance Reg Register

--- a/bindings/haskell/src/Unicorn/CPU/Mips.chs
+++ b/bindings/haskell/src/Unicorn/CPU/Mips.chs
@@ -56,6 +56,6 @@ import Unicorn.Internal.Core (Reg)
     omit (UC_MIPS_REG_INVALID,
           UC_MIPS_REG_ENDING)
     with prefix="UC_MIPS_REG_"
-    deriving (Show, Eq) #}
+    deriving (Show, Eq, Bounded) #}
 
 instance Reg Register

--- a/bindings/haskell/src/Unicorn/CPU/Sparc.chs
+++ b/bindings/haskell/src/Unicorn/CPU/Sparc.chs
@@ -24,6 +24,6 @@ import Unicorn.Internal.Core (Reg)
     omit (UC_SPARC_REG_INVALID,
           UC_SPARC_REG_ENDING)
     with prefix="UC_SPARC_REG_"
-    deriving (Show, Eq) #}
+    deriving (Show, Eq, Bounded) #}
 
 instance Reg Register

--- a/bindings/haskell/src/Unicorn/CPU/X86.chs
+++ b/bindings/haskell/src/Unicorn/CPU/X86.chs
@@ -52,7 +52,7 @@ instance Storable Mmr where
     omit (UC_X86_REG_INVALID,
           UC_X86_REG_ENDING)
     with prefix="UC_X86_REG_"
-    deriving (Show, Eq) #}
+    deriving (Show, Eq, Bounded) #}
 
 instance Reg Register
 
@@ -62,4 +62,4 @@ instance Reg Register
     omit (UC_X86_INS_INVALID,
           UC_X86_INS_ENDING)
     with prefix="UC_X86_INS_"
-    deriving (Show, Eq) #}
+    deriving (Show, Eq, Bounded) #}

--- a/bindings/haskell/src/Unicorn/Internal/Core.chs
+++ b/bindings/haskell/src/Unicorn/Internal/Core.chs
@@ -42,7 +42,7 @@ mkEngine ptr =
 {# enum uc_err as Error
     {underscoreToCase}
     with prefix = "UC_"
-    deriving (Show, Eq) #}
+    deriving (Show, Eq, Bounded) #}
 
 -- | The emulator runs in the IO monad and allows for the handling of errors
 -- "under the hood".

--- a/bindings/haskell/src/Unicorn/Internal/Hook.chs
+++ b/bindings/haskell/src/Unicorn/Internal/Hook.chs
@@ -103,7 +103,7 @@ type Hook = {# type uc_hook #}
           UC_HOOK_MEM_WRITE,
           UC_HOOK_MEM_FETCH)
     with prefix="UC_"
-    deriving (Show, Eq) #}
+    deriving (Show, Eq, Bounded) #}
 
 -- | Memory hook types (for valid memory accesses).
 {# enum uc_hook_type as MemoryHookType
@@ -119,7 +119,7 @@ type Hook = {# type uc_hook #}
           UC_HOOK_MEM_WRITE_PROT,
           UC_HOOK_MEM_FETCH_PROT)
     with prefix="UC_"
-    deriving (Show, Eq) #}
+    deriving (Show, Eq, Bounded) #}
 
 -- | Memory event hook types (for invalid memory accesses).
 {# enum uc_hook_type as MemoryEventHookType
@@ -132,7 +132,7 @@ type Hook = {# type uc_hook #}
           UC_HOOK_MEM_WRITE,
           UC_HOOK_MEM_FETCH)
     with prefix="UC_"
-    deriving (Show, Eq) #}
+    deriving (Show, Eq, Bounded) #}
 
 -- | Unify the hook types with a type class
 class Enum a => HookTypeC a
@@ -145,7 +145,7 @@ instance HookTypeC MemoryEventHookType
 {# enum uc_mem_type as MemoryAccess
     {underscoreToCase}
     with prefix="UC_"
-    deriving (Show, Eq) #}
+    deriving (Show, Eq, Bounded) #}
 
 -------------------------------------------------------------------------------
 -- Hook callbacks

--- a/bindings/haskell/src/Unicorn/Internal/Unicorn.chs
+++ b/bindings/haskell/src/Unicorn/Internal/Unicorn.chs
@@ -61,19 +61,19 @@ import Unicorn.Internal.Util
 {# enum uc_arch as Architecture
     {underscoreToCase}
     with prefix = "UC_"
-    deriving (Show, Eq) #}
+    deriving (Show, Eq, Bounded) #}
 
 -- | CPU hardware mode.
 {# enum uc_mode as Mode
     {underscoreToCase}
     with prefix="UC_"
-    deriving (Show, Eq) #}
+    deriving (Show, Eq, Bounded) #}
 
 -- | Memory permissions.
 {# enum uc_prot as MemoryPermission
     {underscoreToCase}
     with prefix="UC_"
-    deriving (Show, Eq) #}
+    deriving (Show, Eq, Bounded) #}
 
 -- | Memory region mapped by 'memMap'. Retrieve the list of memory regions with
 -- 'memRegions'.
@@ -102,7 +102,7 @@ instance Storable MemoryRegion where
 {# enum uc_query_type as QueryType
     {underscoreToCase}
     with prefix="UC_"
-    deriving (Show, Eq) #}
+    deriving (Show, Eq, Bounded) #}
 
 -------------------------------------------------------------------------------
 -- Emulator control

--- a/bindings/haskell/src/Unicorn/Internal/Util.hs
+++ b/bindings/haskell/src/Unicorn/Internal/Util.hs
@@ -6,13 +6,14 @@ License     : GPL-2
 -}
 module Unicorn.Internal.Util where
 
+import Control.Applicative
 import Data.Bits
 import Foreign
 
 -- | Combine a list of Enums by performing a bitwise-OR.
 combineEnums :: (Enum a, Num b, Bits b) => [a] -> b
 combineEnums =
-    foldr (\p -> (.|.) (enumToNum p)) 0
+    foldr ((.|.) <$> enumToNum) 0
 
 -- | Cast a pointer and then peek inside it.
 castPtrAndPeek :: Storable a => Ptr b -> IO a


### PR DESCRIPTION
`Enum`s now derive `Bounded` and I've made use of `Applicative` in the Utils module.