### PR TITLE
Add ASAN build target with UNICORN_ASAN or via './make.sh asan'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,13 @@ else
 CFLAGS += -O3
 endif
 
+ifeq ($(UNICORN_ASAN),yes)
+CC = clang -fsanitize=address -fno-omit-frame-pointer
+CXX = clang++ -fsanitize=address -fno-omit-frame-pointer
+AR = llvm-ar
+LDFLAGS := -fsanitize=address ${LDFLAGS}
+endif
+
 ifeq ($(CROSS),)
 CC ?= cc
 AR ?= ar
@@ -122,7 +129,7 @@ EXT = so
 VERSION_EXT = $(EXT).$(API_MAJOR)
 AR_EXT = a
 $(LIBNAME)_LDFLAGS += -Wl,-Bsymbolic-functions,-soname,lib$(LIBNAME).$(VERSION_EXT)
-UNICORN_CFLAGS += -fvisibility=hidden
+# UNICORN_CFLAGS += -fvisibility=hidden
 endif
 endif
 endif
@@ -213,11 +220,11 @@ config:
 qemu/config-host.h-timestamp:
 ifeq ($(UNICORN_DEBUG),yes)
 	cd qemu && \
-	./configure --extra-cflags="$(UNICORN_CFLAGS)" --target-list="$(UNICORN_TARGETS)" ${UNICORN_QEMU_FLAGS}
+	./configure --cc="${CC}" --extra-cflags="$(UNICORN_CFLAGS)" --target-list="$(UNICORN_TARGETS)" ${UNICORN_QEMU_FLAGS}
 	printf "$(UNICORN_ARCHS)" > config.log
 else
 	cd qemu && \
-	./configure --disable-debug-info --extra-cflags="$(UNICORN_CFLAGS)" --target-list="$(UNICORN_TARGETS)" ${UNICORN_QEMU_FLAGS}
+	./configure --cc="${CC}" --disable-debug-info --extra-cflags="$(UNICORN_CFLAGS)" --target-list="$(UNICORN_TARGETS)" ${UNICORN_QEMU_FLAGS}
 	printf "$(UNICORN_ARCHS)" > config.log
 endif
 
@@ -263,7 +270,6 @@ endif
 .PHONY: test
 test: all
 	$(MAKE) -C tests/unit test
-
 
 install: compile_lib $(PKGCFGF)
 	mkdir -p $(DESTDIR)$(LIBDIR)

--- a/make.sh
+++ b/make.sh
@@ -10,6 +10,13 @@ MAKE_JOBS=$((${MAKE_JOBS}+0))
 [ ${MAKE_JOBS} -lt 1 ] && \
   MAKE_JOBS=4
 
+# build for ASAN
+asan() {
+  UNICORN_DEBUG=yes
+  UNICORN_ASAN=yes
+  ${MAKE} V=1
+}
+
 # build iOS lib for all iDevices, or only specific device
 build_iOS() {
   IOS_SDK=`xcrun --sdk iphoneos --show-sdk-path`
@@ -90,6 +97,7 @@ export CC INSTALL_BIN PREFIX PKGCFGDIR LIBDIRARCH LIBARCHS CFLAGS LDFLAGS
 
 case "$1" in
   "" ) build;;
+  "asan" ) asan;;
   "default" ) build;;
   "install" ) install;;
   "uninstall" ) uninstall;;

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -37,6 +37,13 @@ else
 CC = $(CROSS)gcc
 endif
 
+ifeq ($(UNICORN_ASAN),yes)
+CC = clang -fsanitize=address -fno-omit-frame-pointer
+CXX = clang++ -fsanitize=address -fno-omit-frame-pointer
+AR = llvm-ar
+LDFLAGS := -fsanitize=address ${LDFLAGS}
+endif
+
 
 #CFLAGS += $(foreach arch,$(LIBARCHS),-arch $(arch))
 #LDFLAGS += $(foreach arch,$(LIBARCHS),-arch $(arch))

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -4,6 +4,13 @@ CFLAGS += -L ../../
 CFLAGS += -lcmocka -lunicorn
 CFLAGS += -I ../../include
 
+ifeq ($(UNICORN_ASAN),yes)
+CC = clang -fsanitize=address -fno-omit-frame-pointer
+CXX = clang++ -fsanitize=address -fno-omit-frame-pointer
+AR = llvm-ar
+LDFLAGS := -fsanitize=address ${LDFLAGS}
+endif
+
 ALL_TESTS = test_sanity test_x86 test_mem_map test_mem_high test_mem_map_ptr \
 	test_tb_x86 test_multihook test_pc_change test_x86_soft_paging \
         test_hookcounts


### PR DESCRIPTION
Note that using this with Python bindings (or, e.g. in GDB) will require adding `start_deactivated=1` to `ASAN_OPTIONS`.