### PR TITLE
Add new bindings and fixed UC_HOOK_INSN hooking.

### DIFF
--- a/bindings/msvc/unicorn.def
+++ b/bindings/msvc/unicorn.def
@@ -8,6 +8,8 @@ uc_errno
 uc_strerror
 uc_reg_write
 uc_reg_read
+uc_reg_write_batch
+uc_reg_read_batch
 uc_mem_write
 uc_mem_read
 uc_emu_start

--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -10,7 +10,7 @@ extern "C" {
 
 #include <stdint.h>
 #ifdef _MSC_VER
-typedef int bool;
+typedef unsigned char bool;
 #define false 0
 #define true 1
 #else

--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -9,7 +9,13 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#ifdef _MSC_VER
+typedef int bool;
+#define false 0
+#define true 1
+#else
 #include <stdbool.h>
+#endif
 #include <stdarg.h>
 #if defined(UNICORN_HAS_OSXKERNEL)
 #include <libkern/libkern.h>


### PR DESCRIPTION
Added MSVC bindings for uc_reg_write_batch() and uc_reg_read_batch() and fixed UC_HOOK_INSN hooking.
Also fixed the use of stdbool.h in MSVC since it is not included in MSVC.
(This fixes #541)