### PR TITLE
New API to set a code exec barrier

### DIFF
--- a/include/uc_priv.h
+++ b/include/uc_priv.h
@@ -233,6 +233,9 @@ struct uc_struct {
 
     uint64_t addr_end;  // address where emulation stops (@end param of uc_emu_start())
 
+    uint64_t code_exec_barrier_start;  // start address where code execution is valid 
+    uint64_t code_exec_barrier_end;  // end address where code execution is valid 
+
     int thumb;  // thumb mode for ARM
     // full TCG cache leads to middle-block break in the last translation?
     bool block_full;

--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -498,6 +498,21 @@ UNICORN_EXPORT
 uc_err uc_mem_read(uc_engine *uc, uint64_t address, void *bytes, size_t size);
 
 /*
+Set the barrier for a valid code exec range.
+
+@uc: handle returned by uc_open()
+@barrier_start: starting memory address of the barrier
+@barrier_end: ending memory address of the barrier
+
+NOTE: @barrier_start and @barrier_end == 0 means no barrier
+
+@return UC_ERR_OK on success, or other value on failure (refer to uc_err enum
+for detailed error).
+*/
+UNICORN_EXPORT
+uc_err uc_code_barrier(uc_engine *uc, uint64_t barrier_start, uint64_t barrier_end);
+
+/*
  Emulate machine code in a specific duration of time.
 
  @uc: handle returned by uc_open()

--- a/uc.c
+++ b/uc.c
@@ -355,6 +355,18 @@ uc_err uc_close(uc_engine *uc)
     return UC_ERR_OK;
 }
 
+UNICORN_EXPORT
+uc_err uc_code_barrier(uc_engine *uc, uint64_t barrier_start, uint64_t barrier_end) 
+{
+	if (barrier_end < barrier_start) {
+		return -1; // FIXME: need a proper uc_err
+	}
+
+	uc->code_exec_barrier_start = barrier_start;
+	uc->code_exec_barrier_end = barrier_end;
+
+	return UC_ERR_OK;
+}
 
 UNICORN_EXPORT
 uc_err uc_reg_read_batch(uc_engine *uc, int *ids, void **vals, int count)


### PR DESCRIPTION
Usefull when you execute code inside a valid image range

uc_err uc_code_barrier(uc_engine *uc, uint64_t barrier_start, uint64_t barrier_end)

barrier_start: Start address of the barrier
barrier_end: End address of the barrier

if barrier_start and barrier_end == 0 then 'No barrier is set'