### PR TITLE
Windows: export a static lib that can be used outside of mingw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ unicorn.pc
 
 unicorn.lib
 unicorn.dll
+unicorn.exp
+unicorn.def
 unicorn_*.lib
 unicorn_*.exp
 unicorn_*.dll

--- a/Makefile
+++ b/Makefile
@@ -122,10 +122,12 @@ UNICORN_CFLAGS := $(UNICORN_CFLAGS:-fPIC=)
 # mingw?
 else ifneq ($(filter MINGW%,$(UNAME_S)),)
 EXT = dll
-AR_EXT = lib
+AR_EXT = a
 BIN_EXT = .exe
 UNICORN_QEMU_FLAGS += --disable-stack-protector
 UNICORN_CFLAGS := $(UNICORN_CFLAGS:-fPIC=)
+$(LIBNAME)_LDFLAGS += -Wl,--output-def,unicorn.def
+DO_WINDOWS_EXPORT = 1
 
 # Linux, Darwin
 else
@@ -220,6 +222,13 @@ else
 	$(CC) $(CFLAGS) -shared $(UC_TARGET_OBJ) uc.o list.o -o $(LIBRARY) $($(LIBNAME)_LDFLAGS)
 	-ln -sf $(LIBRARY) $(LIBRARY_SYMLINK)
 endif
+ifeq ($(DO_WINDOWS_EXPORT),1)
+ifneq ($(filter MINGW32%,$(UNAME_S)),)
+	cmd /c "windows_export.bat x86"
+else
+	cmd /c "windows_export.bat x64"
+endif
+endif
 endif
 
 $(ARCHIVE): qemu/config-host.h-timestamp
@@ -301,7 +310,7 @@ uninstall:
 clean:
 	$(MAKE) -C qemu clean
 	rm -rf *.d *.o
-	rm -rf lib$(LIBNAME)* $(LIBNAME)*.lib $(LIBNAME)*.dll cyg$(LIBNAME)*.dll
+	rm -rf lib$(LIBNAME)* $(LIBNAME)*.lib $(LIBNAME)*.dll $(LIBNAME)*.exp cyg$(LIBNAME)*.dll
 	$(MAKE) -C samples clean
 	$(MAKE) -C tests/unit clean
 

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -43,7 +43,7 @@ if SYSTEM == 'darwin':
     STATIC_LIBRARY_FILE = 'libunicorn.a'
 elif SYSTEM in ('win32', 'cygwin'):
     LIBRARY_FILE = "unicorn.dll"
-    STATIC_LIBRARY_FILE = None
+    STATIC_LIBRARY_FILE = "unicorn.lib"
 else:
     LIBRARY_FILE = "libunicorn.so"
     STATIC_LIBRARY_FILE = 'libunicorn.a'
@@ -147,7 +147,11 @@ def build_libraries():
     subprocess.call(cmd, env=new_env)
 
     shutil.copy(LIBRARY_FILE, LIBS_DIR)
-    if STATIC_LIBRARY_FILE: shutil.copy(STATIC_LIBRARY_FILE, LIBS_DIR)
+    try:
+        # static library may fail to build on windows if user doesn't have visual studio 12 installed. this is fine.
+        shutil.copy(STATIC_LIBRARY_FILE, LIBS_DIR)
+    except:
+        pass
     os.chdir(cwd)
 
 

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -43,7 +43,7 @@ AR_EXT = a
 else ifneq ($(filter MINGW%,$(UNAME_S)),)
 CFLAGS := $(CFLAGS:-fPIC=)
 BIN_EXT = .exe
-AR_EXT = lib
+AR_EXT = a
 endif
 
 ifeq ($(UNICORN_STATIC),yes)

--- a/windows_export.bat
+++ b/windows_export.bat
@@ -1,0 +1,10 @@
+@echo on
+
+:: If anyone ever tells you that windows is a reasonable operating system, they are wrong
+
+FOR /F "usebackq tokens=3*" %%A IN (`REG QUERY "HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\12.0" /v InstallDir`) DO (
+    set appdir=%%A %%B
+)
+
+call "%appdir%..\..\VC\vcvarsall.bat" %1
+call lib /machine:%1 /def:unicorn.def


### PR DESCRIPTION
The .lib file produced by mingw can't be used outside of mingw, even with all the support DLLs present. We can work around this by using mingw to compile the DLL and then calling out to MSVC to produce the lib file.

If the user doesn't have MSVC installed, the operation will fail and the rest of the build will proceed. The original static lib produced by mingw is kept with a `.a` extension and is still used to compile the static examples.

This allows angr's unicorn support to build on windows.