### PR TITLE
i386: set MSR IA32_EFER to correct value at init for IA32e Mode

### DIFF
--- a/qemu/target-i386/unicorn.c
+++ b/qemu/target-i386/unicorn.c
@@ -156,6 +156,7 @@ void x86_reg_reset(struct uc_struct *uc)
         case UC_MODE_64:
             env->hflags |= HF_CS32_MASK | HF_SS32_MASK | HF_CS64_MASK | HF_LMA_MASK | HF_OSFXSR_MASK;
             env->hflags &= ~(HF_ADDSEG_MASK);
+            env->efer |= MSR_EFER_LMA | MSR_EFER_LME; // extended mode activated
             cpu_x86_update_cr0(env, CR0_PE_MASK); // protected mode
             break;
     }


### PR DESCRIPTION
When in IA-32e mode (x86 64) the value of the MSR  IA32_EFER (0xC0000080) should have LMA and LME bits set. The following code allow to test the issue:

```python
from unicorn import *
from unicorn.x86_const import *

mu = Uc(UC_ARCH_X86, UC_MODE_64)

CODE = b'\xb9\x80\x00\x00\xc0\x0f2' # mov rcx, 0xC0000080 ; rdmsr

mu.mem_map(0x2000, 0x1000)
mu.mem_write(0x2000, CODE)
mu.emu_start(0x2000, 0x2000 + len(CODE))

print("IA32_EFER = 0x{:X}".format(mu.reg_read(UC_X86_REG_RAX)))
```