### PR TITLE
Update unicorn.h

### DIFF
--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -208,7 +208,7 @@ typedef enum uc_mem_type {
 typedef enum uc_hook_type {
     // Hook all interrupt/syscall events
     UC_HOOK_INTR = 1 << 0,
-    // Hook a particular instruction
+    // Hook a particular instruction - only a very small subset of instructions supported here
     UC_HOOK_INSN = 1 << 1,
     // Hook a range of code
     UC_HOOK_CODE = 1 << 2,


### PR DESCRIPTION
Make it clear that only very few instructions can be hooked.

This isn't very clear in documentation (or at least the include that users consult) and it should be to avoid users trying to hook and getting no results.