### PR TITLE
Add support for virtual memory access, with Python bindings

### DIFF
--- a/bindings/python/unicorn/unicorn.py
+++ b/bindings/python/unicorn/unicorn.py
@@ -126,6 +126,8 @@ _setup_prototype(_uc, "uc_reg_read", ucerr, uc_engine, ctypes.c_int, ctypes.c_vo
 _setup_prototype(_uc, "uc_reg_write", ucerr, uc_engine, ctypes.c_int, ctypes.c_void_p)
 _setup_prototype(_uc, "uc_mem_read", ucerr, uc_engine, ctypes.c_uint64, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t)
 _setup_prototype(_uc, "uc_mem_write", ucerr, uc_engine, ctypes.c_uint64, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t)
+_setup_prototype(_uc, "uc_virtual_mem_read", ucerr, uc_engine, ctypes.c_uint64, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t)
+_setup_prototype(_uc, "uc_virtual_mem_write", ucerr, uc_engine, ctypes.c_uint64, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t)
 _setup_prototype(_uc, "uc_emu_start", ucerr, uc_engine, ctypes.c_uint64, ctypes.c_uint64, ctypes.c_uint64, ctypes.c_size_t)
 _setup_prototype(_uc, "uc_emu_stop", ucerr, uc_engine)
 _setup_prototype(_uc, "uc_hook_del", ucerr, uc_engine, uc_hook_h)
@@ -436,6 +438,20 @@ class Uc(object):
     # write to memory
     def mem_write(self, address, data):
         status = _uc.uc_mem_write(self._uch, address, data, len(data))
+        if status != uc.UC_ERR_OK:
+            raise UcError(status)
+
+    # read data from virtual memory
+    def virtual_mem_read(self, address, size):
+        data = ctypes.create_string_buffer(size)
+        status = _uc.uc_virtual_mem_read(self._uch, address, data, size)
+        if status != uc.UC_ERR_OK:
+            raise UcError(status)
+        return bytearray(data)
+
+    # write to virtual memory
+    def virtual_mem_write(self, address, data):
+        status = _uc.uc_virtual_mem_write(self._uch, address, data, len(data))
         if status != uc.UC_ERR_OK:
             raise UcError(status)
 

--- a/include/uc_priv.h
+++ b/include/uc_priv.h
@@ -53,6 +53,9 @@ typedef bool (*uc_write_mem_t)(AddressSpace *as, hwaddr addr, const uint8_t *buf
 
 typedef bool (*uc_read_mem_t)(AddressSpace *as, hwaddr addr, uint8_t *buf, int len);
 
+typedef bool (*uc_virtual_read_mem_t)(CPUState *cpu, hwaddr addr, uint8_t *buf, int len);
+typedef bool (*uc_virtual_write_mem_t)(CPUState *cpu, hwaddr addr, const uint8_t *buf, int len);
+
 typedef void (*uc_args_void_t)(void*);
 
 typedef void (*uc_args_uc_t)(struct uc_struct*);
@@ -156,6 +159,8 @@ struct uc_struct {
 
     uc_write_mem_t write_mem;
     uc_read_mem_t read_mem;
+    uc_virtual_write_mem_t write_virtual_mem;
+    uc_virtual_read_mem_t read_virtual_mem;
     uc_args_void_t release;     // release resource when uc_close()
     uc_args_uc_u64_t set_pc;  // set PC for tracecode
     uc_args_int_t stop_interrupt;   // check if the interrupt should stop emulation

--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -498,6 +498,39 @@ UNICORN_EXPORT
 uc_err uc_mem_read(uc_engine *uc, uint64_t address, void *bytes, size_t size);
 
 /*
+ Write to a range of bytes in memory.
+
+ @uc: handle returned by uc_open()
+ @address: starting virtual memory address of bytes to set.
+ @bytes:   pointer to a variable containing data to be written to memory.
+ @size:   size of memory to write to.
+
+ NOTE: @bytes must be big enough to contain @size bytes.
+
+ @return UC_ERR_OK on success, or other value on failure (refer to uc_err enum
+   for detailed error).
+*/
+UNICORN_EXPORT
+uc_err uc_virtual_mem_write(uc_engine *uc, uint64_t address, void *_bytes, size_t size);
+
+/*
+ Read a range of bytes in virtual memory.
+
+ @uc: handle returned by uc_open()
+ @address: starting virtual memory address of bytes to get.
+ @bytes:   pointer to a variable containing data copied from memory.
+ @size:   size of memory to read.
+
+ NOTE: @bytes must be big enough to contain @size bytes.
+
+ @return UC_ERR_OK on success, or other value on failure (refer to uc_err enum
+   for detailed error).
+*/
+UNICORN_EXPORT
+uc_err uc_virtual_mem_read(uc_engine *uc, uint64_t address, void *_bytes, size_t size);
+
+
+/*
  Emulate machine code in a specific duration of time.
 
  @uc: handle returned by uc_open()

--- a/qemu/unicorn_common.h
+++ b/qemu/unicorn_common.h
@@ -19,6 +19,18 @@ static inline bool cpu_physical_mem_write(AddressSpace *as, hwaddr addr,
     return !cpu_physical_memory_rw(as, addr, (void *)buf, len, 1);
 }
 
+static inline bool cpu_virtual_mem_read(CPUState *cpu, hwaddr addr,
+                                            uint8_t *buf, int len)
+{
+    return !cpu_memory_rw_debug(cpu, addr, (void *)buf, len, 0);
+}
+
+static inline bool cpu_virtual_mem_write(CPUState *cpu, hwaddr addr,
+                                            const uint8_t *buf, int len)
+{
+    return !cpu_memory_rw_debug(cpu, addr, (void *)buf, len, 1);
+}
+
 void tb_cleanup(struct uc_struct *uc);
 void free_code_gen_buffer(struct uc_struct *uc);
 
@@ -70,6 +82,8 @@ static inline void uc_common_init(struct uc_struct* uc)
     memory_register_types(uc);
     uc->write_mem = cpu_physical_mem_write;
     uc->read_mem = cpu_physical_mem_read;
+    uc->write_virtual_mem = cpu_virtual_mem_write;
+    uc->read_virtual_mem = cpu_virtual_mem_read;
     uc->tcg_enabled = tcg_enabled;
     uc->tcg_exec_init = tcg_exec_init;
     uc->cpu_exec_init_all = cpu_exec_init_all;


### PR DESCRIPTION
The existing `uc_mem_read` and `uc_mem_write` allow to access the emulator's physical memory. For simple emulated code where the MMU is not setup, this also corresponds to virtual memory. However, there is currently no easy way to access virtual memory for complex code that enables pagination.

I propose to add new APIs to allow users to access virtual memory: `uc_virtual_mem_read` and `uc_virtual_mem_write`. Their prototype is the same than the physical variants. I also added the corresponding Python bindings.