### PR TITLE
[Fix] Fix a problem that use uc_reg_write to write fs, gs has no effets in x86 64-bit mode.

### DIFF
--- a/qemu/target-i386/unicorn.c
+++ b/qemu/target-i386/unicorn.c
@@ -1185,10 +1185,10 @@ int x86_reg_write(struct uc_struct *uc, unsigned int *regs, void *const *vals, i
                         X86_CPU(uc, mycpu)->env.segs[R_ES].selector = *(uint16_t *)value;
                         break;
                     case UC_X86_REG_FS:
-                        X86_CPU(uc, mycpu)->env.segs[R_FS].selector = *(uint16_t *)value;
+                        cpu_x86_load_seg(&X86_CPU(uc, mycpu)->env, R_FS, *(uint16_t *)value);
                         break;
                     case UC_X86_REG_GS:
-                        X86_CPU(uc, mycpu)->env.segs[R_GS].selector = *(uint16_t *)value;
+                        cpu_x86_load_seg(&X86_CPU(uc, mycpu)->env, R_GS, *(uint16_t *)value);
                         break;
                     case UC_X86_REG_R8:
                         X86_CPU(uc, mycpu)->env.regs[8] = *(uint64_t *)value;


### PR DESCRIPTION
I tested this code(before fix):
#----------------------------------
# setup GDT first
mov fs, rax;
mov qword ptr fs:0, 0
#----------------------------------
It works. Even tough I tested only in Unicorn Emulator, but since Unicorn is based on qemu, the result should be correct.

Maybe I should test that code on real CPU, but it is too complicated for me. So I turn to CPU's reference:

Intel® 64 and IA-32 Architectures Software Developer’s Manual Volume 3 (3A, 3B, 3C & 3D): System Programming Guide:
https://www.intel.com/content/www/us/en/architecture-and-technology/64-ia-32-architectures-software-developer-system-programming-manual-325384.html
and
AMD64 Architecture Programmer’s Manual Volume 2: System Programming:
http://developer.amd.com/wordpress/media/2012/10/24593_APM_v2.pdf

Both says that MOV or POP will change lower 32-bit of base address.(Intel : 3.4.4 Segment Loading Instructions in IA-32e Mode.  AMD: 4.5.3 Segment Registers in 64-Bit Mode)

I guess, uc_write_reg should act like a MOV instruction.
So writing into fs and gs should have effect, isn't it?