### PR TITLE
[RFC] Add support for mapping MMIO through a new function.

### DIFF
--- a/include/uc_priv.h
+++ b/include/uc_priv.h
@@ -66,6 +66,8 @@ typedef void (*uc_args_uc_u64_t)(struct uc_struct *, uint64_t addr);
 
 typedef MemoryRegion* (*uc_args_uc_ram_size_t)(struct uc_struct*,  hwaddr begin, size_t size, uint32_t perms);
 
+typedef MemoryRegion* (*uc_args_uc_ram_size_io_t)(struct uc_struct *uc, ram_addr_t begin, size_t size, uc_cb_mmio_read read_cb, uc_cb_mmio_write write_cb, void *user_data);
+
 typedef MemoryRegion* (*uc_args_uc_ram_size_ptr_t)(struct uc_struct*,  hwaddr begin, size_t size, uint32_t perms, void *ptr);
 
 typedef void (*uc_mem_unmap_t)(struct uc_struct*, MemoryRegion *mr);
@@ -165,6 +167,7 @@ struct uc_struct {
     uc_args_tcg_enable_t tcg_enabled;
     uc_args_uc_long_t tcg_exec_init;
     uc_args_uc_ram_size_t memory_map;
+    uc_args_uc_ram_size_io_t memory_map_io;
     uc_args_uc_ram_size_ptr_t memory_map_ptr;
     uc_mem_unmap_t memory_unmap;
     uc_readonly_mem_t readonly_mem;

--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -114,7 +114,7 @@ typedef enum uc_mode {
     UC_MODE_16 = 1 << 1,          // 16-bit mode
     UC_MODE_32 = 1 << 2,          // 32-bit mode
     UC_MODE_64 = 1 << 3,          // 64-bit mode
-    // ppc 
+    // ppc
     UC_MODE_PPC32 = 1 << 2,       // 32-bit mode (currently unsupported)
     UC_MODE_PPC64 = 1 << 3,       // 64-bit mode (currently unsupported)
     UC_MODE_QPX = 1 << 4,         // Quad Processing eXtensions mode (currently unsupported)
@@ -188,6 +188,10 @@ typedef uint32_t (*uc_cb_insn_in_t)(uc_engine *uc, uint32_t port, int size, void
 */
 typedef void (*uc_cb_insn_out_t)(uc_engine *uc, uint32_t port, int size, uint32_t value, void *user_data);
 
+typedef uint64_t (*uc_cb_mmio_read)(struct uc_struct* uc, void *opaque, uint64_t addr, unsigned size);
+
+typedef void (*uc_cb_mmio_write)(struct uc_struct* uc, void *opaque, uint64_t addr, uint64_t data, unsigned size);
+
 // All type of memory accesses for UC_HOOK_MEM_*
 typedef enum uc_mem_type {
     UC_MEM_READ = 16,   // Memory is read from
@@ -249,7 +253,7 @@ typedef enum uc_hook_type {
 #define UC_HOOK_MEM_INVALID (UC_HOOK_MEM_UNMAPPED + UC_HOOK_MEM_PROT)
 // Hook type for all events of valid memory access
 // NOTE: UC_HOOK_MEM_READ is triggered before UC_HOOK_MEM_READ_PROT and UC_HOOK_MEM_READ_UNMAPPED, so
-//       this hook may technically trigger on some invalid reads. 
+//       this hook may technically trigger on some invalid reads.
 #define UC_HOOK_MEM_VALID (UC_HOOK_MEM_READ + UC_HOOK_MEM_WRITE + UC_HOOK_MEM_FETCH)
 
 /*
@@ -277,11 +281,11 @@ typedef void (*uc_cb_hookmem_t)(uc_engine *uc, uc_mem_type type,
   @return: return true to continue, or false to stop program (due to invalid memory).
            NOTE: returning true to continue execution will only work if if the accessed
            memory is made accessible with the correct permissions during the hook.
-           
+
            In the event of a UC_MEM_READ_UNMAPPED or UC_MEM_WRITE_UNMAPPED callback,
            the memory should be uc_mem_map()-ed with the correct permissions, and the
            instruction will then read or write to the address as it was supposed to.
-           
+
            In the event of a UC_MEM_FETCH_UNMAPPED callback, the memory can be mapped
            in as executable, in which case execution will resume from the fetched address.
            The instruction pointer may be written to in order to change where execution resumes,
@@ -588,6 +592,26 @@ typedef enum uc_prot {
 */
 UNICORN_EXPORT
 uc_err uc_mem_map(uc_engine *uc, uint64_t address, size_t size, uint32_t perms);
+
+/*
+ Map MMIO in for emulation.
+ This API adds a MMIO region that can be used by emulation.
+
+ @uc: handle returned by uc_open()
+ @address: starting address of the new MMIO region to be mapped in.
+    This address must be aligned to 4KB, or this will return with UC_ERR_ARG error.
+ @size: size of the new MMIO region to be mapped in.
+    This size must be multiple of 4KB, or this will return with UC_ERR_ARG error.
+ @read_cb: function for handling reads from this MMIO region.
+ @write_cb: function for handling writes to this MMIO region.
+ @user_data: user-defined data. This will be passed to callback function in its
+      last argument @user_data
+
+ @return UC_ERR_OK on success, or other value on failure (refer to uc_err enum
+   for detailed error).
+*/
+UNICORN_EXPORT
+uc_err uc_mmio_map(uc_engine *uc, uint64_t address, size_t size, uc_cb_mmio_read read_cb, uc_cb_mmio_write write_cb, void *user_data);
 
 /*
  Map existing host memory in for emulation.

--- a/qemu/aarch64.h
+++ b/qemu/aarch64.h
@@ -13,6 +13,7 @@
 #define phys_mem_clean phys_mem_clean_aarch64
 #define tb_cleanup tb_cleanup_aarch64
 #define memory_map memory_map_aarch64
+#define memory_map_io memory_map_io_aarch64
 #define memory_map_ptr memory_map_ptr_aarch64
 #define memory_unmap memory_unmap_aarch64
 #define memory_free memory_free_aarch64

--- a/qemu/aarch64eb.h
+++ b/qemu/aarch64eb.h
@@ -13,6 +13,7 @@
 #define phys_mem_clean phys_mem_clean_aarch64eb
 #define tb_cleanup tb_cleanup_aarch64eb
 #define memory_map memory_map_aarch64eb
+#define memory_map_io memory_map_io_aarch64eb
 #define memory_map_ptr memory_map_ptr_aarch64eb
 #define memory_unmap memory_unmap_aarch64eb
 #define memory_free memory_free_aarch64eb

--- a/qemu/arm.h
+++ b/qemu/arm.h
@@ -13,6 +13,7 @@
 #define phys_mem_clean phys_mem_clean_arm
 #define tb_cleanup tb_cleanup_arm
 #define memory_map memory_map_arm
+#define memory_map_io memory_map_io_arm
 #define memory_map_ptr memory_map_ptr_arm
 #define memory_unmap memory_unmap_arm
 #define memory_free memory_free_arm

--- a/qemu/armeb.h
+++ b/qemu/armeb.h
@@ -13,6 +13,7 @@
 #define phys_mem_clean phys_mem_clean_armeb
 #define tb_cleanup tb_cleanup_armeb
 #define memory_map memory_map_armeb
+#define memory_map_io memory_map_io_armeb
 #define memory_map_ptr memory_map_ptr_armeb
 #define memory_unmap memory_unmap_armeb
 #define memory_free memory_free_armeb

--- a/qemu/header_gen.py
+++ b/qemu/header_gen.py
@@ -19,6 +19,7 @@ symbols = (
     'phys_mem_clean',
     'tb_cleanup',
     'memory_map',
+    'memory_map_io',
     'memory_map_ptr',
     'memory_unmap',
     'memory_free',

--- a/qemu/include/exec/memory.h
+++ b/qemu/include/exec/memory.h
@@ -35,6 +35,10 @@
 #define MEMORY_REGION(uc, obj) \
         OBJECT_CHECK(uc, MemoryRegion, (obj), TYPE_MEMORY_REGION)
 
+typedef uint64_t (*uc_cb_mmio_read)(struct uc_struct* uc, void *opaque, uint64_t addr, unsigned size);
+
+typedef void (*uc_cb_mmio_write)(struct uc_struct* uc, void *opaque, uint64_t addr, uint64_t data, unsigned size);
+
 typedef struct MemoryRegionOps MemoryRegionOps;
 typedef struct MemoryRegionMmio MemoryRegionMmio;
 
@@ -855,6 +859,7 @@ void address_space_unmap(AddressSpace *as, void *buffer, hwaddr len,
 void memory_register_types(struct uc_struct *uc);
 
 MemoryRegion *memory_map(struct uc_struct *uc, hwaddr begin, size_t size, uint32_t perms);
+MemoryRegion *memory_map_io(struct uc_struct *uc, ram_addr_t begin, size_t size, uc_cb_mmio_read read_cb, uc_cb_mmio_write write_cb, void *user_data);
 MemoryRegion *memory_map_ptr(struct uc_struct *uc, hwaddr begin, size_t size, uint32_t perms, void *ptr);
 void memory_unmap(struct uc_struct *uc, MemoryRegion *mr);
 int memory_free(struct uc_struct *uc);

--- a/qemu/m68k.h
+++ b/qemu/m68k.h
@@ -13,6 +13,7 @@
 #define phys_mem_clean phys_mem_clean_m68k
 #define tb_cleanup tb_cleanup_m68k
 #define memory_map memory_map_m68k
+#define memory_map_io memory_map_io_m68k
 #define memory_map_ptr memory_map_ptr_m68k
 #define memory_unmap memory_unmap_m68k
 #define memory_free memory_free_m68k

--- a/qemu/mips.h
+++ b/qemu/mips.h
@@ -13,6 +13,7 @@
 #define phys_mem_clean phys_mem_clean_mips
 #define tb_cleanup tb_cleanup_mips
 #define memory_map memory_map_mips
+#define memory_map_io memory_map_io_mips
 #define memory_map_ptr memory_map_ptr_mips
 #define memory_unmap memory_unmap_mips
 #define memory_free memory_free_mips

--- a/qemu/mips64.h
+++ b/qemu/mips64.h
@@ -13,6 +13,7 @@
 #define phys_mem_clean phys_mem_clean_mips64
 #define tb_cleanup tb_cleanup_mips64
 #define memory_map memory_map_mips64
+#define memory_map_io memory_map_io_mips64
 #define memory_map_ptr memory_map_ptr_mips64
 #define memory_unmap memory_unmap_mips64
 #define memory_free memory_free_mips64

--- a/qemu/mips64el.h
+++ b/qemu/mips64el.h
@@ -13,6 +13,7 @@
 #define phys_mem_clean phys_mem_clean_mips64el
 #define tb_cleanup tb_cleanup_mips64el
 #define memory_map memory_map_mips64el
+#define memory_map_io memory_map_io_mips64el
 #define memory_map_ptr memory_map_ptr_mips64el
 #define memory_unmap memory_unmap_mips64el
 #define memory_free memory_free_mips64el

--- a/qemu/mipsel.h
+++ b/qemu/mipsel.h
@@ -13,6 +13,7 @@
 #define phys_mem_clean phys_mem_clean_mipsel
 #define tb_cleanup tb_cleanup_mipsel
 #define memory_map memory_map_mipsel
+#define memory_map_io memory_map_io_mipsel
 #define memory_map_ptr memory_map_ptr_mipsel
 #define memory_unmap memory_unmap_mipsel
 #define memory_free memory_free_mipsel

--- a/qemu/sparc.h
+++ b/qemu/sparc.h
@@ -13,6 +13,7 @@
 #define phys_mem_clean phys_mem_clean_sparc
 #define tb_cleanup tb_cleanup_sparc
 #define memory_map memory_map_sparc
+#define memory_map_io memory_map_io_sparc
 #define memory_map_ptr memory_map_ptr_sparc
 #define memory_unmap memory_unmap_sparc
 #define memory_free memory_free_sparc

--- a/qemu/sparc64.h
+++ b/qemu/sparc64.h
@@ -13,6 +13,7 @@
 #define phys_mem_clean phys_mem_clean_sparc64
 #define tb_cleanup tb_cleanup_sparc64
 #define memory_map memory_map_sparc64
+#define memory_map_io memory_map_io_sparc64
 #define memory_map_ptr memory_map_ptr_sparc64
 #define memory_unmap memory_unmap_sparc64
 #define memory_free memory_free_sparc64

--- a/qemu/unicorn_common.h
+++ b/qemu/unicorn_common.h
@@ -75,6 +75,7 @@ static inline void uc_common_init(struct uc_struct* uc)
     uc->cpu_exec_init_all = cpu_exec_init_all;
     uc->vm_start = vm_start;
     uc->memory_map = memory_map;
+    uc->memory_map_io = memory_map_io;
     uc->memory_map_ptr = memory_map_ptr;
     uc->memory_unmap = memory_unmap;
     uc->readonly_mem = memory_region_set_readonly;

--- a/qemu/x86_64.h
+++ b/qemu/x86_64.h
@@ -13,6 +13,7 @@
 #define phys_mem_clean phys_mem_clean_x86_64
 #define tb_cleanup tb_cleanup_x86_64
 #define memory_map memory_map_x86_64
+#define memory_map_io memory_map_io_x86_64
 #define memory_map_ptr memory_map_ptr_x86_64
 #define memory_unmap memory_unmap_x86_64
 #define memory_free memory_free_x86_64

--- a/samples/.gitignore
+++ b/samples/.gitignore
@@ -2,4 +2,4 @@
 sample_*
 shellcode*
 mem_apis*
-
+mmio_api

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -65,6 +65,7 @@ SOURCES =
 ifneq (,$(findstring arm,$(UNICORN_ARCHS)))
 SOURCES += sample_arm.c
 SOURCES += sample_armeb.c
+SOURCES += mmio_api.c
 endif
 ifneq (,$(findstring aarch64,$(UNICORN_ARCHS)))
 SOURCES += sample_arm64.c

--- a/samples/mmio_api.c
+++ b/samples/mmio_api.c
@@ -1,0 +1,132 @@
+/*
+   Sample use of uc_mmio_map
+
+   Copyright(c) 2017 Kitlith
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   version 2 as published by the Free Software Foundation.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+ */
+
+#define __STDC_FORMAT_MACROS
+
+#include <unicorn/unicorn.h>
+#include <string.h>
+#include <stdlib.h>
+
+static const int registers[] = { UC_ARM_REG_R0, UC_ARM_REG_R1, UC_ARM_REG_R2, UC_ARM_REG_R3,
+                                 UC_ARM_REG_R4, UC_ARM_REG_R5, UC_ARM_REG_R6, UC_ARM_REG_R7,
+                                 UC_ARM_REG_R8, UC_ARM_REG_R9, UC_ARM_REG_R10, UC_ARM_REG_R11,
+                                 UC_ARM_REG_R12, UC_ARM_REG_SP, UC_ARM_REG_LR, UC_ARM_REG_PC };
+
+static void print_ctx(uc_engine *emu) {
+
+    int64_t r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, sp, lr, pc;
+    r0 = r1 = r2 = r3 = r4 = r5 = r6 = r7 = r8 = r9 = r10 = r11 = r12 = sp = lr = pc = 0;
+    int64_t *reg_array[] = {&r0, &r1, &r2, &r3, &r4, &r5, &r6, &r7, &r8, &r9, &r10, &r11, &r12, &sp, &lr, &pc};
+    // No error checking wrapper because this can be called from inside...
+    // Don't want to infinitely loop and stackoverflow.
+    // There is a way to read a bunch of registers at once! But is this everything...
+    uc_reg_read_batch(emu, (int*)registers, (void**)reg_array, 16);
+    printf( "R0 > 0x%08" PRIx64 " | R1 > 0x%08" PRIx64 " | R2 > 0x%08" PRIx64 " | R3 > 0x%08" PRIx64 "\n"
+            "R4 > 0x%08" PRIx64 " | R5 > 0x%08" PRIx64 " | R6 > 0x%08" PRIx64 " | R7 > 0x%08" PRIx64 "\n"
+            "R8 > 0x%08" PRIx64 " | R9 > 0x%08" PRIx64 " | R10> 0x%08" PRIx64 " | R11> 0x%08" PRIx64 "\n"
+            "R12> 0x%08" PRIx64 " | SP > 0x%08" PRIx64 " | LR > 0x%08" PRIx64 " | PC > 0x%08" PRIx64 "\n",
+            r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, sp, lr, pc);
+}
+
+static uint64_t read_cb(struct uc_struct* uc, void *opaque, uint64_t addr, unsigned size) {
+    static uint64_t count = 0;
+    switch (addr) {
+        case 0x0:
+            printf(">>> IO counter value: %08" PRIu64 "\n", count);
+            return count++;
+        case 0x4:
+            printf(">>> Requested magic value!\n");
+            return 0xDEADBEEF;
+        default:
+            return 0;
+    }
+    return 0;
+}
+
+static void write_cb(struct uc_struct* uc, void *opaque, uint64_t addr, uint64_t data, unsigned size) {
+    printf(">>> Recieved 0x%08" PRIx64 " via 0x%08" PRIx64 "\n", data, addr);
+    switch(addr) {
+        case 0x8:
+            if (data) {
+                printf(">>> Halting execution!\n");
+                uc_emu_stop(uc);
+            }
+
+        default:
+            break;
+    }
+}
+
+const uint8_t prog[] = {
+    0x01, 0xDA, 0xA0, 0xE3, 0x03, 0x00, 0x00, 0xEB, 0x01, 0x3A, 0xA0, 0xE3, 0x01, 0x20, 0xA0, 0xE3,
+    0x08, 0x20, 0x83, 0xE5, 0x1E, 0xFF, 0x2F, 0xE1, 0x01, 0x3A, 0xA0, 0xE3, 0x2C, 0x20, 0x9F, 0xE5,
+    0x04, 0x10, 0x93, 0xE5, 0x02, 0x00, 0x51, 0xE1, 0x01, 0x00, 0x00, 0x0A, 0x01, 0x20, 0xA0, 0xE3,
+    0x08, 0x20, 0x83, 0xE5, 0x00, 0x20, 0x93, 0xE5, 0x04, 0x00, 0x52, 0xE3, 0xFA, 0xFF, 0xFF, 0x8A,
+    0x00, 0x20, 0x93, 0xE5, 0x04, 0x00, 0x52, 0xE3, 0xF9, 0xFF, 0xFF, 0x9A, 0xF6, 0xFF, 0xFF, 0xEA,
+    0xEF, 0xBE, 0xAD, 0xDE
+};
+
+// prog checks for the magic value, loops until the counter is at 5, and then tells the emulator to halt.
+
+int main() {
+    #ifdef DYNLOAD
+        if (!uc_dyn_load(NULL, 0)) {
+            printf("Error dynamically loading shared library.\n");
+            printf("Please check that unicorn.dll/unicorn.so is available as well as\n");
+            printf("any other dependent dll/so files.\n");
+            printf("The easiest way is to place them in the same directory as this app.\n");
+            return 1;
+        }
+    #endif
+
+    uc_engine *uc;
+    uc_err err;
+
+    // Initialize emulator in ARM mode
+    err = uc_open(UC_ARCH_ARM, UC_MODE_ARM, &uc);
+    if (err) {
+        printf("not ok - Failed on uc_open() with error: %s\n", uc_strerror(err));
+        return 1;
+    }
+
+    // Map a page for execution and stack.
+    uc_mem_map(uc, 0x0, 0x1000, UC_PROT_ALL);
+    if (uc_mem_write(uc, 0x0, prog, sizeof(prog))) {
+        printf("not ok - Failed to write emulation code to memory, quit!\n");
+        return 1;
+    }
+    // Map a page for IO
+    uc_mmio_map(uc, 0x1000, 0x1000, read_cb, write_cb, NULL);
+
+    printf("BEGINNING EXECUTION\n");
+    err = uc_emu_start(uc, 0x0, 0x1000, 0, 0);
+    printf("Execution stopped with: %s\n", uc_strerror(err));
+    print_ctx(uc);
+
+    // Unmap the IO page.
+    uc_mem_unmap(uc, 0x1000, 0x1000);
+    uc_close(uc);
+
+    #ifdef DYNLOAD
+        uc_dyn_free();
+    #endif
+
+    return 0;
+}

--- a/uc.c
+++ b/uc.c
@@ -351,7 +351,7 @@ uc_err uc_close(uc_engine *uc)
     // finally, free uc itself.
     memset(uc, 0, sizeof(*uc));
     free(uc);
-    
+
     return UC_ERR_OK;
 }
 
@@ -728,6 +728,25 @@ uc_err uc_mem_map(uc_engine *uc, uint64_t address, size_t size, uint32_t perms)
         return res;
 
     return mem_map(uc, address, size, perms, uc->memory_map(uc, address, size, perms));
+}
+
+UNICORN_EXPORT
+uc_err uc_mmio_map(uc_engine *uc, uint64_t address, size_t size, uc_cb_mmio_read read_cb, uc_cb_mmio_write write_cb, void *user_data)
+{
+    uc_err res;
+    struct mmio_data *data;
+
+    if (uc->mem_redirect) {
+        address = uc->mem_redirect(address);
+    }
+
+    res = mem_map_check(uc, address, size, UC_PROT_ALL);
+    if (res)
+        return res;
+
+    // The callbacks do not need to be checked for NULL here, as their presence
+    // (or lack thereof) will determine the permissions used.
+    return mem_map(uc, address, size, UC_PROT_NONE, uc->memory_map_io(uc, address, size, read_cb, write_cb, user_data));
 }
 
 UNICORN_EXPORT


### PR DESCRIPTION
Could fix #565.

I don't expect this to be accepted, given complaints before about a new function like this creating inconsistant API, but I figured that I'd polish up and fix the issues with my old PR (#627) before starting on anything else, as I feel like this is the best/cleanest way to do it with the facilities available.

This comes with an example of using the new function created, `uc_mmio_map`.

I have verified that no memory leaks are caused when used in this manner. However, perhaps I need to do something more, as currently some memory is leaked if you do not unmap the IO memory before closing the engine. (maybe I need to add my freeing code to `memory_free` as well as `memory_unmap`?)