### PR TITLE
Support for MCLASS ARM cpu (Cortex-M3)

### DIFF
--- a/include/uc_priv.h
+++ b/include/uc_priv.h
@@ -13,7 +13,7 @@
 
 // These are masks of supported modes for each cpu/arch.
 // They should be updated when changes are made to the uc_mode enum typedef.
-#define UC_MODE_ARM_MASK    (UC_MODE_ARM|UC_MODE_THUMB|UC_MODE_LITTLE_ENDIAN)
+#define UC_MODE_ARM_MASK    (UC_MODE_ARM|UC_MODE_THUMB|UC_MODE_LITTLE_ENDIAN|UC_MODE_MCLASS)
 #define UC_MODE_MIPS_MASK   (UC_MODE_MIPS32|UC_MODE_MIPS64|UC_MODE_LITTLE_ENDIAN|UC_MODE_BIG_ENDIAN)
 #define UC_MODE_X86_MASK    (UC_MODE_16|UC_MODE_32|UC_MODE_64|UC_MODE_LITTLE_ENDIAN)
 #define UC_MODE_PPC_MASK    (UC_MODE_PPC64|UC_MODE_BIG_ENDIAN)

--- a/qemu/hw/arm/tosa.c
+++ b/qemu/hw/arm/tosa.c
@@ -19,8 +19,11 @@
 
 static int tosa_init(struct uc_struct *uc, MachineState *machine)
 {
-    //cpu_arm_init(uc, "pxa255");
-    uc->cpu = (CPUState *)cpu_arm_init(uc, "cortex-a15"); // FIXME
+    if (uc->mode & UC_MODE_MCLASS) {
+        uc->cpu = (CPUState *)cpu_arm_init(uc, "cortex-m3");
+    } else {
+        uc->cpu = (CPUState *)cpu_arm_init(uc, "cortex-a15");
+    }
 
     return 0;
 }


### PR DESCRIPTION
Support for Cortex-M ARM CPU already exists in Qemu. This patch just
exposes a "cortex-m3" CPU.

Example:
`uc_open(UC_ARCH_ARM, UC_MODE_THUMB | UC_MODE_MCLASS, &uc);`

Signed-off-by: Lucian Cojocar <lucian@cojocar.com>