### PR TITLE
Fix pausing within Thumb2 ITE blocks (#853)

### DIFF
--- a/qemu/target-arm/translate.c
+++ b/qemu/target-arm/translate.c
@@ -10425,17 +10425,23 @@ static void disas_thumb_insn(CPUARMState *env, DisasContext *s) // qq
     // Unicorn: trace this instruction on request
     if (HOOK_EXISTS_BOUNDED(s->uc, UC_HOOK_CODE, s->pc)) {
         // determine instruction size (Thumb/Thumb2)
-        switch(insn & 0xf800) {
-            // Thumb2: 32-bit
-            case 0xe800:
-            case 0xf000:
-            case 0xf800:
-                gen_uc_tracecode(tcg_ctx, 4, UC_HOOK_CODE_IDX, s->uc, s->pc);
-                break;
-            // Thumb: 16-bit
-            default:
-                gen_uc_tracecode(tcg_ctx, 2, UC_HOOK_CODE_IDX, s->uc, s->pc);
-                break;
+        // avoid terminating inside ITE clause
+        if (s->condexec_mask == 0) {
+            switch(insn & 0xf800) {
+                // Thumb2: 32-bit
+                case 0xe800:
+                case 0xf000:
+                case 0xf800:
+                    gen_uc_tracecode(tcg_ctx, 4, UC_HOOK_CODE_IDX, s->uc, s->pc);
+                    break;
+                // Thumb: 16-bit
+                default:
+                    // avoid terminating at an IT instruction
+                    if (!((insn & 0xff00) == 0xbf00)) {
+                        gen_uc_tracecode(tcg_ctx, 2, UC_HOOK_CODE_IDX, s->uc, s->pc);
+                    }
+                    break;
+            }
         }
         // the callback might want to stop emulation immediately
         check_exit_request(tcg_ctx);


### PR DESCRIPTION
A fix to issue #853 where restarting the emulator during ITE instructions would lead to incorrect operations.

While there seems to be code addressing the topic using condexec_bits, locating their underlying issue may be a better fix for another time. This solution ignores tracing instructions within ITE blocks (where condexec_mask should be greater than zero) and on IT instructions which prevents emulation from halting and breaking the code.