### PR TITLE
eflags patch

### DIFF
--- a/qemu/target-i386/cpu.h
+++ b/qemu/target-i386/cpu.h
@@ -1315,7 +1315,7 @@ void update_fp_status(CPUX86State *env);
 
 static inline uint32_t cpu_compute_eflags(CPUX86State *env)
 {
-    return env->eflags0 | cpu_cc_compute_all(env, CC_OP) | (env->df & DF_MASK);
+    return (env->eflags0 & ~(CC_O | CC_S | CC_Z | CC_A | CC_P | CC_C | DF_MASK)) | cpu_cc_compute_all(env, CC_OP) | (env->df & DF_MASK);
 }
 
 /* NOTE: the translator must set DisasContext.cc_op to CC_OP_EFLAGS

--- a/tests/regress/x86_eflags.py
+++ b/tests/regress/x86_eflags.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+import regress
+import unicorn as U
+
+class WrongEFLAGS2(regress.RegressTest):
+    def test_eflags(self):
+        # imul eax, ebx
+        CODE = '\x0f\xaf\xc3'
+
+        uc = U.Uc(U.UC_ARCH_X86, U.UC_MODE_32)
+        uc.reg_write(U.x86_const.UC_X86_REG_EAX, 16)
+        uc.reg_write(U.x86_const.UC_X86_REG_EBX, 1)
+        uc.reg_write(U.x86_const.UC_X86_REG_EFLAGS, 0x292)
+
+        uc.mem_map(0x600000, 0x1000)
+        uc.mem_write(0x6000b0, CODE)
+        uc.emu_start(0x6000b0, 0, count=1)
+
+
+        # Here's the original execution trace for this on actual hardware.
+        #
+        # (gdb) x/i $eip
+        # => 0x804aae5:   imul   eax,DWORD PTR [ebp-0x8]
+        # (gdb) p/x $eax
+        # $2 = 0x10
+        # (gdb) x/wx $ebp-8
+        # 0xbaaaad4c:     0x00000001
+        # (gdb) p/x $eflags
+        # $3 = 0x292
+        # (gdb) si
+        # 0x0804aae9 in ?? ()
+        # (gdb) p/x $eflags
+        # $4 = 0x202
+
+        self.assertEqual(0x202, uc.reg_read(U.x86_const.UC_X86_REG_EFLAGS))
+
+if __name__ == '__main__':
+    regress.main()


### PR DESCRIPTION
This is a patch to the x86 eflags computation. I don't know what it does, exactly, since someone else on the angr team wrote this and I don't understand the diff, but it makes the unicorn eflags match the libVEX eflags in tests we run to ensure accuracy.