### PR TITLE
Unit Test for Issue #534 [Bug Fixes]

### DIFF
--- a/tests/unit/test_hang.c
+++ b/tests/unit/test_hang.c
@@ -87,8 +87,8 @@ void test_hang(void **state)
 	uc_reg_read(uc, UC_ARM64_REG_X0, &x0);
 	uc_reg_read(uc, UC_ARM64_REG_X1, &x1);
 
-	printf("x0: %#llx\n", x0);
-	printf("x1: %#llx\n", x1);
+	printf("x0: %#lx\n", x0);
+	printf("x1: %#lx\n", x1);
 }
 
 int main(int argc, const char * argv[]) {

--- a/tests/unit/test_x86_rip_bug.c
+++ b/tests/unit/test_x86_rip_bug.c
@@ -162,7 +162,7 @@ static void test_i386(void **state)
     uc_assert_fail(uc_emu_start(uc, CodePage, CodePage + sizeof(i386_bug), 0, 0));
 
     if (!data.good)
-        fail_msg("De-synced RIP value. 0x%016lX != 0x%016lX\n", data.expected, data.actual);
+        fail_msg("De-synced RIP value. 0x%"PRIX64" != 0x%"PRIX64"\n", data.expected, data.actual);
 }
 
 /**
@@ -191,7 +191,7 @@ static void test_amd64(void **state)
     uc_assert_fail(uc_emu_start(uc, CodePage, CodePage + sizeof(amd64_bug), 0, 0));
 
     if (!data.good)
-        fail_msg("De-synced RIP value. 0x%016lX != 0x%016lX\n", data.expected, data.actual);
+        fail_msg("De-synced RIP value. 0x%"PRIX64" != 0x%"PRIX64"\n", data.expected, data.actual);
 }
 
 /**
@@ -221,7 +221,7 @@ static void test_i386_fix(void **state)
     uc_assert_fail(uc_emu_start(uc, CodePage, CodePage + sizeof(i386_bug), 0, 0));
 
     if (!data.good)
-        fail_msg("De-synced RIP value. 0x%016lX != 0x%016lX\n", data.expected, data.actual);
+        fail_msg("De-synced RIP value. 0x%"PRIX64" != 0x%"PRIX64"\n", data.expected, data.actual);
 }
 
 /**
@@ -252,7 +252,7 @@ static void test_amd64_fix(void **state)
     uc_assert_fail(uc_emu_start(uc, CodePage, CodePage + sizeof(amd64_bug), 0, 0));
 
     if (!data.good)
-        fail_msg("De-synced RIP value. 0x%016lX != 0x%016lX\n", data.expected, data.actual);
+        fail_msg("De-synced RIP value. 0x%"PRIX64" != 0x%"PRIX64"\n", data.expected, data.actual);
 }
 
 /**


### PR DESCRIPTION
Cleaned up the unit test for Issue #534, corrected the expected address for x86_64, added workaround to show proper of EIP/RIP.

Also contains a format string fix for tests/unit/test_hang.c