### PR TITLE
Don't clobber EIP after non INT/SYSCALL exception

### DIFF
--- a/qemu/cpu-exec.c
+++ b/qemu/cpu-exec.c
@@ -143,8 +143,10 @@ int cpu_exec(struct uc_struct *uc, CPUArchState *env)   // qq
                     }
                     cpu->exception_index = -1;
 #if defined(TARGET_X86_64)
-                    // point EIP to the next instruction after INT
-                    env->eip = env->exception_next_eip;
+                    if (env->exception_is_int) {
+                        // point EIP to the next instruction after INT
+                        env->eip = env->exception_next_eip;
+                    }
 #endif
 #if defined(TARGET_MIPS) || defined(TARGET_MIPS64)
                     env->active_tc.PC = uc->next_pc;


### PR DESCRIPTION
Fixes #872 