### PR TITLE
add uc_hook_ex() to allow front insertion

### DIFF
--- a/bindings/go/unicorn/hook.c
+++ b/bindings/go/unicorn/hook.c
@@ -1,16 +1,14 @@
 #include <unicorn/unicorn.h>
 #include "_cgo_export.h"
 
-uc_err uc_hook_add(uc_engine *uc, uc_hook *hh, int type, void *callback,
-                void *user_data, uint64_t begin, uint64_t end, ...);
+uc_err uc_hook_add_ex(uc_engine *uc, uc_hook *hh, int type, void *callback, bool front, void *user_data, uint64_t begin, uint64_t end, ...);
 
-
-uc_err uc_hook_add_wrap(uc_engine *handle, uc_hook *h2, uc_hook_type type, void *callback, uintptr_t user, uint64_t begin, uint64_t end) {
-    return uc_hook_add(handle, h2, type, callback, (void *)user, begin, end);
+uc_err uc_hook_add_wrap(uc_engine *handle, uc_hook *h2, uc_hook_type type, void *callback, bool front, uintptr_t user, uint64_t begin, uint64_t end) {
+    return uc_hook_add_ex(handle, h2, type, callback, front, (void *)user, begin, end);
 }
 
-uc_err uc_hook_add_insn(uc_engine *handle, uc_hook *h2, uc_hook_type type, void *callback, uintptr_t user, uint64_t begin, uint64_t end, int insn) {
-    return uc_hook_add(handle, h2, type, callback, (void *)user, begin, end, insn);
+uc_err uc_hook_add_insn(uc_engine *handle, uc_hook *h2, uc_hook_type type, void *callback, bool front, uintptr_t user, uint64_t begin, uint64_t end, int insn) {
+    return uc_hook_add_ex(handle, h2, type, callback, front, (void *)user, begin, end, insn);
 }
 
 void hookCode_cgo(uc_engine *handle, uint64_t addr, uint32_t size, uintptr_t user) {

--- a/bindings/go/unicorn/hook.h
+++ b/bindings/go/unicorn/hook.h
@@ -1,5 +1,5 @@
-uc_err uc_hook_add_wrap(uc_engine *handle, uc_hook *h2, uc_hook_type type, void *callback, uintptr_t user, uint64_t begin, uint64_t end);
-uc_err uc_hook_add_insn(uc_engine *handle, uc_hook *h2, uc_hook_type type, void *callback, uintptr_t user, uint64_t begin, uint64_t end, int insn);
+uc_err uc_hook_add_wrap(uc_engine *handle, uc_hook *h2, uc_hook_type type, void *callback, bool front, uintptr_t user, uint64_t begin, uint64_t end);
+uc_err uc_hook_add_insn(uc_engine *handle, uc_hook *h2, uc_hook_type type, void *callback, bool front, uintptr_t user, uint64_t begin, uint64_t end, int insn);
 void hookCode_cgo(uc_engine *handle, uint64_t addr, uint32_t size, uintptr_t user);
 bool hookMemInvalid_cgo(uc_engine *handle, uc_mem_type type, uint64_t addr, int size, int64_t value, uintptr_t user);
 void hookMemAccess_cgo(uc_engine *handle, uc_mem_type type, uint64_t addr, int size, int64_t value, uintptr_t user);

--- a/bindings/go/unicorn/unicorn.go
+++ b/bindings/go/unicorn/unicorn.go
@@ -52,6 +52,7 @@ type Unicorn interface {
 	Start(begin, until uint64) error
 	StartWithOptions(begin, until uint64, options *UcOptions) error
 	Stop() error
+	HookAddEx(htype int, cb interface{}, front bool, begin, end uint64, extra ...int) (Hook, error)
 	HookAdd(htype int, cb interface{}, begin, end uint64, extra ...int) (Hook, error)
 	HookDel(hook Hook) error
 	Query(queryType int) (uint64, error)

--- a/include/list.h
+++ b/include/list.h
@@ -14,6 +14,8 @@ struct list {
 
 struct list *list_new(void);
 void list_clear(struct list *list);
+void *list_add(struct list *list, void *data, bool front);
+void *list_insert(struct list *list, void *data);
 void *list_append(struct list *list, void *data);
 bool list_remove(struct list *list, void *data);
 

--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -543,6 +543,16 @@ uc_err uc_emu_stop(uc_engine *uc);
    for detailed error).
 */
 UNICORN_EXPORT
+uc_err uc_hook_add_ex(uc_engine *uc, uc_hook *hh, int type, void *callback, bool front,
+        void *user_data, uint64_t begin, uint64_t end, ...);
+
+/*
+ Register callback for a hook event.
+ The callback will be run when the hook event is hit.
+
+ Just wraps uc_hook_add_ex() with front=false for legacy reasons.
+ */
+UNICORN_EXPORT
 uc_err uc_hook_add(uc_engine *uc, uc_hook *hh, int type, void *callback,
         void *user_data, uint64_t begin, uint64_t end, ...);
 

--- a/list.c
+++ b/list.c
@@ -22,7 +22,29 @@ void list_clear(struct list *list)
     list->tail = NULL;
 }
 
-// returns generated linked list node, or NULL on failure
+
+// dispatches to insert/append based on the value of front
+void *list_add(struct list *list, void *data, bool front) {
+    if (front) {
+        return list_insert(list, data);
+    } else {
+        return list_append(list, data);
+    }
+}
+
+// insert to front of list. returns new node, or NULL on failure.
+void *list_insert(struct list *list, void *data) {
+    struct list_item *item = malloc(sizeof(struct list_item));
+    if (item == NULL) {
+        return NULL;
+    }
+    item->next = list->head;
+    item->data = data;
+    list->head = item;
+    return item;
+}
+
+// append to end of list. returns new node, or NULL on failure.
 void *list_append(struct list *list, void *data)
 {
     struct list_item *item = malloc(sizeof(struct list_item));


### PR DESCRIPTION
this is required for sane operation of a tracing interactive debugger with unicorn, as otherwise you can't insert watch/breakpoints before trace hooks fire and you get duplicate data