### PR TITLE
fix possible segfault in hook del (#691)

### DIFF
--- a/uc.c
+++ b/uc.c
@@ -1069,19 +1069,19 @@ uc_err uc_hook_add(uc_engine *uc, uc_hook *hh, int type, void *callback,
 UNICORN_EXPORT
 uc_err uc_hook_del(uc_engine *uc, uc_hook hh)
 {
-    int i = 0;
+    int i;
     struct hook *hook = (struct hook *)hh;
-    int type = hook->type;
-
-    while ((type >> i) > 0 && i < UC_HOOK_MAX) {
-        if ((type >> i) & 1) {
-            if (list_remove(&uc->hook[i], (void *)hh)) {
-                if (--hook->refs == 0) {
-                    free(hook);
-                }
+    // we can't dereference hook->type if hook is invalid
+    // so for now we need to iterate over all possible types to remove the hook
+    // which is less efficient
+    // an optimization would be to align the hook pointer
+    // and store the type mask in the hook pointer.
+    for (i = 0; i < UC_HOOK_MAX; i++) {
+        if (list_remove(&uc->hook[i], (void *)hook)) {
+            if (--hook->refs == 0) {
+                free(hook);
             }
         }
-        i++;
     }
     return UC_ERR_OK;
 }


### PR DESCRIPTION
this will be slightly slower (`UC_HOOK_MAX * len(hooks)` instead of `num_types * len(hooks)`) for removing hooks because we can't safely dereference a hook struct to get its types.

this could be fixed by aligning the hook's pointer and storing the hook types as a mask in the pointer value.