### PR TITLE
Provide path to good python to qemu configure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ all: unicorn
 
 qemu/config-host.h-timestamp:
 	cd qemu && \
-	./configure --cc="${CC}" --extra-cflags="$(UNICORN_CFLAGS)" --target-list="$(UNICORN_TARGETS)" ${UNICORN_QEMU_FLAGS}
+	./configure --cc="${CC}" --extra-cflags="$(UNICORN_CFLAGS)" --target-list="$(UNICORN_TARGETS)" --python=`which python2` ${UNICORN_QEMU_FLAGS}
 	printf "$(UNICORN_ARCHS)" > config.log
 	$(MAKE) -C qemu $(SMP_MFLAGS)
 	$(eval UC_TARGET_OBJ += $$(wildcard qemu/util/*.o) $$(wildcard qemu/*.o) $$(wildcard qemu/qom/*.o) $$(wildcard qemu/hw/core/*.o) $$(wildcard qemu/qapi/*.o) $$(wildcard qemu/qobject/*.o))


### PR DESCRIPTION
If a system has python on the path point to python3 then the qemu build will fail to configure. This change configures qemu with an explicit path to python2.