### PR TITLE
Add support for the ARM IPSR register.

### DIFF
--- a/include/unicorn/arm.h
+++ b/include/unicorn/arm.h
@@ -133,6 +133,7 @@ typedef enum uc_arm_reg {
     UC_ARM_REG_C13_C0_2,
     UC_ARM_REG_C13_C0_3,
 
+    UC_ARM_REG_IPSR,
     UC_ARM_REG_ENDING,		// <-- mark the end of the list or registers
 
     //> alias registers

--- a/qemu/target-arm/unicorn_arm.c
+++ b/qemu/target-arm/unicorn_arm.c
@@ -90,6 +90,9 @@ int arm_reg_read(struct uc_struct *uc, unsigned int *regs, void **vals, int coun
                 case UC_ARM_REG_FPEXC:
                     *(int32_t *)value = ARM_CPU(uc, mycpu)->env.vfp.xregs[ARM_VFP_FPEXC];
                     break;
+                case UC_ARM_REG_IPSR:
+                    *(uint32_t *)value = xpsr_read(&ARM_CPU(uc, mycpu)->env) & 0x1ff;
+                    break;
             }
         }
     }
@@ -145,6 +148,9 @@ int arm_reg_write(struct uc_struct *uc, unsigned int *regs, void* const* vals, i
                     break;
                 case UC_ARM_REG_FPEXC:
                     ARM_CPU(uc, mycpu)->env.vfp.xregs[ARM_VFP_FPEXC] = *(int32_t *)value;
+                    break;
+                case UC_ARM_REG_IPSR:
+                    xpsr_write(&ARM_CPU(uc, mycpu)->env, *(uint32_t *)value, 0x1ff);
                     break;
             }
         }


### PR DESCRIPTION
1. Create an enum name for the IPSR register.
2. Implement read and write of the IPSR via the xpsr helper functions.

Fixes #1065