### PR TITLE
Python 3 compatibility: raise unicode exception messages

### DIFF
--- a/bindings/python/unicorn/unicorn.py
+++ b/bindings/python/unicorn/unicorn.py
@@ -156,7 +156,7 @@ class UcError(Exception):
         self.errno = errno
 
     def __str__(self):
-        return _uc.uc_strerror(self.errno)
+        return _uc.uc_strerror(self.errno).decode('ascii')
 
 
 # return the core's version


### PR DESCRIPTION
In order to make exceptions display well with the Python binding on Python 3.x, return exception message as unicode/str rather than str/bytes.