### PR TITLE
Add ARM MSP, PSP and CONTROL register access

### DIFF
--- a/include/unicorn/arm.h
+++ b/include/unicorn/arm.h
@@ -134,6 +134,9 @@ typedef enum uc_arm_reg {
     UC_ARM_REG_C13_C0_3,
 
     UC_ARM_REG_IPSR,
+    UC_ARM_REG_MSP,
+    UC_ARM_REG_PSP,
+    UC_ARM_REG_CONTROL,
     UC_ARM_REG_ENDING,		// <-- mark the end of the list or registers
 
     //> alias registers

--- a/qemu/target-arm/unicorn_arm.c
+++ b/qemu/target-arm/unicorn_arm.c
@@ -93,6 +93,15 @@ int arm_reg_read(struct uc_struct *uc, unsigned int *regs, void **vals, int coun
                 case UC_ARM_REG_IPSR:
                     *(uint32_t *)value = xpsr_read(&ARM_CPU(uc, mycpu)->env) & 0x1ff;
                     break;
+                case UC_ARM_REG_MSP:
+                    *(uint32_t *)value = helper_v7m_mrs(&ARM_CPU(uc, mycpu)->env, 8);
+                    break;
+                case UC_ARM_REG_PSP:
+                    *(uint32_t *)value = helper_v7m_mrs(&ARM_CPU(uc, mycpu)->env, 9);
+                    break;
+                 case UC_ARM_REG_CONTROL:
+                    *(uint32_t *)value = helper_v7m_mrs(&ARM_CPU(uc, mycpu)->env, 20);
+                    break; 
             }
         }
     }
@@ -151,6 +160,15 @@ int arm_reg_write(struct uc_struct *uc, unsigned int *regs, void* const* vals, i
                     break;
                 case UC_ARM_REG_IPSR:
                     xpsr_write(&ARM_CPU(uc, mycpu)->env, *(uint32_t *)value, 0x1ff);
+                    break;
+                case UC_ARM_REG_MSP:
+                    helper_v7m_msr(&ARM_CPU(uc, mycpu)->env, 8, *(uint32_t *)value);
+                    break;
+                case UC_ARM_REG_PSP:
+                    helper_v7m_msr(&ARM_CPU(uc, mycpu)->env, 9, *(uint32_t *)value);
+                    break;
+                 case UC_ARM_REG_CONTROL:
+                    helper_v7m_msr(&ARM_CPU(uc, mycpu)->env, 20, *(uint32_t *)value);
                     break;
             }
         }


### PR DESCRIPTION
Necessary for NVIC exception emulation from user.