### PR TITLE
call handle_mmu_fault from CPUClass

### DIFF
--- a/qemu/target-arm/cpu.c
+++ b/qemu/target-arm/cpu.c
@@ -1062,9 +1062,8 @@ static void arm_cpu_class_init(struct uc_struct *uc, ObjectClass *oc, void *data
     cc->cpu_exec_interrupt = arm_cpu_exec_interrupt;
     //cc->dump_state = arm_cpu_dump_state;
     cc->set_pc = arm_cpu_set_pc;
-#ifdef CONFIG_USER_ONLY
     cc->handle_mmu_fault = arm_cpu_handle_mmu_fault;
-#else
+#ifndef CONFIG_USER_ONLY
     cc->do_interrupt = arm_cpu_do_interrupt;
     cc->get_phys_page_debug = arm_cpu_get_phys_page_debug;
 #endif
@@ -1088,7 +1087,7 @@ static void cpu_register(struct uc_struct *uc, const ARMCPUInfo *info)
 void arm_cpu_register_types(void *opaque)
 {
     const ARMCPUInfo *info = arm_cpus;
-    
+
     TypeInfo arm_cpu_type_info = { 0 };
     arm_cpu_type_info.name = TYPE_ARM_CPU,
     arm_cpu_type_info.parent = TYPE_CPU,

--- a/qemu/target-arm/op_helper.c
+++ b/qemu/target-arm/op_helper.c
@@ -65,8 +65,9 @@ void tlb_fill(CPUState *cs, target_ulong addr, int is_write, int mmu_idx,
               uintptr_t retaddr)
 {
     int ret;
+    CPUClass *cc = CPU_GET_CLASS(cs->uc, cs);
 
-    ret = arm_cpu_handle_mmu_fault(cs, addr, is_write, mmu_idx);
+    ret = cc->handle_mmu_fault(cs, addr, is_write, mmu_idx);
     if (unlikely(ret)) {
         ARMCPU *cpu = ARM_CPU(cs->uc, cs);
         CPUARMState *env = &cpu->env;

--- a/qemu/target-i386/cpu.c
+++ b/qemu/target-i386/cpu.c
@@ -2586,9 +2586,8 @@ static void x86_cpu_common_class_init(struct uc_struct *uc, ObjectClass *oc, voi
     cc->synchronize_from_tb = x86_cpu_synchronize_from_tb;
     cc->get_arch_id = x86_cpu_get_arch_id;
     cc->get_paging_enabled = x86_cpu_get_paging_enabled;
-#ifdef CONFIG_USER_ONLY
     cc->handle_mmu_fault = x86_cpu_handle_mmu_fault;
-#else
+#ifndef CONFIG_USER_ONLY
     cc->get_memory_mapping = x86_cpu_get_memory_mapping;
     cc->get_phys_page_debug = x86_cpu_get_phys_page_debug;
 #endif

--- a/qemu/target-i386/mem_helper.c
+++ b/qemu/target-i386/mem_helper.c
@@ -114,8 +114,9 @@ void tlb_fill(CPUState *cs, target_ulong addr, int is_write, int mmu_idx,
               uintptr_t retaddr)
 {
     int ret;
+    CPUClass *cc = CPU_GET_CLASS(cs->uc, cs);
 
-    ret = x86_cpu_handle_mmu_fault(cs, addr, is_write, mmu_idx);
+    ret = cc->handle_mmu_fault(cs, addr, is_write, mmu_idx);
     if (ret) {
         X86CPU *cpu = X86_CPU(cs->uc, cs);
         CPUX86State *env = &cpu->env;

--- a/qemu/target-m68k/cpu.c
+++ b/qemu/target-m68k/cpu.c
@@ -190,9 +190,8 @@ static void m68k_cpu_class_init(struct uc_struct *uc, ObjectClass *c, void *data
     cc->do_interrupt = m68k_cpu_do_interrupt;
     cc->cpu_exec_interrupt = m68k_cpu_exec_interrupt;
     cc->set_pc = m68k_cpu_set_pc;
-#ifdef CONFIG_USER_ONLY
     cc->handle_mmu_fault = m68k_cpu_handle_mmu_fault;
-#else
+#ifndef CONFIG_USER_ONLY
     cc->get_phys_page_debug = m68k_cpu_get_phys_page_debug;
 #endif
     cc->cpu_exec_enter = m68k_cpu_exec_enter;
@@ -215,11 +214,11 @@ void m68k_cpu_register_types(void *opaque)
     const TypeInfo m68k_cpu_type_info = {
         TYPE_M68K_CPU,
         TYPE_CPU,
-        
+
         sizeof(M68kCPUClass),
         sizeof(M68kCPU),
         opaque,
-        
+
         m68k_cpu_initfn,
         NULL,
         NULL,

--- a/qemu/target-m68k/op_helper.c
+++ b/qemu/target-m68k/op_helper.c
@@ -42,8 +42,9 @@ void tlb_fill(CPUState *cs, target_ulong addr, int is_write, int mmu_idx,
               uintptr_t retaddr)
 {
     int ret;
+    CPUClass *cc = CPU_GET_CLASS(cs->uc, cs);
 
-    ret = m68k_cpu_handle_mmu_fault(cs, addr, is_write, mmu_idx);
+    ret = cc->handle_mmu_fault(cs, addr, is_write, mmu_idx);
     if (unlikely(ret)) {
         if (retaddr) {
             /* now we have a real cpu fault */

--- a/qemu/target-mips/cpu.c
+++ b/qemu/target-mips/cpu.c
@@ -134,9 +134,8 @@ static void mips_cpu_class_init(struct uc_struct *uc, ObjectClass *c, void *data
     cc->cpu_exec_interrupt = mips_cpu_exec_interrupt;
     cc->set_pc = mips_cpu_set_pc;
     cc->synchronize_from_tb = mips_cpu_synchronize_from_tb;
-#ifdef CONFIG_USER_ONLY
     cc->handle_mmu_fault = mips_cpu_handle_mmu_fault;
-#else
+#ifndef CONFIG_USER_ONLY
     cc->do_unassigned_access = mips_cpu_unassigned_access;
     cc->do_unaligned_access = mips_cpu_do_unaligned_access;
     cc->get_phys_page_debug = mips_cpu_get_phys_page_debug;
@@ -148,11 +147,11 @@ void mips_cpu_register_types(void *opaque)
     const TypeInfo mips_cpu_type_info = {
         TYPE_MIPS_CPU,
         TYPE_CPU,
-        
+
         sizeof(MIPSCPUClass),
         sizeof(MIPSCPU),
         opaque,
-        
+
         mips_cpu_initfn,
         NULL,
         NULL,

--- a/qemu/target-mips/op_helper.c
+++ b/qemu/target-mips/op_helper.c
@@ -2304,8 +2304,9 @@ void tlb_fill(CPUState *cs, target_ulong addr, int is_write, int mmu_idx,
               uintptr_t retaddr)
 {
     int ret;
+    CPUClass *cc = CPU_GET_CLASS(cs->uc, cs);
 
-    ret = mips_cpu_handle_mmu_fault(cs, addr, is_write, mmu_idx);
+    ret = cc->handle_mmu_fault(cs, addr, is_write, mmu_idx);
     if (ret) {
         MIPSCPU *cpu = MIPS_CPU(cs->uc, cs);
         CPUMIPSState *env = &cpu->env;

--- a/qemu/target-sparc/cpu.c
+++ b/qemu/target-sparc/cpu.c
@@ -886,9 +886,8 @@ static void sparc_cpu_class_init(struct uc_struct *uc, ObjectClass *oc, void *da
 #endif
     cc->set_pc = sparc_cpu_set_pc;
     cc->synchronize_from_tb = sparc_cpu_synchronize_from_tb;
-#ifdef CONFIG_USER_ONLY
     cc->handle_mmu_fault = sparc_cpu_handle_mmu_fault;
-#else
+#ifndef CONFIG_USER_ONLY
     cc->do_unassigned_access = sparc_cpu_unassigned_access;
     cc->do_unaligned_access = sparc_cpu_do_unaligned_access;
     cc->get_phys_page_debug = sparc_cpu_get_phys_page_debug;
@@ -900,15 +899,15 @@ void sparc_cpu_register_types(void *opaque)
     const TypeInfo sparc_cpu_type_info = {
         TYPE_SPARC_CPU,
         TYPE_CPU,
-        
+
         sizeof(SPARCCPUClass),
         sizeof(SPARCCPU),
         opaque,
-        
+
         sparc_cpu_initfn,
         NULL,
         sparc_cpu_uninitfn,
-        
+
         NULL,
 
         sparc_cpu_class_init,

--- a/qemu/target-sparc/ldst_helper.c
+++ b/qemu/target-sparc/ldst_helper.c
@@ -2448,8 +2448,9 @@ void tlb_fill(CPUState *cs, target_ulong addr, int is_write, int mmu_idx,
               uintptr_t retaddr)
 {
     int ret;
+    CPUClass *cc = CPU_GET_CLASS(cs->uc, cs);
 
-    ret = sparc_cpu_handle_mmu_fault(cs, addr, is_write, mmu_idx);
+    ret = cc->handle_mmu_fault(cs, addr, is_write, mmu_idx);
     if (ret) {
         if (retaddr) {
             cpu_restore_state(cs, retaddr);


### PR DESCRIPTION
Always fill handle_mmu_fault in CPUClass with arch-specific
handler, and calls from there in tlb_fill().

This brought the possiblity to overriding the builtin
memory management machenisms in the future.

Signed-off-by: vardyh <vardyh@huorong.cn>