### PR TITLE
changed '%02hhx' to '%02x' in sample_x86_32_gdt_and_seg_regs.c

### DIFF
--- a/samples/sample_x86_32_gdt_and_seg_regs.c
+++ b/samples/sample_x86_32_gdt_and_seg_regs.c
@@ -269,7 +269,7 @@ static void gdt_demo()
 
     int i;
     for (i = 0; i < 8; i++) {
-        fprintf(stderr, "%02hhx", buf[i]);
+        fprintf(stderr, "%02x", buf[i]);
     }
     fprintf(stderr, "\n");
 


### PR DESCRIPTION
This PR is to fix the following error that occurred while compiling unicorn-engine using MinGW32
![unicorn_error](https://cloud.githubusercontent.com/assets/4945570/19905147/7536f19c-a0b0-11e6-8854-0f5d35f68f9a.png)
