### PR TITLE
Add Ruby hash for consts

### DIFF
--- a/bindings/const_generator.py
+++ b/bindings/const_generator.py
@@ -40,6 +40,22 @@ template = {
             'comment_open': '#',
             'comment_close': '',
         },
+    'ruby-hash': {
+            'header': "# For Unicorn Engine. AUTO-GENERATED FILE, DO NOT EDIT\n\nmodule Unicorn\n%s_const = {\n",
+            'footer': "}\nend",
+            'line_format': '\t\'UC_%s\' => %s\n',
+            'out_file': './ruby/unicorn_gem/lib/unicorn/%s_const_hash.rb',
+            # prefixes for constant filenames of all archs - case sensitive
+            'arm.h': 'arm',
+            'arm64.h': 'arm64',
+            'mips.h': 'mips',
+            'x86.h': 'x86',
+            'sparc.h': 'sparc',
+            'm68k.h': 'm68k',
+            'unicorn.h': 'unicorn',
+            'comment_open': '#',
+            'comment_close': '',
+        },
     'go': {
             'header': "package unicorn\n// For Unicorn Engine. AUTO-GENERATED FILE, DO NOT EDIT [%s_const.go]\nconst (\n",
             'footer': ")",


### PR DESCRIPTION
Similar idea to #617, this uses a ruby hash to access constants

Indexing through ruby hash:

``` ruby
for x in 0..9:
    puts "R" + String(x) + ":" + '%08x'%mu.reg_read(arm_const['UC_ARM_REG_D' + String(x))
```
