### PR TITLE
fixed a memory leak

### DIFF
--- a/qemu/translate-all.c
+++ b/qemu/translate-all.c
@@ -812,6 +812,10 @@ static void page_flush_tb_1(int level, void **lp)
             pd[i].first_tb = NULL;
             invalidate_page_bitmap(pd + i);
         }
+        //free pd here
+        if(pd != NULL){
+            g_free(pd);
+        }
     } else {
         void **pp = *lp;
 


### PR DESCRIPTION
I found a memory leak problem when I running a big data on unicorn, I tried to repaired the leak and it's worked, This may be helpful for the project。
the error report by **valgrind** is below...
==123664== HEAP SUMMARY:
==123664==     in use at exit: 24,576 bytes in 1 blocks
==123664==   total heap usage: 2,314 allocs, 2,313 frees, 90,900,877 bytes allocated
==123664== 
==123664== 24,576 bytes in 1 blocks are definitely lost in loss record 1 of 1
==123664==    at 0x4C2818D: calloc (vg_replace_malloc.c:751)
==123664==    by 0x56E55D: g_malloc0 (glib_compat.c:1229)
==123664==    by 0x4CF7B4: page_find_alloc_aarch64 (translate-all.c:444)
==123664==    by 0x4D0987: tb_alloc_page_aarch64 (translate-all.c:1353)
==123664==    by 0x4D0B4B: tb_link_page_aarch64 (translate-all.c:1453)
==123664==    by 0x4D069E: tb_gen_code_aarch64 (translate-all.c:1128)
==123664==    by 0x4D2319: tb_find_slow_aarch64 (cpu-exec.c:368)
==123664==    by 0x4D249A: tb_find_fast_aarch64 (cpu-exec.c:396)
==123664==    by 0x4D1E0F: cpu_arm_exec_aarch64 (cpu-exec.c:208)
==123664==    by 0x4C0440: tcg_cpu_exec_aarch64 (cpus.c:120)
==123664==    by 0x4C04A7: tcg_exec_all_aarch64 (cpus.c:135)
==123664==    by 0x4C03D7: qemu_tcg_cpu_loop (cpus.c:102)
==123664== 
==123664== LEAK SUMMARY:
==123664==    definitely lost: 24,576 bytes in 1 blocks
==123664==    indirectly lost: 0 bytes in 0 blocks
==123664==      possibly lost: 0 bytes in 0 blocks
==123664==    still reachable: 0 bytes in 0 blocks
==123664==         suppressed: 0 bytes in 0 blocks
==123664== 
==123664== For counts of detected and suppressed errors, rerun with: -v
==123664== ERROR SUMMARY: 23 errors from 2 contexts (suppressed: 4 from 4)

