### PR TITLE
Add six crash cases (2 * ARM + 4 * M68K)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,12 @@ threaded_emu_start
 emu_stop_in_hook_overrun
 mips_branch_likely_issue
 emu_clear_errors
+001-bad_condition_code_0xe
+002-qemu__fatal__unimplemented_control_register_write_0xffb___0x0
+003-qemu__fatal__wdebug_not_implemented
+004-segmentation_fault_1
+005-qemu__fatal__illegal_instruction__0000___00000404
+006-qemu__fatal__illegal_instruction__0421___00040026
 
 test_mem_map_ptr
 test_mem_high

--- a/tests/regress/001-bad_condition_code_0xe.c
+++ b/tests/regress/001-bad_condition_code_0xe.c
@@ -1,0 +1,31 @@
+#include <unicorn/unicorn.h>
+
+#define HARDWARE_ARCHITECTURE UC_ARCH_ARM
+#define HARDWARE_MODE 16
+#define MEMORY_STARTING_ADDRESS 8192
+#define MEMORY_SIZE 4096
+#define MEMORY_PERMISSIONS 6
+#define BINARY_CODE "\x56\xe8\x46\x46\x80\xf6\x8c\x56\xff\xbf\xcd\x90\xda\xa0\xed\xe8\x46\x43\x45\xe5\x80\x90\x44\x46\x04"
+
+static void hook_code(uc_engine *uc, uint64_t address, uint32_t size, void *user_data) {
+  printf("hook_code(…) called\n");
+}
+
+int main(int argc, char **argv, char **envp) {
+  uc_engine *uc;
+  if (uc_open(HARDWARE_ARCHITECTURE, HARDWARE_MODE, &uc)) {
+    printf("uc_open(…) failed\n");
+    return 1;
+  }
+  uc_mem_map(uc, MEMORY_STARTING_ADDRESS, MEMORY_SIZE, MEMORY_PERMISSIONS);
+  if (uc_mem_write(uc, MEMORY_STARTING_ADDRESS, BINARY_CODE, sizeof(BINARY_CODE) - 1)) {
+    printf("uc_mem_write(…) failed\n");
+    return 1;
+  }
+  uc_hook trace;
+  uc_hook_add(uc, &trace, UC_HOOK_CODE, hook_code, NULL, (uint64_t)MEMORY_STARTING_ADDRESS, (uint64_t)(MEMORY_STARTING_ADDRESS + 1));
+  printf("uc_emu_start(…)\n");
+  uc_emu_start(uc, MEMORY_STARTING_ADDRESS, MEMORY_STARTING_ADDRESS + sizeof(BINARY_CODE) - 1, 0, 0);
+  printf("done\n");
+  return 0;
+}

--- a/tests/regress/002-qemu__fatal__unimplemented_control_register_write_0xffb___0x0.c
+++ b/tests/regress/002-qemu__fatal__unimplemented_control_register_write_0xffb___0x0.c
@@ -1,0 +1,31 @@
+#include <unicorn/unicorn.h>
+
+#define HARDWARE_ARCHITECTURE UC_ARCH_M68K
+#define HARDWARE_MODE 1073741824
+#define MEMORY_STARTING_ADDRESS 8388608
+#define MEMORY_SIZE 2097152
+#define MEMORY_PERMISSIONS 7
+#define BINARY_CODE "\xaf\x80\x4e\x7b\xff\xfb\x80\x4e\x3e\x80"
+
+static void hook_code(uc_engine *uc, uint64_t address, uint32_t size, void *user_data) {
+  printf("hook_code(…) called\n");
+}
+
+int main(int argc, char **argv, char **envp) {
+  uc_engine *uc;
+  if (uc_open(HARDWARE_ARCHITECTURE, HARDWARE_MODE, &uc)) {
+    printf("uc_open(…) failed\n");
+    return 1;
+  }
+  uc_mem_map(uc, MEMORY_STARTING_ADDRESS, MEMORY_SIZE, MEMORY_PERMISSIONS);
+  if (uc_mem_write(uc, MEMORY_STARTING_ADDRESS, BINARY_CODE, sizeof(BINARY_CODE) - 1)) {
+    printf("uc_mem_write(…) failed\n");
+    return 1;
+  }
+  uc_hook trace;
+  uc_hook_add(uc, &trace, UC_HOOK_CODE, hook_code, NULL, (uint64_t)MEMORY_STARTING_ADDRESS, (uint64_t)(MEMORY_STARTING_ADDRESS + 1));
+  printf("uc_emu_start(…)\n");
+  uc_emu_start(uc, MEMORY_STARTING_ADDRESS, MEMORY_STARTING_ADDRESS + sizeof(BINARY_CODE) - 1, 0, 0);
+  printf("done\n");
+  return 0;
+}

--- a/tests/regress/003-qemu__fatal__wdebug_not_implemented.c
+++ b/tests/regress/003-qemu__fatal__wdebug_not_implemented.c
@@ -1,0 +1,31 @@
+#include <unicorn/unicorn.h>
+
+#define HARDWARE_ARCHITECTURE UC_ARCH_M68K
+#define HARDWARE_MODE 1073741824
+#define MEMORY_STARTING_ADDRESS 1048576
+#define MEMORY_SIZE 403456
+#define MEMORY_PERMISSIONS 7
+#define BINARY_CODE "\x42\xc7\xfb\xfb\x54\x36"
+
+static void hook_code(uc_engine *uc, uint64_t address, uint32_t size, void *user_data) {
+  printf("hook_code(…) called\n");
+}
+
+int main(int argc, char **argv, char **envp) {
+  uc_engine *uc;
+  if (uc_open(HARDWARE_ARCHITECTURE, HARDWARE_MODE, &uc)) {
+    printf("uc_open(…) failed\n");
+    return 1;
+  }
+  uc_mem_map(uc, MEMORY_STARTING_ADDRESS, MEMORY_SIZE, MEMORY_PERMISSIONS);
+  if (uc_mem_write(uc, MEMORY_STARTING_ADDRESS, BINARY_CODE, sizeof(BINARY_CODE) - 1)) {
+    printf("uc_mem_write(…) failed\n");
+    return 1;
+  }
+  uc_hook trace;
+  uc_hook_add(uc, &trace, UC_HOOK_CODE, hook_code, NULL, (uint64_t)MEMORY_STARTING_ADDRESS, (uint64_t)(MEMORY_STARTING_ADDRESS + 1));
+  printf("uc_emu_start(…)\n");
+  uc_emu_start(uc, MEMORY_STARTING_ADDRESS, MEMORY_STARTING_ADDRESS + sizeof(BINARY_CODE) - 1, 0, 0);
+  printf("done\n");
+  return 0;
+}

--- a/tests/regress/004-segmentation_fault_1.c
+++ b/tests/regress/004-segmentation_fault_1.c
@@ -1,0 +1,31 @@
+#include <unicorn/unicorn.h>
+
+#define HARDWARE_ARCHITECTURE UC_ARCH_ARM
+#define HARDWARE_MODE 16
+#define MEMORY_STARTING_ADDRESS 1024
+#define MEMORY_SIZE 1796096
+#define MEMORY_PERMISSIONS 7
+#define BINARY_CODE "\x20\xbf\xbf\xbf\xbf\xdd\x5d\x74\x5e\x66\x72\x10"
+
+static void hook_code(uc_engine *uc, uint64_t address, uint32_t size, void *user_data) {
+  printf("hook_code(…) called\n");
+}
+
+int main(int argc, char **argv, char **envp) {
+  uc_engine *uc;
+  if (uc_open(HARDWARE_ARCHITECTURE, HARDWARE_MODE, &uc)) {
+    printf("uc_open(…) failed\n");
+    return 1;
+  }
+  uc_mem_map(uc, MEMORY_STARTING_ADDRESS, MEMORY_SIZE, MEMORY_PERMISSIONS);
+  if (uc_mem_write(uc, MEMORY_STARTING_ADDRESS, BINARY_CODE, sizeof(BINARY_CODE) - 1)) {
+    printf("uc_mem_write(…) failed\n");
+    return 1;
+  }
+  uc_hook trace;
+  uc_hook_add(uc, &trace, UC_HOOK_CODE, hook_code, NULL, (uint64_t)MEMORY_STARTING_ADDRESS, (uint64_t)(MEMORY_STARTING_ADDRESS + 1));
+  printf("uc_emu_start(…)\n");
+  uc_emu_start(uc, MEMORY_STARTING_ADDRESS, MEMORY_STARTING_ADDRESS + sizeof(BINARY_CODE) - 1, 0, 0);
+  printf("done\n");
+  return 0;
+}

--- a/tests/regress/005-qemu__fatal__illegal_instruction__0000___00000404.c
+++ b/tests/regress/005-qemu__fatal__illegal_instruction__0000___00000404.c
@@ -1,0 +1,31 @@
+#include <unicorn/unicorn.h>
+
+#define HARDWARE_ARCHITECTURE UC_ARCH_M68K
+#define HARDWARE_MODE 1073741824
+#define MEMORY_STARTING_ADDRESS 1024
+#define MEMORY_SIZE 1044480
+#define MEMORY_PERMISSIONS 5
+#define BINARY_CODE "\x4c\x4c"
+
+static void hook_code(uc_engine *uc, uint64_t address, uint32_t size, void *user_data) {
+  printf("hook_code(…) called\n");
+}
+
+int main(int argc, char **argv, char **envp) {
+  uc_engine *uc;
+  if (uc_open(HARDWARE_ARCHITECTURE, HARDWARE_MODE, &uc)) {
+    printf("uc_open(…) failed\n");
+    return 1;
+  }
+  uc_mem_map(uc, MEMORY_STARTING_ADDRESS, MEMORY_SIZE, MEMORY_PERMISSIONS);
+  if (uc_mem_write(uc, MEMORY_STARTING_ADDRESS, BINARY_CODE, sizeof(BINARY_CODE) - 1)) {
+    printf("uc_mem_write(…) failed\n");
+    return 1;
+  }
+  uc_hook trace;
+  uc_hook_add(uc, &trace, UC_HOOK_CODE, hook_code, NULL, (uint64_t)MEMORY_STARTING_ADDRESS, (uint64_t)(MEMORY_STARTING_ADDRESS + 1));
+  printf("uc_emu_start(…)\n");
+  uc_emu_start(uc, MEMORY_STARTING_ADDRESS, MEMORY_STARTING_ADDRESS + sizeof(BINARY_CODE) - 1, 0, 0);
+  printf("done\n");
+  return 0;
+}

--- a/tests/regress/006-qemu__fatal__illegal_instruction__0421___00040026.c
+++ b/tests/regress/006-qemu__fatal__illegal_instruction__0421___00040026.c
@@ -1,0 +1,31 @@
+#include <unicorn/unicorn.h>
+
+#define HARDWARE_ARCHITECTURE UC_ARCH_M68K
+#define HARDWARE_MODE 1073741824
+#define MEMORY_STARTING_ADDRESS 262144
+#define MEMORY_SIZE 403456
+#define MEMORY_PERMISSIONS 7
+#define BINARY_CODE "\xe2\x86\x09\xbc\xf2\x17\x09\xca\xca\xca\xca\x09\x09\x09\xf2\x17\x09\x20\x09\x09\xf2\x08\x09\x03\x09\xca\x6b\x6b\x6b\x1e\xca\xca\x86\x09\x09\xf2\x17\x09\x04\x21\x09\x09\xf4\xf4\xf4\xf4\xf4\xf4\xf4\xf4\xf4\xf4\xf4\xf4\xf4\xf4\xf4\xf4\xf4\xf4\xf4\xf4\xf2"
+
+static void hook_code(uc_engine *uc, uint64_t address, uint32_t size, void *user_data) {
+  printf("hook_code(…) called\n");
+}
+
+int main(int argc, char **argv, char **envp) {
+  uc_engine *uc;
+  if (uc_open(HARDWARE_ARCHITECTURE, HARDWARE_MODE, &uc)) {
+    printf("uc_open(…) failed\n");
+    return 1;
+  }
+  uc_mem_map(uc, MEMORY_STARTING_ADDRESS, MEMORY_SIZE, MEMORY_PERMISSIONS);
+  if (uc_mem_write(uc, MEMORY_STARTING_ADDRESS, BINARY_CODE, sizeof(BINARY_CODE) - 1)) {
+    printf("uc_mem_write(…) failed\n");
+    return 1;
+  }
+  uc_hook trace;
+  uc_hook_add(uc, &trace, UC_HOOK_CODE, hook_code, NULL, (uint64_t)MEMORY_STARTING_ADDRESS, (uint64_t)(MEMORY_STARTING_ADDRESS + 1));
+  printf("uc_emu_start(…)\n");
+  uc_emu_start(uc, MEMORY_STARTING_ADDRESS, MEMORY_STARTING_ADDRESS + sizeof(BINARY_CODE) - 1, 0, 0);
+  printf("done\n");
+  return 0;
+}

--- a/tests/regress/Makefile
+++ b/tests/regress/Makefile
@@ -38,6 +38,12 @@ TESTS += hook_extrainvoke
 TESTS += sysenter_hook_x86
 TESTS += emu_clear_errors
 TESTS += mem_fuzz
+TESTS += 001-bad_condition_code_0xe
+TESTS += 002-qemu__fatal__unimplemented_control_register_write_0xffb___0x0
+TESTS += 003-qemu__fatal__wdebug_not_implemented
+TESTS += 004-segmentation_fault_1
+TESTS += 005-qemu__fatal__illegal_instruction__0000___00000404
+TESTS += 006-qemu__fatal__illegal_instruction__0421___00040026
 
 all: $(TESTS)
 


### PR DESCRIPTION
```
$ ./001-bad_condition_code_0xe # ARM
uc_emu_start(…)
Bad condition code 0xe
Aborted

$ ./002-qemu__fatal__unimplemented_control_register_write_0xffb___0x0 # M68K
uc_emu_start(…)
hook_code(…) called
qemu: fatal: Unimplemented control register write 0xffb = 0x0
Aborted

$ ./003-qemu__fatal__wdebug_not_implemented # M68K
uc_emu_start(…)
qemu: fatal: WDEBUG not implemented
Aborted

$ ./004-segmentation_fault_1 # ARM
uc_emu_start(…)
hook_code(…) called
Segmentation fault

$ ./005-qemu__fatal__illegal_instruction__0000___00000404 # M68K
uc_emu_start(…)
qemu: fatal: Illegal instruction: 0000 @ 00000404
Aborted

$ ./006-qemu__fatal__illegal_instruction__0421___00040026 # M68K
uc_emu_start(…)
hook_code(…) called
qemu: fatal: Illegal instruction: 0421 @ 00040026
Aborted
```