### PR TITLE
Use latest qemu to avoid abort

### DIFF
--- a/qemu/target-arm/translate-a64.c
+++ b/qemu/target-arm/translate-a64.c
@@ -2619,9 +2619,9 @@ static void disas_ldst_single_struct(DisasContext *s, uint32_t insn)
         } else {
             /* Load/store one element per register */
             if (is_load) {
-                do_vec_ld(s, rt, index, tcg_addr, MO_TE + scale);
+                do_vec_ld(s, rt, index, tcg_addr, scale);
             } else {
-                do_vec_st(s, rt, index, tcg_addr, MO_TE + scale);
+                do_vec_st(s, rt, index, tcg_addr, scale);
             }
         }
         tcg_gen_addi_i64(tcg_ctx, tcg_addr, tcg_addr, ebytes);


### PR DESCRIPTION
As in #1021 this patch is inspired by current qemu version
This one avoids a later abort found by
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10459
