### PR TITLE
Set thumb mode based on PC value in ARM. Mask off last bit of PC.

### DIFF
--- a/qemu/target-arm/unicorn_arm.c
+++ b/qemu/target-arm/unicorn_arm.c
@@ -106,8 +106,9 @@ int arm_reg_write(struct uc_struct *uc, unsigned int *regs, void* const* vals, i
                     break;
                 //case UC_ARM_REG_PC:
                 case UC_ARM_REG_R15:
-                    ARM_CPU(uc, mycpu)->env.pc = *(uint32_t *)value;
-                    ARM_CPU(uc, mycpu)->env.regs[15] = *(uint32_t *)value;
+                    ARM_CPU(uc, mycpu)->env.pc = (*(uint32_t *)value & ~1);
+                    ARM_CPU(uc, mycpu)->env.thumb = (*(uint32_t *)value & 1);
+                    ARM_CPU(uc, mycpu)->env.regs[15] = (*(uint32_t *)value & ~1);
                     // force to quit execution and flush TB
                     uc->quit_request = true;
                     uc_emu_stop(uc);


### PR DESCRIPTION
I tested this with code compiled using a cross-compiler from the Android NDK and seems to work fine. I don't see why it would fail, but it might be worth running more ARM tests on it before merging.

See issue #391 