### PR TITLE
UC_HOOK_MEM_WRITE not firing on cmpxchg8b

### DIFF
--- a/qemu/include/exec/cpu_ldst_template.h
+++ b/qemu/include/exec/cpu_ldst_template.h
@@ -115,20 +115,12 @@ static inline void
 glue(glue(cpu_st, SUFFIX), MEMSUFFIX)(CPUArchState *env, target_ulong ptr,
                                       RES_TYPE v)
 {
-    int page_index;
     target_ulong addr;
     int mmu_idx;
 
     addr = ptr;
-    page_index = (addr >> TARGET_PAGE_BITS) & (CPU_TLB_SIZE - 1);
     mmu_idx = CPU_MMU_INDEX;
-    if (unlikely(env->tlb_table[mmu_idx][page_index].addr_write !=
-                 (addr & (TARGET_PAGE_MASK | (DATA_SIZE - 1))))) {
-        glue(glue(helper_st, SUFFIX), MMUSUFFIX)(env, addr, v, mmu_idx);
-    } else {
-        uintptr_t hostaddr = (uintptr_t)(addr + env->tlb_table[mmu_idx][page_index].addend);
-        glue(glue(st, SUFFIX), _raw)(hostaddr, v);
-    }
+    glue(glue(helper_st, SUFFIX), MMUSUFFIX)(env, addr, v, mmu_idx);
 }
 
 

--- a/qemu/include/exec/cpu_ldst_template.h
+++ b/qemu/include/exec/cpu_ldst_template.h
@@ -66,21 +66,13 @@
 static inline RES_TYPE
 glue(glue(cpu_ld, USUFFIX), MEMSUFFIX)(CPUArchState *env, target_ulong ptr)
 {
-    int page_index;
     RES_TYPE res;
     target_ulong addr;
     int mmu_idx;
 
     addr = ptr;
-    page_index = (addr >> TARGET_PAGE_BITS) & (CPU_TLB_SIZE - 1);
     mmu_idx = CPU_MMU_INDEX;
-    if (unlikely(env->tlb_table[mmu_idx][page_index].ADDR_READ !=
-                 (addr & (TARGET_PAGE_MASK | (DATA_SIZE - 1))))) {
-        res = glue(glue(helper_ld, SUFFIX), MMUSUFFIX)(env, addr, mmu_idx);
-    } else {
-        uintptr_t hostaddr = (uintptr_t)(addr + env->tlb_table[mmu_idx][page_index].addend);
-        res = glue(glue(ld, USUFFIX), _raw)(hostaddr);
-    }
+    res = glue(glue(helper_ld, SUFFIX), MMUSUFFIX)(env, addr, mmu_idx);
     return res;
 }
 
@@ -88,21 +80,14 @@ glue(glue(cpu_ld, USUFFIX), MEMSUFFIX)(CPUArchState *env, target_ulong ptr)
 static inline int
 glue(glue(cpu_lds, SUFFIX), MEMSUFFIX)(CPUArchState *env, target_ulong ptr)
 {
-    int res, page_index;
+    int res;
     target_ulong addr;
     int mmu_idx;
 
     addr = ptr;
-    page_index = (addr >> TARGET_PAGE_BITS) & (CPU_TLB_SIZE - 1);
     mmu_idx = CPU_MMU_INDEX;
-    if (unlikely(env->tlb_table[mmu_idx][page_index].ADDR_READ !=
-                 (addr & (TARGET_PAGE_MASK | (DATA_SIZE - 1))))) {
-        res = (DATA_STYPE)glue(glue(helper_ld, SUFFIX),
-                               MMUSUFFIX)(env, addr, mmu_idx);
-    } else {
-        uintptr_t hostaddr = (uintptr_t)(addr + env->tlb_table[mmu_idx][page_index].addend);
-        res = glue(glue(lds, SUFFIX), _raw)(hostaddr);
-    }
+    res = (DATA_STYPE)glue(glue(helper_ld, SUFFIX),
+                           MMUSUFFIX)(env, addr, mmu_idx);
     return res;
 }
 #endif

--- a/tests/regress/regress.sh
+++ b/tests/regress/regress.sh
@@ -19,4 +19,4 @@
 ./eflags_nosync
 ./mips_kseg0_1
 ./mem_double_unmap
-
+./x86_cmpxchg

--- a/tests/regress/x86_cmpxchg.c
+++ b/tests/regress/x86_cmpxchg.c
@@ -1,0 +1,58 @@
+#include <unicorn/unicorn.h>
+#include <assert.h>
+
+#define CODE "\x0F\xC7\x0D\xE0\xBE\xAD\xDE" // cmpxchg8b [0xdeadbee0]
+#define CODE_ADDR 0
+#define DATA_ADDR 0xdeadb000
+
+int read_happened = 0;
+int write_happened = 0;
+
+static void hook_mem(uc_engine *uc, uc_mem_type type,
+	uint64_t address, int size, int64_t value, void *user_data)
+{
+	switch (type) {
+	default: break;
+	case UC_MEM_READ:
+		read_happened = 1;
+		break;
+	case UC_MEM_WRITE:
+		write_happened = 1;
+		break;
+	}
+}
+
+int main(int argc, char **argv, char **envp)
+{
+	uc_engine *uc;
+	uc_hook trace1;
+	uint64_t buffer;
+
+	uc_open(UC_ARCH_X86, UC_MODE_32, &uc);
+	uc_mem_map(uc, CODE_ADDR, 0x1000, UC_PROT_ALL);
+	uc_mem_map(uc, DATA_ADDR, 0x1000, UC_PROT_ALL);
+	uc_mem_write(uc, CODE_ADDR, CODE, sizeof(CODE) - 1);
+	uc_hook_add(uc, &trace1, UC_HOOK_MEM_READ | UC_HOOK_MEM_WRITE, hook_mem, NULL, 1, 0);
+
+	// memory is initially zero
+	uc_mem_read(uc, 0xdeadbee0, &buffer, sizeof(buffer));
+	assert(buffer == 0x0000000000000000);
+
+	// mov edx:eax, 0x0000000000000000
+	// mov ecx:ebx, 0x4141414141414141
+	int zero = 0x00000000;
+	int AAAA = 0x41414141;
+	uc_reg_write(uc, UC_X86_REG_EDX, &zero);
+	uc_reg_write(uc, UC_X86_REG_EAX, &zero);
+	uc_reg_write(uc, UC_X86_REG_ECX, &AAAA);
+	uc_reg_write(uc, UC_X86_REG_EBX, &AAAA);
+	uc_emu_start(uc, CODE_ADDR, CODE_ADDR + sizeof(CODE) - 1, 0, 0);
+
+	// memory was written to at 0xdeadbee0, but no write hook fired!
+	uc_mem_read(uc, 0xdeadbee0, &buffer, sizeof(buffer));
+	assert(buffer == 0x4141414141414141);
+	assert(read_happened);
+	assert(write_happened);
+	printf("Test passed!\n");
+	return 0;
+}


### PR DESCRIPTION
Ensures that UC_HOOK_MEM_WRITE fires on cmpxchg8b by disabling MMU caching
at a level below where unicorn performs its hooking logic.

Adds a regression test.

Fixes unicorn-engine/unicorn#990