### PR TITLE
python bindings: unsiged conversion in memory hooks

### DIFF
--- a/bindings/python/unicorn/unicorn.py
+++ b/bindings/python/unicorn/unicorn.py
@@ -342,11 +342,15 @@ class Uc(object):
         cb(self, address, size, data)
 
     def _hook_mem_invalid_cb(self, handle, access, address, size, value, user_data):
+        # transform to unsigned
+        value &= 2 ** (size * 8) - 1
         # call user's callback with self object
         (cb, data) = self._callbacks[user_data]
         return cb(self, access, address, size, value, data)
 
     def _hook_mem_access_cb(self, handle, access, address, size, value, user_data):
+        # transform to unsigned
+        value &= 2 ** (size * 8) - 1
         # call user's callback with self object
         (cb, data) = self._callbacks[user_data]
         cb(self, access, address, size, value, data)


### PR DESCRIPTION
fixes the annotation that is described [here](https://github.com/unicorn-engine/unicorn/issues/654#issuecomment-256640923)
