### PR TITLE
 [for osx mojave] remove i386 at line 120,121 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,8 +117,8 @@ AR_EXT = a
 UNICORN_CFLAGS += -fvisibility=hidden
 
 ifeq ($(MACOS_UNIVERSAL),yes)
-$(LIBNAME)_LDFLAGS += -m32 -arch i386 -m64 -arch x86_64
-UNICORN_CFLAGS += -m32 -arch i386 -m64 -arch x86_64
+$(LIBNAME)_LDFLAGS += -m64 -arch x86_64
+UNICORN_CFLAGS += -m64 -arch x86_64
 endif
 
 # Cygwin?


### PR DESCRIPTION
#1031 #1029


** Capstone have same problem and it is changed! 

macOS 10.14 (Mojave) deprecated support for i386 so removing it from

https://github.com/unicorn-engine/unicorn/Makefile#L120
https://github.com/unicorn-engine/unicorn/Makefile#L121