### PR TITLE
support for YMM registers ymm8-ymm15

### DIFF
--- a/bindings/python/unicorn/unicorn.py
+++ b/bindings/python/unicorn/unicorn.py
@@ -341,7 +341,7 @@ class Uc(object):
                 if status != uc.UC_ERR_OK:
                     raise UcError(status)
                 return reg.low_qword | (reg.high_qword << 64)
-            if reg_id in range(x86_const.UC_X86_REG_YMM0, x86_const.UC_X86_REG_YMM0+8):
+            if reg_id in range(x86_const.UC_X86_REG_YMM0, x86_const.UC_X86_REG_YMM0+16):
                 reg = uc_x86_ymm()
                 status = _uc.uc_reg_read(self._uch, reg_id, ctypes.byref(reg))
                 if status != uc.UC_ERR_OK:
@@ -392,7 +392,7 @@ class Uc(object):
                 reg = uc_x86_xmm()
                 reg.low_qword = value & 0xffffffffffffffff
                 reg.high_qword = value >> 64
-            if reg_id in range(x86_const.UC_X86_REG_YMM0, x86_const.UC_X86_REG_YMM0+8):
+            if reg_id in range(x86_const.UC_X86_REG_YMM0, x86_const.UC_X86_REG_YMM0+16):
                 reg = uc_x86_ymm()
                 reg.first_qword = value & 0xffffffffffffffff
                 reg.second_qword = (value >> 64) & 0xffffffffffffffff

--- a/qemu/target-i386/unicorn.c
+++ b/qemu/target-i386/unicorn.c
@@ -293,6 +293,14 @@ int x86_reg_read(struct uc_struct *uc, unsigned int *regs, void **vals, int coun
             case UC_X86_REG_YMM5:
             case UC_X86_REG_YMM6:
             case UC_X86_REG_YMM7:
+            case UC_X86_REG_YMM8:
+            case UC_X86_REG_YMM9:
+            case UC_X86_REG_YMM10:
+            case UC_X86_REG_YMM11:
+            case UC_X86_REG_YMM12:
+            case UC_X86_REG_YMM13:
+            case UC_X86_REG_YMM14:
+            case UC_X86_REG_YMM15:
                 {
                     float64 *dst = (float64*)value;
                     XMMReg *lo_reg = &X86_CPU(uc, mycpu)->env.xmm_regs[regid - UC_X86_REG_YMM0];
@@ -838,6 +846,14 @@ int x86_reg_write(struct uc_struct *uc, unsigned int *regs, void *const *vals, i
             case UC_X86_REG_YMM5:
             case UC_X86_REG_YMM6:
             case UC_X86_REG_YMM7:
+            case UC_X86_REG_YMM8:
+            case UC_X86_REG_YMM9:
+            case UC_X86_REG_YMM10:
+            case UC_X86_REG_YMM11:
+            case UC_X86_REG_YMM12:
+            case UC_X86_REG_YMM13:
+            case UC_X86_REG_YMM14:
+            case UC_X86_REG_YMM15:
                 {
                     float64 *src = (float64*)value;
                     XMMReg *lo_reg = &X86_CPU(uc, mycpu)->env.xmm_regs[regid - UC_X86_REG_YMM0];


### PR DESCRIPTION
Accessing the ymm8-ymm15 registers so far only returned 0 because they were not handled.

Should I add the following registers the same way? 

- [ ] xmm8-15
- [ ] ymm-registers
- [ ] zmm-registers