### PR TITLE
go: add faster RegBatch type

### DIFF
--- a/bindings/go/unicorn/reg_batch.go
+++ b/bindings/go/unicorn/reg_batch.go
@@ -1,0 +1,91 @@
+package unicorn
+
+import (
+	"errors"
+	"runtime"
+	"unsafe"
+)
+
+/*
+#include <unicorn/unicorn.h>
+
+void *reg_batch_setup(int *regs, int count, uint64_t **vals, int **enums, void ***refs) {
+	size_t uvsz = sizeof(uint64_t) * count;
+	size_t ensz = sizeof(int) * count;
+	size_t ursz = sizeof(uintptr_t) * count;
+	int i;
+
+	uintptr_t buf = (uintptr_t)calloc(1, uvsz+ensz+ursz);
+	if (buf == 0) return NULL;
+
+	*vals = (uint64_t *)buf;
+	*enums = (int *)(buf + uvsz);
+	*refs = (void **)(buf + uvsz + ensz);
+	for (i = 0; i < count; i++) {
+		(*enums)[i] = regs[i];
+		(*refs)[i] = &(*vals)[i];
+	}
+	return (void *)buf;
+}
+*/
+import "C"
+
+type RegBatch struct {
+	// cast to local type
+	vals []uint64
+
+	// pass these to C
+	cenums *C.int
+	crefs  *unsafe.Pointer
+	ccount C.int
+}
+
+func regBatchSetup(regs []int) (buf unsafe.Pointer, vals []uint64, cenums *C.int, crefs *unsafe.Pointer) {
+	enums := make([]C.int, len(regs))
+	for i := 0; i < len(regs); i++ {
+		enums[i] = C.int(regs[i])
+	}
+	var cvals *C.uint64_t
+	buf = C.reg_batch_setup((*C.int)(unsafe.Pointer(&enums[0])), C.int(len(regs)), &cvals, &cenums, &crefs)
+	vals = (*[1 << 24]uint64)(unsafe.Pointer(cvals))[:len(regs)]
+	return
+}
+
+func NewRegBatch(regs []int) (*RegBatch, error) {
+	r := &RegBatch{}
+	var buf unsafe.Pointer
+	buf, r.vals, r.cenums, r.crefs = regBatchSetup(regs)
+	if buf == nil {
+		return nil, errors.New("failed to allocate RegBatch memory")
+	}
+	r.ccount = C.int(len(regs))
+	// when RegBatch is collected, free C-owned data
+	runtime.SetFinalizer(r, func(r *RegBatch) {
+		C.free(buf)
+	})
+	return r, nil
+}
+
+// ReadFast skips copying and returns the internal vals array
+func (r *RegBatch) ReadFast(u Unicorn) ([]uint64, error) {
+	ucerr := C.uc_reg_read_batch(u.Handle(), r.cenums, r.crefs, r.ccount)
+	if ucerr != ERR_OK {
+		return nil, errReturn(ucerr)
+	}
+	return r.vals, nil
+}
+
+func (r *RegBatch) Read(u Unicorn, vals []uint64) error {
+	tmp, err := r.ReadFast(u)
+	if err != nil {
+		return err
+	}
+	copy(vals, tmp[:len(vals)])
+	return nil
+}
+
+func (r *RegBatch) Write(u Unicorn, vals []uint64) error {
+	copy(r.vals[:len(vals)], vals)
+	ucerr := C.uc_reg_write_batch(u.Handle(), r.cenums, r.crefs, r.ccount)
+	return errReturn(ucerr)
+}

--- a/bindings/go/unicorn/unicorn.go
+++ b/bindings/go/unicorn/unicorn.go
@@ -59,6 +59,7 @@ type Unicorn interface {
 
 	ContextSave(reuse Context) (Context, error)
 	ContextRestore(Context) error
+	Handle() *C.uc_engine
 }
 
 type uc struct {
@@ -225,4 +226,8 @@ func (u *uc) Query(queryType int) (uint64, error) {
 	var ret C.size_t
 	ucerr := C.uc_query(u.handle, C.uc_query_type(queryType), &ret)
 	return uint64(ret), errReturn(ucerr)
+}
+
+func (u *uc) Handle() *C.uc_engine {
+	return u.handle
 }


### PR DESCRIPTION
This adds a second technique for batch reading regs in Go that's about 50% faster:

```
running: x86_64
 single reg: 1000000 in 430.385148ms  ( 2323500.25/s)
 single reg: 1000000 in 426.116067ms  ( 2346778.44/s)
 single reg: 1000000 in 420.033392ms  ( 2380763.10/s)
 single reg: 1000000 in 421.195042ms  ( 2374196.99/s)
 single reg: 1000000 in 409.085793ms  ( 2444475.02/s)
      batch: 1000000 in 66.105382ms   (15127361.34/s)
      batch: 1000000 in 69.302988ms   (14429392.28/s)
      batch: 1000000 in 69.14085ms    (14463229.77/s)
      batch: 1000000 in 74.227314ms   (13472129.68/s)
      batch: 1000000 in 68.082625ms   (14688035.31/s)
   RegBatch: 1000000 in 40.463085ms   (24713884.27/s)
   RegBatch: 1000000 in 42.801571ms   (23363628.41/s)
   RegBatch: 1000000 in 43.444415ms   (23017918.41/s)
   RegBatch: 1000000 in 44.891513ms   (22275925.52/s)
   RegBatch: 1000000 in 42.100686ms   (23752582.08/s)
c (control): 1000000 in 20.789182ms   (48101940.71/s)
c (control): 1000000 in 19.605365ms   (51006446.45/s)
c (control): 1000000 in 20.776845ms   (48130502.97/s)
c (control): 1000000 in 20.122531ms   (49695537.80/s)
c (control): 1000000 in 21.830203ms   (45808094.41/s)
avg single: 2373942.76/s   avg batch: 14436029.68/s   avg ng: 23424787.74/s   avg c: 48548504.47/s

running: arm64
 single reg: 5800000 in 2.308072531s  ( 2512919.30/s)
 single reg: 5800000 in 2.334925325s  ( 2484019.48/s)
 single reg: 5800000 in 2.340510971s  ( 2478091.35/s)
 single reg: 5800000 in 2.346660293s  ( 2471597.62/s)
 single reg: 5800000 in 2.332164301s  ( 2486960.29/s)
      batch: 5800000 in 152.217138ms  (38103462.44/s)
      batch: 5800000 in 151.120407ms  (38379991.92/s)
      batch: 5800000 in 147.862616ms  (39225601.15/s)
      batch: 5800000 in 151.963149ms  (38167148.01/s)
      batch: 5800000 in 153.232102ms  (37851076.40/s)
   RegBatch: 5800000 in 94.948831ms   (61085533.53/s)
   RegBatch: 5800000 in 95.627086ms   (60652271.68/s)
   RegBatch: 5800000 in 95.529866ms   (60713997.02/s)
   RegBatch: 5800000 in 94.518978ms   (61363338.06/s)
   RegBatch: 5800000 in 100.30485ms   (57823724.38/s)
c (control): 5800000 in 73.253597ms   (79176999.32/s)
c (control): 5800000 in 76.992193ms   (75332313.24/s)
c (control): 5800000 in 73.258249ms   (79171971.47/s)
c (control): 5800000 in 75.429188ms   (76893310.85/s)
c (control): 5800000 in 76.790811ms   (75529870.36/s)
avg single: 2486717.61/s   avg batch: 38345455.98/s   avg ng: 60327772.93/s   avg c: 77220893.05/s
```