### PR TITLE
changed cpu_compute_eflags to use the updated eflags variable.

### DIFF
--- a/qemu/target-i386/cpu.h
+++ b/qemu/target-i386/cpu.h
@@ -1317,7 +1317,7 @@ void update_fp_status(CPUX86State *env);
 
 static inline uint32_t cpu_compute_eflags(CPUX86State *env)
 {
-    return (env->eflags0 & ~(CC_O | CC_S | CC_Z | CC_A | CC_P | CC_C | DF_MASK)) | cpu_cc_compute_all(env, CC_OP) | (env->df & DF_MASK);
+    return (env->eflags & ~(CC_O | CC_S | CC_Z | CC_A | CC_P | CC_C | DF_MASK)) | cpu_cc_compute_all(env, CC_OP) | (env->df & DF_MASK);
 }
 
 /* NOTE: the translator must set DisasContext.cc_op to CC_OP_EFLAGS


### PR DESCRIPTION
There seem to be several issues with eflags.
#1005 Trying to set eflags with sti may fail. eflags0, which will not be updated by sti, rewrites eflags when cpu_compute_eflags uses it.  
This also happens with popfl and that's one reason why regress/eflags_noset.c doesn't pass (see issue #252).

This is similar to the fix proposed in issue #313 by @farmdve , d773548 solves the problem he was facing.