### PR TITLE
Mips undefined shift fix

### DIFF
--- a/qemu/target-mips/translate.c
+++ b/qemu/target-mips/translate.c
@@ -34,7 +34,7 @@
 //#define MIPS_DEBUG_SIGN_EXTENSIONS
 
 /* MIPS major opcodes */
-#define MASK_OP_MAJOR(op)  (op & (0x3F << 26))
+#define MASK_OP_MAJOR(op)  (op & (((uint32_t)0x3F) << 26))
 
 enum {
     /* indirect opcode tables */


### PR DESCRIPTION
Found by oss-fuzz

Explicit cast to unsigned int is required in order to avoid undefined behavior on left shift hitting the most significant bit