### PR TITLE
only build brew HEAD on master and rm trusty jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,12 @@ os:
   - osx
 matrix:
   include:
-    - os: linux
-      dist: trusty
-      compiler: gcc
-    - os: linux
-      dist: trusty
-      compiler: clang
-    - os: osx
+    - if: branch = master
+      os: osx
       script: brew install --HEAD unicorn && brew test unicorn
       compiler: gcc
-    - os: osx
+    - if: branch = master
+      os: osx
       script: brew install --HEAD unicorn && brew test unicorn
       compiler: clang
   allow_failures:


### PR DESCRIPTION
brew HEAD pulls from master, so it only makes sense to build on master

trusty is now the travis default, explicit jobs are no longer required