### PR TITLE
add g_free to make future integration easier

### DIFF
--- a/qemu/include/glib_compat.h
+++ b/qemu/include/glib_compat.h
@@ -106,6 +106,7 @@ GHashTable *g_hash_table_ref(GHashTable *hash_table);
 guint g_hash_table_size(GHashTable *hash_table);
 
 /* replacement for g_malloc dependency */
+#define g_free(x) free(x)
 void *g_malloc(size_t size);
 void *g_malloc0(size_t size);
 void *g_try_malloc0(size_t size);


### PR DESCRIPTION
Added define for g_free so that integration w/ future versions of qemu won't require global search and replace of g_free to free