### PR TITLE
Fix leak and style in map_write.c

### DIFF
--- a/tests/regress/map_write.c
+++ b/tests/regress/map_write.c
@@ -8,20 +8,20 @@
 
 int main()
 {
-    uc_engine *uc;
-    uint8_t *buf, *buf2;
+    uc_engine *uc = NULL;
+    uint8_t *buf = NULL, *buf2 = NULL;
     int i;
     uc_err err;
 
     err = uc_open (UC_ARCH_X86, UC_MODE_64, &uc);
     if (err) {
         printf ("uc_open %d\n", err);
-        return 1;
+        goto exit;
     }
     err = uc_mem_map (uc, ADDR, SIZE, UC_PROT_ALL);
     if (err) {
         printf ("uc_mem_map %d\n", err);
-        return 1;
+        goto exit;
     }
     buf = calloc (SIZE*2, 1);
     buf2 = calloc (SIZE, 1);
@@ -31,20 +31,24 @@ int main()
     /* crash here */
     err = uc_mem_write (uc, ADDR, buf, SIZE+OVERFLOW); 
     if (err) {
-        printf ("uc_mem_map %d\n", err);
-        return 1;
+        printf ("uc_mem_write %d\n", err);
+        goto exit;
     }
     err = uc_mem_read (uc, ADDR+10, buf2, 4);
     if (err) {
-        printf ("uc_mem_map %d\n", err);
-        return 1;
+        printf ("uc_mem_read %d\n", err);
+        goto exit;
     }
     if (buf2[0] != 0xa) {
         printf ("mem contents are wrong\n");
-        return 1;
+        goto exit;
     }
     printf ("OK\n");
+
+exit:
+    if (uc)
+        uc_close (uc);
     free (buf);
     free (buf2);
-    return 0;
+    return err ? 1 : 0;
 }


### PR DESCRIPTION
Fix potential leak, wrong text in log, and restyle
to a cleaner exit path