### PR TITLE
changed gem name to unicorn-engine

### DIFF
--- a/bindings/ruby/Makefile
+++ b/bindings/ruby/Makefile
@@ -5,7 +5,7 @@
 # Use bundle install && rake to install gem and test
 install: gen_const
 	cd unicorn_gem && rake build
-	cd unicorn_gem && gem install --local pkg/unicorn_engine-1.0.0.gem
+	cd unicorn_gem && gem install --local pkg/unicorn-engine-1.0.0.gem
 
 gen_const:
 	cd .. && python const_generator.py ruby

--- a/bindings/ruby/unicorn_gem/unicorn.gemspec
+++ b/bindings/ruby/unicorn_gem/unicorn.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'unicorn_engine/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "unicorn_engine"
+  spec.name          = "unicorn-engine"
   spec.version       = Unicorn::VERSION
   spec.authors       = ["Sascha Schirra"]
   spec.email         = ["sashs@scoding.de"]


### PR DESCRIPTION
Hi, 

I changed the name of the gem to unicorn-engine. This name is used when you install the gem from rubygems. 

regards