### PR TITLE
Relax transformers constraint for haskell bindings for GHC 8

### DIFF
--- a/bindings/haskell/unicorn.cabal
+++ b/bindings/haskell/unicorn.cabal
@@ -31,7 +31,7 @@ library
   other-modules:       Unicorn.Internal.Util
   build-depends:       base >=4 && <5,
                        bytestring >= 0.9.1,
-                       transformers <= 0.5,
+                       transformers < 0.6,
                        either >= 4.4
   hs-source-dirs:      src
   c-sources:           src/cbits/unicorn_wrapper.c


### PR DESCRIPTION
Haskell bindings do not build on GHC 8 due to too strict transformers constraint. This relaxes the constraint to fix the build.