### PR TITLE
Remove undefined behaviour with out-of-bounds shift count.

### DIFF
--- a/qemu/fpu/softfloat.c
+++ b/qemu/fpu/softfloat.c
@@ -669,7 +669,7 @@ static void
     int8 shiftCount;
 
     shiftCount = countLeadingZeros64( aSig );
-    *zSigPtr = aSig<<shiftCount;
+    *zSigPtr = aSig<<(shiftCount&63);
     *zExpPtr = 1 - shiftCount;
 
 }

--- a/qemu/translate-all.c
+++ b/qemu/translate-all.c
@@ -1420,7 +1420,7 @@ void tb_invalidate_phys_page_fast(struct uc_struct* uc, tb_page_addr_t start, in
         unsigned long b;
 
         nr = start & ~TARGET_PAGE_MASK;
-        b = p->code_bitmap[BIT_WORD(nr)] >> (nr & (BITS_PER_LONG - 1));
+        b = p->code_bitmap[BIT_WORD(nr)] >> (nr & 7);
         if (b & ((1 << len) - 1)) {
             goto do_invalidate;
         }


### PR DESCRIPTION
Testing with sanitizers reports that the two patched locations can be
reached with an out-of-bounds shift count, the patch should not alter
the behaviour of the code except to prevent the undefined behaviour.