### PR TITLE
Remove double-free

### DIFF
--- a/uc.c
+++ b/uc.c
@@ -299,9 +299,6 @@ uc_err uc_close(uc_engine *uc)
         free(uc->ram_list.dirty_memory[i]);
     }
 
-    // TODO: remove uc->root    (created with object_new())
-    uc->root->free(uc->root);
-
     // free hooks and hook lists
     for (i = 0; i < UC_HOOK_MAX; i++) {
         cur = uc->hook[i].head;


### PR DESCRIPTION
This was previously released at uc_close ../uc.c:286

    if (uc->release)
        uc->release(uc->tcg_ctx);

Which effectively does:

    object_unref(uc, OBJECT(uc->root));

Fixes #528 