### PR TITLE
Move to new OSX dependency management system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 sudo: false
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cmocka crosstool-ng; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap Homebrew/bundle && brew bundle; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./install-cmocka-linux.sh; fi
 script:
   - make && make -C bindings/go && make -C bindings/go test && make test

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+brew "cmocka"
+brew "crosstool-ng"

--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,4 @@
+# used for testing framework
 brew "cmocka"
+# used for cross assembly of code for testing
 brew "crosstool-ng"


### PR DESCRIPTION
prevents issues stemming from brew's "already installed package" error

been using for a while and can recommend