### PR TITLE
remove slow cpu QOM casts

### DIFF
--- a/qemu/target-arm/cpu-qom.h
+++ b/qemu/target-arm/cpu-qom.h
@@ -26,8 +26,7 @@
 
 #define ARM_CPU_CLASS(uc, klass) \
     OBJECT_CLASS_CHECK(uc, ARMCPUClass, (klass), TYPE_ARM_CPU)
-#define ARM_CPU(uc, obj) \
-    OBJECT_CHECK(uc, ARMCPU, (obj), TYPE_ARM_CPU)
+#define ARM_CPU(uc, obj) ((ARMCPU *)obj)
 #define ARM_CPU_GET_CLASS(uc, obj) \
     OBJECT_GET_CLASS(uc, ARMCPUClass, (obj), TYPE_ARM_CPU)
 

--- a/qemu/target-i386/cpu-qom.h
+++ b/qemu/target-i386/cpu-qom.h
@@ -32,8 +32,7 @@
 
 #define X86_CPU_CLASS(uc, klass) \
     OBJECT_CLASS_CHECK(uc, X86CPUClass, (klass), TYPE_X86_CPU)
-#define X86_CPU(uc, obj) \
-    OBJECT_CHECK(uc, X86CPU, (obj), TYPE_X86_CPU)
+#define X86_CPU(uc, obj) ((X86CPU *)obj)
 #define X86_CPU_GET_CLASS(uc, obj) \
     OBJECT_GET_CLASS(uc, X86CPUClass, (obj), TYPE_X86_CPU)
 

--- a/qemu/target-m68k/cpu-qom.h
+++ b/qemu/target-m68k/cpu-qom.h
@@ -26,8 +26,7 @@
 
 #define M68K_CPU_CLASS(uc, klass) \
     OBJECT_CLASS_CHECK(uc, M68kCPUClass, (klass), TYPE_M68K_CPU)
-#define M68K_CPU(uc, obj) \
-    OBJECT_CHECK(uc, M68kCPU, (obj), TYPE_M68K_CPU)
+#define M68K_CPU(uc, obj) ((M68kCPU *)obj)
 #define M68K_CPU_GET_CLASS(uc, obj) \
     OBJECT_GET_CLASS(uc, M68kCPUClass, (obj), TYPE_M68K_CPU)
 

--- a/qemu/target-mips/cpu-qom.h
+++ b/qemu/target-mips/cpu-qom.h
@@ -30,8 +30,7 @@
 
 #define MIPS_CPU_CLASS(uc, klass) \
     OBJECT_CLASS_CHECK(uc, MIPSCPUClass, (klass), TYPE_MIPS_CPU)
-#define MIPS_CPU(uc, obj) \
-    OBJECT_CHECK(uc, MIPSCPU, (obj), TYPE_MIPS_CPU)
+#define MIPS_CPU(uc, obj) ((MIPSCPU *)obj)
 #define MIPS_CPU_GET_CLASS(uc, obj) \
     OBJECT_GET_CLASS(uc, MIPSCPUClass, (obj), TYPE_MIPS_CPU)
 

--- a/qemu/target-sparc/cpu-qom.h
+++ b/qemu/target-sparc/cpu-qom.h
@@ -31,8 +31,7 @@
 
 #define SPARC_CPU_CLASS(uc, klass) \
     OBJECT_CLASS_CHECK(uc, SPARCCPUClass, (klass), TYPE_SPARC_CPU)
-#define SPARC_CPU(uc, obj) \
-    OBJECT_CHECK(uc, SPARCCPU, (obj), TYPE_SPARC_CPU)
+#define SPARC_CPU(uc, obj) ((SPARCCPU *)obj)
 #define SPARC_CPU_GET_CLASS(uc, obj) \
     OBJECT_GET_CLASS(uc, SPARCCPUClass, (obj), TYPE_SPARC_CPU)
 


### PR DESCRIPTION
I don't think these have any value in Unicorn, as there's no public QOM API and we already know the object types at call sites. This increases batch register read throughput in the Go bindings by 8-12% based on a benchmark I wrote, and single register read by a few percent (Go has a large C function call overhead, which I think is dominating Unicorn's internal overhead for single register access).

```
$ go run bench.go # with the patch
running: x86_64
single reg: 1000000 in 437.443535ms  ( 2286009.32/s)
 batch reg: 1000000 in 693.68116ms   (14415844.88/s)
single reg: 1000000 in 431.988547ms  ( 2314876.19/s)
 batch reg: 1000000 in 688.839308ms  (14517173.87/s)
single reg: 1000000 in 432.21778ms   ( 2313648.46/s)
 batch reg: 1000000 in 692.371699ms  (14443109.12/s)
single reg: 1000000 in 423.957743ms  ( 2358725.64/s)
 batch reg: 1000000 in 690.668441ms  (14478727.28/s)
single reg: 1000000 in 423.566425ms  ( 2360904.79/s)
 batch reg: 1000000 in 691.783063ms  (14455398.72/s)
avg single: 2326832.88/s   avg batch: 14462050.77/s

running: arm64
single reg: 1000000 in 411.26507ms   ( 2431521.84/s)
 batch reg: 1000000 in 623.631669ms  (16035106.13/s)
single reg: 1000000 in 416.314836ms  ( 2402028.26/s)
 batch reg: 1000000 in 619.417266ms  (16144206.09/s)
single reg: 1000000 in 412.812402ms  ( 2422407.84/s)
 batch reg: 1000000 in 616.323532ms  (16225244.50/s)
single reg: 1000000 in 413.011079ms  ( 2421242.55/s)
 batch reg: 1000000 in 605.116983ms  (16525730.20/s)
single reg: 1000000 in 416.741626ms  ( 2399568.31/s)
 batch reg: 1000000 in 608.375533ms  (16437215.93/s)
avg single: 2415353.76/s   avg batch: 16273500.57/s

$ go run bench.go # without the patch
running: x86_64
single reg: 1000000 in 459.383514ms  ( 2176830.40/s)
 batch reg: 1000000 in 763.179103ms  (13103084.14/s)
single reg: 1000000 in 447.152159ms  ( 2236375.20/s)
 batch reg: 1000000 in 753.409239ms  (13272998.90/s)
single reg: 1000000 in 429.18052ms   ( 2330021.88/s)
 batch reg: 1000000 in 753.996545ms  (13262660.24/s)
single reg: 1000000 in 436.905622ms  ( 2288823.83/s)
 batch reg: 1000000 in 747.392275ms  (13379854.64/s)
single reg: 1000000 in 445.408956ms  ( 2245127.73/s)
 batch reg: 1000000 in 746.774168ms  (13390929.18/s)
avg single: 2255435.81/s   avg batch: 13281905.42/s

running: arm64
single reg: 1000000 in 429.128007ms  ( 2330307.00/s)
 batch reg: 1000000 in 692.541567ms  (14439566.48/s)
single reg: 1000000 in 424.276156ms  ( 2356955.45/s)
 batch reg: 1000000 in 693.059843ms  (14428768.45/s)
single reg: 1000000 in 419.756346ms  ( 2382334.44/s)
 batch reg: 1000000 in 682.172415ms  (14659050.67/s)
single reg: 1000000 in 425.936216ms  ( 2347769.37/s)
 batch reg: 1000000 in 699.606227ms  (14293754.99/s)
single reg: 1000000 in 418.4033ms    ( 2390038.51/s)
 batch reg: 1000000 in 688.075937ms  (14533279.63/s)
avg single: 2361480.96/s   avg batch: 14470884.05/s
```