### PR TITLE
Use python2 rather than python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ all: unicorn
 
 qemu/config-host.h-timestamp:
 	cd qemu && \
-	./configure --cc="${CC}" --extra-cflags="$(UNICORN_CFLAGS)" --target-list="$(UNICORN_TARGETS)" ${UNICORN_QEMU_FLAGS}
+	./configure --cc="${CC}" --extra-cflags="$(UNICORN_CFLAGS)" --target-list="$(UNICORN_TARGETS)" --python=python2 ${UNICORN_QEMU_FLAGS}
 	printf "$(UNICORN_ARCHS)" > config.log
 	$(MAKE) -C qemu $(SMP_MFLAGS)
 	$(eval UC_TARGET_OBJ += $$(wildcard qemu/util/*.o) $$(wildcard qemu/*.o) $$(wildcard qemu/qom/*.o) $$(wildcard qemu/hw/core/*.o) $$(wildcard qemu/qapi/*.o) $$(wildcard qemu/qobject/*.o))
@@ -306,7 +306,7 @@ header:
 	$(eval TARGETS := m68k arm armeb aarch64 aarch64eb mips mipsel mips64 mips64el\
 		powerpc sparc sparc64 x86_64)
 	$(foreach var,$(TARGETS),\
-		$(shell python qemu/header_gen.py $(var) > qemu/$(var).h;))
+		$(shell python2 qemu/header_gen.py $(var) > qemu/$(var).h;))
 	@echo "Generated headers for $(TARGETS)."
 
 

--- a/bindings/python/sample_arm.py
+++ b/bindings/python/sample_arm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Sample code for ARM of Unicorn. Nguyen Anh Quynh <aquynh@gmail.com>
 # Python sample ported by Loi Anh Tuan <loianhtuan@gmail.com>
 

--- a/bindings/python/sample_arm64.py
+++ b/bindings/python/sample_arm64.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Sample code for ARM64 of Unicorn. Nguyen Anh Quynh <aquynh@gmail.com>
 # Python sample ported by Loi Anh Tuan <loianhtuan@gmail.com>
 

--- a/bindings/python/sample_arm64eb.py
+++ b/bindings/python/sample_arm64eb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Sample code for ARM64 of Unicorn. Nguyen Anh Quynh <aquynh@gmail.com>
 # Python sample ported by Loi Anh Tuan <loianhtuan@gmail.com>
 # AARCH64 Python sample ported by zhangwm <rustydaar@gmail.com>

--- a/bindings/python/sample_armeb.py
+++ b/bindings/python/sample_armeb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Sample code for ARM big endian of Unicorn. zhangwm <rustydaar@gmail.com>
 
 from __future__ import print_function

--- a/bindings/python/sample_m68k.py
+++ b/bindings/python/sample_m68k.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Sample code for ARM of Unicorn. Nguyen Anh Quynh <aquynh@gmail.com>
 # Python sample ported by Loi Anh Tuan <loianhtuan@gmail.com>
 

--- a/bindings/python/sample_mips.py
+++ b/bindings/python/sample_mips.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Sample code for MIPS of Unicorn. Nguyen Anh Quynh <aquynh@gmail.com>
 # Python sample ported by Loi Anh Tuan <loianhtuan@gmail.com>
 

--- a/bindings/python/sample_network_auditing.py
+++ b/bindings/python/sample_network_auditing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Unicorn sample for auditing network connection and file handling in shellcode.
 # Nguyen Tan Cong <shenlongbk@gmail.com>
 

--- a/bindings/python/sample_sparc.py
+++ b/bindings/python/sample_sparc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Sample code for SPARC of Unicorn. Nguyen Anh Quynh <aquynh@gmail.com>
 # Python sample ported by Loi Anh Tuan <loianhtuan@gmail.com>
 

--- a/bindings/python/sample_x86.py
+++ b/bindings/python/sample_x86.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Sample code for X86 of Unicorn. Nguyen Anh Quynh <aquynh@gmail.com>
 
 from __future__ import print_function

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Python binding for Unicorn engine. Nguyen Anh Quynh <aquynh@gmail.com>
 
 from __future__ import print_function

--- a/bindings/python/shellcode.py
+++ b/bindings/python/shellcode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Sample code for X86 of Unicorn. Nguyen Anh Quynh <aquynh@gmail.com>
 
 from __future__ import print_function

--- a/tests/regress/arm_init_input_crash.py
+++ b/tests/regress/arm_init_input_crash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Sample code for ARM of Unicorn. Nguyen Anh Quynh <aquynh@gmail.com>
 # Python sample ported by Loi Anh Tuan <loianhtuan@gmail.com>
 #

--- a/tests/regress/callback-pc.py
+++ b/tests/regress/callback-pc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # reg_write() can't modify PC from within trace callbacks
 # issue #210

--- a/tests/regress/hook_add_crash.py
+++ b/tests/regress/hook_add_crash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """https://github.com/unicorn-engine/unicorn/issues/165"""
 

--- a/tests/regress/invalid_write.py
+++ b/tests/regress/invalid_write.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Test callback that returns False to cancel emulation
 
 from __future__ import print_function

--- a/tests/regress/jmp_ebx_hang.py
+++ b/tests/regress/jmp_ebx_hang.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """See https://github.com/unicorn-engine/unicorn/issues/82"""
 

--- a/tests/regress/jumping.py
+++ b/tests/regress/jumping.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Mariano Graziano
 
 from unicorn import *

--- a/tests/regress/memmap_segfault.py
+++ b/tests/regress/memmap_segfault.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import unicorn
 from unicorn import *

--- a/tests/regress/osx_qemu_thread_create_crash.py
+++ b/tests/regress/osx_qemu_thread_create_crash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import platform
 import resource

--- a/tests/regress/potential_memory_leak.py
+++ b/tests/regress/potential_memory_leak.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import platform
 import resource

--- a/tests/regress/reg_write_sign_extension.py
+++ b/tests/regress/reg_write_sign_extension.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """See https://github.com/unicorn-engine/unicorn/issues/98"""
 

--- a/tests/regress/segfault_on_stop.py
+++ b/tests/regress/segfault_on_stop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import regress
 import unicorn

--- a/tests/regress/vld.py
+++ b/tests/regress/vld.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Moshe Kravchik
 
 from __future__ import print_function

--- a/tests/regress/write_before_map.py
+++ b/tests/regress/write_before_map.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from __future__ import print_function
 from unicorn import *

--- a/tests/regress/x86_64_msr.py
+++ b/tests/regress/x86_64_msr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from unicorn import *
 from unicorn.x86_const import *
 from struct import pack

--- a/tests/regress/x86_fldt_fsqrt.py
+++ b/tests/regress/x86_fldt_fsqrt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from unicorn import *
 from unicorn.x86_const import *
 from struct import pack

--- a/tests/regress/x86_gdt.py
+++ b/tests/regress/x86_gdt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from unicorn import *
 from unicorn.x86_const import *
 from struct import pack

--- a/tests/regress/x86_self_modifying.py
+++ b/tests/regress/x86_self_modifying.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from unicorn import *
 from unicorn.x86_const import *
 from struct import pack


### PR DESCRIPTION
I maintain the Unicorn package for Fedora, and I recently found that the package failed to build. This appears due to Fedora's migration to Python 3 [1]. Namely, "Ensure that /usr/bin/python or /usr/bin/env python shebangs are replaced with either /usr/bin/python2 or /usr/bin/python3." PEP 394 [2] describes the over-arching Python plans which are driving this.

This pull request fixes the Fedora build by replacing "python" with "python2" in the top-level Makefile and making use of "--python=python2" when running QEMU's configure script. It also changes the shebangs used throughout Unicorn from "python" to "python2."

[1] https://fedoraproject.org/wiki/FinalizingFedoraSwitchtoPython3
[2] https://www.python.org/dev/peps/pep-0394/

Signed-off-by: W. Michael Petullo <mike@flyn.org>