### PR TITLE
Homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ matrix:
     - os: osx
       script: brew install --HEAD unicorn
       compiler: clang
+  allow_failures:
+    - os: osx
+      script: brew install --HEAD unicorn
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
     - os: linux
       dist: trusty
       compiler: clang
+    - os: osx
+      script: brew install --head unicorn
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,11 @@ matrix:
       dist: trusty
       compiler: clang
     - os: osx
-      script: brew install --head unicorn
+      script: brew install --HEAD unicorn
+      compiler: gcc
+    - os: osx
+      script: brew install --HEAD unicorn
+      compiler: clang
 addons:
   apt:
     packages:


### PR DESCRIPTION
start monitoring `homebrew` builds by building with `homebrew install --HEAD`, but allow failures (in case a change is needed in the `homebrew` script)