### PR TITLE
Ruby: Support reading and writing x86 FPU stack registers

### DIFF
--- a/bindings/ruby/unicorn_gem/ext/types.h
+++ b/bindings/ruby/unicorn_gem/ext/types.h
@@ -1,0 +1,25 @@
+/*
+
+Ruby bindings for the Unicorn Emulator Engine
+
+Copyright(c) 2016 Sascha Schirra
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+version 2 as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+*/
+
+typedef struct uc_x86_float80 {
+    uint64_t mantissa;
+    uint16_t exponent;
+} uc_x86_float80;

--- a/bindings/ruby/unicorn_gem/unicorn.gemspec
+++ b/bindings/ruby/unicorn_gem/unicorn.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Ruby binding for Unicorn-Engine <unicorn-engine.org>}
   spec.homepage      = "https://unicorn-engine.org"
 
-  spec.files         = Dir["lib/unicorn/*.rb"] + Dir["ext/unicorn.c"] + Dir["ext/unicorn.h"] + Dir["ext/extconf.rb"]
+  spec.files         = Dir["lib/unicorn/*.rb"] + Dir["ext/unicorn.c"] + Dir["ext/unicorn.h"] + Dir["ext/types.h"] + Dir["ext/extconf.rb"]
   spec.require_paths = ["lib","ext"]
   spec.extensions    = ["ext/extconf.rb"]
   spec.add_development_dependency "bundler", "~> 1.11"


### PR DESCRIPTION
In order to reduce rounding problems from calculations, FPU stack registers for x86 architectures contain values stored in an 80-bit extended precision format.

As a result, reading and writing to these registers requires specific handling.

This update brings the Ruby bindings in line with the Python bindings by supporting reading and writing the FPU stack registers using 2-element arrays: [mantissa, exponent]

The mantissa array element contains the first 64 bits of the FPU stack register.

The exponent array element contains the last 16 bits of the FPU stack register.

Closes #891