### PR TITLE
Added a continue function that can be used to continue the emulation …

### DIFF
--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -515,6 +515,23 @@ UNICORN_EXPORT
 uc_err uc_emu_start(uc_engine *uc, uint64_t begin, uint64_t until, uint64_t timeout, size_t count);
 
 /*
+ Coninue to Emulate machine code in a specific duration of time from the last
+ time it stopped.
+
+ @uc: handle returned by uc_open()
+ @until: address where emulation stops (i.e when this address is hit)
+ @timeout: duration to emulate the code (in microseconds). When this value is 0,
+        we will emulate the code in infinite time, until the code is finished.
+ @count: the number of instructions to be emulated. When this value is 0,
+        we will emulate all the code available, until the code is finished.
+
+ @return UC_ERR_OK on success, or other value on failure (refer to uc_err enum
+   for detailed error).
+*/
+UNICORN_EXPORT
+uc_err uc_emu_continue(uc_engine *uc, uint64_t until, uint64_t timeout, size_t count);
+
+/*
  Stop emulation (which was started by uc_emu_start() API.
  This is typically called from callback functions registered via tracing APIs.
 

--- a/uc.c
+++ b/uc.c
@@ -529,12 +529,7 @@ static void hook_count_cb(struct uc_struct *uc, uint64_t address, uint32_t size,
 UNICORN_EXPORT
 uc_err uc_emu_start(uc_engine* uc, uint64_t begin, uint64_t until, uint64_t timeout, size_t count)
 {
-    // reset the counter
-    uc->emu_counter = 0;
-    uc->invalid_error = UC_ERR_OK;
-    uc->block_full = false;
-    uc->emulation_done = false;
-
+    // Set the Address Register
     switch(uc->arch) {
         default:
             break;
@@ -583,6 +578,19 @@ uc_err uc_emu_start(uc_engine* uc, uint64_t begin, uint64_t until, uint64_t time
             break;
 #endif
     }
+
+
+    return uc_emu_continue(uc, until, timeout, count);
+}
+
+UNICORN_EXPORT
+uc_err uc_emu_continue(uc_engine* uc, uint64_t until, uint64_t timeout, size_t count)
+{
+    // reset the counter
+    uc->emu_counter = 0;
+    uc->invalid_error = UC_ERR_OK;
+    uc->block_full = false;
+    uc->emulation_done = false;
 
     uc->stop_request = false;
 


### PR DESCRIPTION
…after it has been stopped

Hey, I noticed there is no easy way to run say 10 cycles at a time and then go do other stuff. Seems like you would have to call uc_emu_start and keep track of the current address register every time though the loop. I know I could use hooks to stop every 10 cycles, but I would like to run multiple different instances of unicorn simultaneously and asynchronously.

I know it isn't a complete change, I probably need to write tests and update the other language bindings (I have no idea how to do that). But before I jumped in with that stuff I wanted your thoughts.