### PR TITLE
x86::trans: handle illegal case for opc c6/c7

### DIFF
--- a/qemu/target-i386/translate.c
+++ b/qemu/target-i386/translate.c
@@ -6005,9 +6005,15 @@ static target_ulong disas_insn(CPUX86State *env, DisasContext *s,
         ot = mo_b_d(b, dflag);
         modrm = cpu_ldub_code(env, s->pc++);
         mod = (modrm >> 6) & 3;
+        reg = ((modrm >> 3) & 7) | rex_r;
         if (mod != 3) {
+            if (reg != 0)
+                goto illegal_op;
             s->rip_offset = insn_const_size(ot);
             gen_lea_modrm(env, s, modrm);
+        } else {
+            if (reg != 0 && reg != 7)
+                goto illegal_op;
         }
         val = insn_get(env, s, ot);
         tcg_gen_movi_tl(tcg_ctx, *cpu_T[0], val);


### PR DESCRIPTION
Reference Intel software developer manual vol2 Appendix A Table A-6 for
detailed decoding information.

Signed-off-by: vardyh <vardyh.dev@gmail.com>