### PR TITLE
Static library copying nitpicks

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -151,8 +151,10 @@ def build_libraries():
 
     # check if a prebuilt library exists
     # if so, use it instead of building
-    if os.path.exists(os.path.join(ROOT_DIR, 'prebuilt', LIBRARY_FILE)):
+    if os.path.exists(os.path.join(ROOT_DIR, 'prebuilt', LIBRARY_FILE)) \
+            and os.path.exists(os.path.join(ROOT_DIR, 'prebuilt', STATIC_LIBRARY_FILE)):
         shutil.copy(os.path.join(ROOT_DIR, 'prebuilt', LIBRARY_FILE), LIBS_DIR)
+        shutil.copy(os.path.join(ROOT_DIR, 'prebuilt', STATIC_LIBRARY_FILE), LIBS_DIR)
         return
 
     # otherwise, build!!
@@ -177,10 +179,13 @@ def build_libraries():
 
     shutil.copy(LIBRARY_FILE, LIBS_DIR)
     try:
-        # static library may fail to build on windows if user doesn't have visual studio 12 installed. this is fine.
+        # static library may fail to build on windows if user doesn't have visual studio installed. this is fine.
         shutil.copy(STATIC_LIBRARY_FILE, LIBS_DIR)
     except:
-        pass
+        print('Warning: Could not build static library file! This build is not appropriate for a binary distribution')
+        # enforce this
+        if 'upload' in sys.argv:
+            sys.exit(1)
     os.chdir(cwd)
 
 


### PR DESCRIPTION
Copy prebuilt static library if available. Disallow uploads from builds that fail to provide the static library.

These are untested, they're just from me scrutinizing the code that's gonna get run as soon as my backup finishes.