### PR TITLE
Cleanups/fixes for the library issue conglomerate

### DIFF
--- a/bindings/python/README.TXT
+++ b/bindings/python/README.TXT
@@ -8,6 +8,11 @@ from source.
 	This will build the core C library, package it with the python bindings, 
 	and install it to your system.
 
+    If you want to prevent the build of the native library during the python installation,
+    set the environment variable LIBUNICORN_PATH. You may also set this to a directory
+    containing libunicorn.so if you wish to use a verison of the native library other than
+    the globally installed one.
+
 
 2. Installing on Windows:
 

--- a/bindings/python/unicorn/unicorn.py
+++ b/bindings/python/unicorn/unicorn.py
@@ -71,13 +71,15 @@ def _load_lib(path):
 _uc = None
 
 # Loading attempts, in order
+# - user-provided environment variable
 # - pkg_resources can get us the path to the local libraries
 # - we can get the path to the local libraries by parsing our filename
 # - global load
 # - python's lib directory
 # - last-gasp attempt at some hardcoded paths on darwin and linux
 
-_path_list = [pkg_resources.resource_filename(__name__, 'lib'),
+_path_list = [os.getenv('LIBUNICORN_PATH', None),
+              pkg_resources.resource_filename(__name__, 'lib'),
               os.path.join(os.path.split(__file__)[0], 'lib'),
               '',
               distutils.sysconfig.get_python_lib(),
@@ -88,6 +90,7 @@ _path_list = [pkg_resources.resource_filename(__name__, 'lib'),
 #print("-" * 80)
 
 for _path in _path_list:
+    if _path is None: continue
     _uc = _load_lib(_path)
     if _uc is not None: break
 else:


### PR DESCRIPTION
- I tried to use pkgconfig, but then I realized that this would seriously complicate building for distribution when the distributor has the library is installed globally (likely). I opted for the simpler environment variable approach instead.
- I disabled the distribution of the static library on linux and macos. On windows it is required because even if a DLL is present, the LIB must also be present in order to build against it. Yell at the msvc people, not me.