### PR TITLE
Go: improve hook callback speed by 30% and add a HOOK_CODE benchmark

### DIFF
--- a/bindings/go/unicorn/hook.go
+++ b/bindings/go/unicorn/hook.go
@@ -19,54 +19,82 @@ type HookData struct {
 
 type Hook uint64
 
-var hookDataLock sync.RWMutex
-var hookDataMap = make(map[uintptr]*HookData)
-
-func getHookData(user unsafe.Pointer) *HookData {
-	hookDataLock.RLock()
-	defer hookDataLock.RUnlock()
-	return hookDataMap[uintptr(user)]
+type fastHookMap struct {
+	vals []*HookData
+	sync.RWMutex
 }
+
+func (m *fastHookMap) insert(h *HookData) uintptr {
+	// don't change this to defer
+	m.Lock()
+	for i, v := range m.vals {
+		if v == nil {
+			m.vals[i] = h
+			m.Unlock()
+			return uintptr(i)
+		}
+	}
+	i := len(m.vals)
+	m.vals = append(m.vals, h)
+	m.Unlock()
+	return uintptr(i)
+}
+
+func (m *fastHookMap) get(i unsafe.Pointer) *HookData {
+	m.RLock()
+	// TODO: nil check?
+	v := m.vals[uintptr(i)]
+	m.RUnlock()
+	return v
+}
+
+func (m *fastHookMap) remove(i uintptr) {
+	m.Lock()
+	m.vals[i] = nil
+	m.Unlock()
+}
+
+var hookMap fastHookMap
 
 //export hookCode
 func hookCode(handle unsafe.Pointer, addr uint64, size uint32, user unsafe.Pointer) {
-	hook := getHookData(user)
+	hook := hookMap.get(user)
 	hook.Callback.(func(Unicorn, uint64, uint32))(hook.Uc, uint64(addr), uint32(size))
 }
 
 //export hookMemInvalid
 func hookMemInvalid(handle unsafe.Pointer, typ C.uc_mem_type, addr uint64, size int, value int64, user unsafe.Pointer) bool {
-	hook := getHookData(user)
+	hook := hookMap.get(user)
 	return hook.Callback.(func(Unicorn, int, uint64, int, int64) bool)(hook.Uc, int(typ), addr, size, value)
 }
 
 //export hookMemAccess
 func hookMemAccess(handle unsafe.Pointer, typ C.uc_mem_type, addr uint64, size int, value int64, user unsafe.Pointer) {
-	hook := getHookData(user)
+	hook := hookMap.get(user)
 	hook.Callback.(func(Unicorn, int, uint64, int, int64))(hook.Uc, int(typ), addr, size, value)
 }
 
 //export hookInterrupt
 func hookInterrupt(handle unsafe.Pointer, intno uint32, user unsafe.Pointer) {
-	hook := getHookData(user)
+	hook := hookMap.get(user)
 	hook.Callback.(func(Unicorn, uint32))(hook.Uc, intno)
 }
 
 //export hookX86In
 func hookX86In(handle unsafe.Pointer, port, size uint32, user unsafe.Pointer) uint32 {
-	hook := getHookData(user)
+	hook := hookMap.get(user)
 	return hook.Callback.(func(Unicorn, uint32, uint32) uint32)(hook.Uc, port, size)
 }
 
 //export hookX86Out
 func hookX86Out(handle unsafe.Pointer, port, size, value uint32, user unsafe.Pointer) {
-	hook := getHookData(user)
+	hook := hookMap.get(user)
 	hook.Callback.(func(Unicorn, uint32, uint32, uint32))(hook.Uc, port, size, value)
 }
 
 //export hookX86Syscall
 func hookX86Syscall(handle unsafe.Pointer, user unsafe.Pointer) {
-	hook := getHookData(user)
+	hook := hookMap.get(user)
 	hook.Callback.(func(Unicorn))(hook.Uc)
 }
 
@@ -105,15 +133,13 @@ func (u *uc) HookAdd(htype int, cb interface{}, begin, end uint64, extra ...int)
 	}
 	var h2 C.uc_hook
 	data := &HookData{u, cb}
-	uptr := uintptr(unsafe.Pointer(data))
+	uptr := hookMap.insert(data)
 	if insnMode {
 		C.uc_hook_add_insn(u.handle, &h2, C.uc_hook_type(htype), callback, C.uintptr_t(uptr), C.uint64_t(begin), C.uint64_t(end), insn)
 	} else {
 		C.uc_hook_add_wrap(u.handle, &h2, C.uc_hook_type(htype), callback, C.uintptr_t(uptr), C.uint64_t(begin), C.uint64_t(end))
 	}
-	hookDataLock.Lock()
-	hookDataMap[uptr] = data
-	hookDataLock.Unlock()
+	// TODO: could move Hook and uptr onto HookData and just return it
 	u.hooks[Hook(h2)] = uptr
 	return Hook(h2), nil
 }
@@ -121,9 +147,7 @@ func (u *uc) HookAdd(htype int, cb interface{}, begin, end uint64, extra ...int)
 func (u *uc) HookDel(hook Hook) error {
 	if uptr, ok := u.hooks[hook]; ok {
 		delete(u.hooks, hook)
-		hookDataLock.Lock()
-		delete(hookDataMap, uptr)
-		hookDataLock.Unlock()
+		hookMap.remove(uptr)
 	}
 	return errReturn(C.uc_hook_del(u.handle, C.uc_hook(hook)))
 }

--- a/bindings/go/unicorn/unicorn.go
+++ b/bindings/go/unicorn/unicorn.go
@@ -96,7 +96,7 @@ func (u *uc) Close() (err error) {
 	u.final.Do(func() {
 		if u.handle != nil {
 			for _, uptr := range u.hooks {
-				delete(hookDataMap, uptr)
+				hookMap.remove(uptr)
 			}
 			u.hooks = nil
 			err = errReturn(C.uc_close(u.handle))


### PR DESCRIPTION
    Before: BenchmarkX86Hook-4    2000000    905 ns/op
    After:  BenchmarkX86Hook-4    2000000    683 ns/op
