### PR TITLE
Add Python-style dict for const values

### DIFF
--- a/bindings/const_generator.py
+++ b/bindings/const_generator.py
@@ -25,9 +25,9 @@ template = {
             'comment_close': '',
         },
     'python-dict': {
-            'header': "# For Unicorn Engine. AUTO-GENERATED FILE, DO NOT EDIT [%s_const_dict.py]\n%s_const = {\n",
+            'header': "# For Unicorn Engine. AUTO-GENERATED FILE, DO NOT EDIT\n%s_const = {\n",
             'footer': "}",
-            'line_format': '\'UC_%s\': %s\n',
+            'line_format': '\'UC_%s\': %s,\n',
             'out_file': './python/unicorn/%s_const_dict.py',
             # prefixes for constant filenames of all archs - case sensitive
             'arm.h': 'arm',

--- a/bindings/const_generator.py
+++ b/bindings/const_generator.py
@@ -24,6 +24,22 @@ template = {
             'comment_open': '#',
             'comment_close': '',
         },
+    'python-dict': {
+            'header': "# For Unicorn Engine. AUTO-GENERATED FILE, DO NOT EDIT [%s_const_dict.py]\n%s_const = {\n",
+            'footer': "}",
+            'line_format': '\'UC_%s\': %s\n',
+            'out_file': './python/unicorn/%s_const_dict.py',
+            # prefixes for constant filenames of all archs - case sensitive
+            'arm.h': 'arm',
+            'arm64.h': 'arm64',
+            'mips.h': 'mips',
+            'x86.h': 'x86',
+            'sparc.h': 'sparc',
+            'm68k.h': 'm68k',
+            'unicorn.h': 'unicorn',
+            'comment_open': '#',
+            'comment_close': '',
+        },
     'ruby': {
             'header': "# For Unicorn Engine. AUTO-GENERATED FILE, DO NOT EDIT [%s_const.rb]\n\nmodule Unicorn\n",
             'footer': "end",


### PR DESCRIPTION
Use python-style dict so that accessing const values can be done with mutable strings.

I'm not wedded to this idea, just hate that I can't easily programmatically go through the constants; python dicts provide that function

Indexing through const values before:

``` python
for x in range(0,10):
    exec("y = UC_ARM_REG_R" + str(x))
    print "R" + str(x) + ": " + '%08x'%mu.reg_read(y)
```

Indexing through python dict:

``` python
for x in range(0,10):
    print "R" + str(x) + ":" + '%08x'%mu.reg_read(arm_const['UC_ARM_REG_D' + str(x))
```
