### PR TITLE
Fix Java Makefile on macOS

### DIFF
--- a/bindings/java/Makefile
+++ b/bindings/java/Makefile
@@ -15,6 +15,9 @@ jar:
 install: lib jar
 	$(MAKE) -f Makefile.build install
 
+uninstall:
+		$(MAKE) -f Makefile.build uninstall
+
 gen_const:
 	cd .. && python const_generator.py java
 

--- a/bindings/java/Makefile.build
+++ b/bindings/java/Makefile.build
@@ -15,8 +15,7 @@ SRC := $(shell ls unicorn/*.java)
 OS := $(shell uname)
 ifeq ($(OS),Darwin)
    LIB_EXT=.dylib
-endif
-ifeq ($(OS),Linux)
+else ifeq ($(OS),Linux)
    LIB_EXT=.so
 else
    LIB_EXT=.dll
@@ -48,7 +47,7 @@ all: lib jar samples
 
 unicorn_Unicorn.h: unicorn/Unicorn.java
 	javah unicorn.Unicorn
-	
+
 unicorn_Unicorn.o: unicorn_Unicorn.c unicorn_Unicorn.h
 	$(CC) -c $(CFLAGS) $(INCS) $< -o $@
 
@@ -61,11 +60,15 @@ samples: $(SAMPLES:.java=.class)
 jarfiles: $(SRC:.java=.class)
 
 jar: jarfiles
-	jar cf $(JARFILE) unicorn/*.class 
+	jar cf $(JARFILE) unicorn/*.class
 
 install: lib jar
 	cp libunicorn_java$(LIB_EXT) $(JAVA_HOME)/lib/ext
 	cp $(JARFILE) $(JAVA_HOME)/lib/ext
+
+uninstall:
+	rm $(JAVA_HOME)/lib/ext/libunicorn_java$(LIB_EXT)
+	rm $(JAVA_HOME)/lib/ext/$(JARFILE)
 
 gen_const:
 	cd .. && python const_generator.py java

--- a/bindings/java/README.TXT
+++ b/bindings/java/README.TXT
@@ -32,3 +32,6 @@ The samples directory contains some sample code to show how to use Unicorn API.
 - SampleNetworkAuditing.java
   Unicorn sample for auditing network connection and file handling in shellcode.
 
+To uninstall Java binding for Unicorn:
+
+   $ sudo make uninstall


### PR DESCRIPTION
* Fixes the logic for Dylib extensions on macOS.  The logic would previously use the .dll extension instead of .dylib
* Adds an uninstall task and documentation.