### PR TITLE
handle not having a path in python bindings

### DIFF
--- a/bindings/python/unicorn/unicorn.py
+++ b/bindings/python/unicorn/unicorn.py
@@ -82,7 +82,7 @@ _path_list = [pkg_resources.resource_filename(__name__, 'lib'),
               '',
               distutils.sysconfig.get_python_lib(),
               "/usr/local/lib/" if sys.platform == 'darwin' else '/usr/lib64',
-              os.environ['PATH']]
+              os.getenv('PATH','')]
 
 #print(_path_list)
 #print("-" * 80)


### PR DESCRIPTION
Very silly issue: I am using the python bindings, and for various reasons I don't have a PATH set in my environment. Right now I can't `import unicorn` because of that. That is stupid, this makes it better.