### PR TITLE
Update UC_HOOK_MEM_VALID

### DIFF
--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -248,7 +248,9 @@ typedef enum uc_hook_type {
 // Hook type for all events of illegal memory access
 #define UC_HOOK_MEM_INVALID (UC_HOOK_MEM_UNMAPPED + UC_HOOK_MEM_PROT)
 // Hook type for all events of valid memory access
-#define UC_HOOK_MEM_VALID (UC_HOOK_MEM_READ_AFTER + UC_HOOK_MEM_WRITE + UC_HOOK_MEM_FETCH)
+// NOTE: UC_HOOK_MEM_READ is triggered before UC_HOOK_MEM_READ_PROT and UC_HOOK_MEM_READ_UNMAPPED, so
+//       this hook will technically trigger on some invalid reads.
+#define UC_HOOK_MEM_VALID (UC_HOOK_MEM_READ + UC_HOOK_MEM_WRITE + UC_HOOK_MEM_FETCH)
 
 /*
   Callback function for hooking memory (READ, WRITE & FETCH)

--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -249,7 +249,7 @@ typedef enum uc_hook_type {
 #define UC_HOOK_MEM_INVALID (UC_HOOK_MEM_UNMAPPED + UC_HOOK_MEM_PROT)
 // Hook type for all events of valid memory access
 // NOTE: UC_HOOK_MEM_READ is triggered before UC_HOOK_MEM_READ_PROT and UC_HOOK_MEM_READ_UNMAPPED, so
-//       this hook will technically trigger on some invalid reads.
+//       this hook may technically trigger on some invalid reads.
 #define UC_HOOK_MEM_VALID (UC_HOOK_MEM_READ + UC_HOOK_MEM_WRITE + UC_HOOK_MEM_FETCH)
 
 /*

--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -248,7 +248,7 @@ typedef enum uc_hook_type {
 // Hook type for all events of illegal memory access
 #define UC_HOOK_MEM_INVALID (UC_HOOK_MEM_UNMAPPED + UC_HOOK_MEM_PROT)
 // Hook type for all events of valid memory access
-#define UC_HOOK_MEM_VALID (UC_HOOK_MEM_READ + UC_HOOK_MEM_WRITE + UC_HOOK_MEM_FETCH)
+#define UC_HOOK_MEM_VALID (UC_HOOK_MEM_READ_AFTER + UC_HOOK_MEM_WRITE + UC_HOOK_MEM_FETCH)
 
 /*
   Callback function for hooking memory (READ, WRITE & FETCH)

--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -249,7 +249,7 @@ typedef enum uc_hook_type {
 #define UC_HOOK_MEM_INVALID (UC_HOOK_MEM_UNMAPPED + UC_HOOK_MEM_PROT)
 // Hook type for all events of valid memory access
 // NOTE: UC_HOOK_MEM_READ is triggered before UC_HOOK_MEM_READ_PROT and UC_HOOK_MEM_READ_UNMAPPED, so
-//       this hook may technically trigger on some invalid reads.
+//       this hook may technically trigger on some invalid reads. 
 #define UC_HOOK_MEM_VALID (UC_HOOK_MEM_READ + UC_HOOK_MEM_WRITE + UC_HOOK_MEM_FETCH)
 
 /*


### PR DESCRIPTION
UC_HOOK_MEM_READ fires before handlers for invalid memory reads, so UC_HOOK_MEM_VALID would technically also be receiving invalid memory reads. Switching to UC_HOOK_MEM_READ_AFTER ensures that only actually valid reads are hooked