### PR TITLE
Makes SYSENTER hookable on x86

### DIFF
--- a/qemu/target-i386/unicorn.c
+++ b/qemu/target-i386/unicorn.c
@@ -1341,7 +1341,8 @@ static bool x86_insn_hook_validate(uint32_t insn_enum)
     //for x86 we can only hook IN, OUT, and SYSCALL
     if (insn_enum != UC_X86_INS_IN
         &&  insn_enum != UC_X86_INS_OUT
-        &&  insn_enum != UC_X86_INS_SYSCALL) {
+        &&  insn_enum != UC_X86_INS_SYSCALL
+        &&  insn_enum != UC_X86_INS_SYSENTER) {
         return false;
     }
     return true;

--- a/tests/regress/sysenter_hook_x86.c
+++ b/tests/regress/sysenter_hook_x86.c
@@ -36,7 +36,7 @@ int main(int argc, char **argv, char **envp)
   }
 
   // Hook the SYSENTER instructions
-  if (uc_hook_add (uc, &sysenterHook, UC_HOOK_INSN, sysenter, NULL, UC_X86_INS_SYSENTER, 1, 0) != UC_ERR_OK) {
+  if (uc_hook_add (uc, &sysenterHook, UC_HOOK_INSN, sysenter, NULL, 1, 0, UC_X86_INS_SYSENTER) != UC_ERR_OK) {
       printf ("Cannot hook SYSENTER instruction\n.");
       return -1;
   }


### PR DESCRIPTION
Adds SYSENTER to the whitelist of supported hookable instructions in unicorn
as well as fixes up the existing sysenter_hook_x86 regression test which was
previously failing

Fixes unicorn-engine/unicorn#995