### PR TITLE
Add ARM64 Android support in make.sh

### DIFF
--- a/docs/COMPILE-NIX.md
+++ b/docs/COMPILE-NIX.md
@@ -87,23 +87,23 @@ To build Unicorn on *nix (such as MacOSX, Linux, *BSD, Solaris):
 
 
 
-[3] Cross-compile for iOS from Mac OSX.
+[3] Cross-compile for iOS from macOS.
 
-To cross-compile for iOS (iPhone/iPad/iPod), Mac OSX with XCode installed is required.
+To cross-compile for iOS (iPhone/iPad/iPod), macOS with Xcode installed is required.
 
-- To cross-compile for ArmV7 (iPod 4, iPad 1/2/3, iPhone4, iPhone4S), run:
+- To cross-compile for iOS ArmV7 (iPod 4, iPad 1/2/3, iPhone4, iPhone4S), run:
 
         $ ./make.sh ios_armv7
 
-- To cross-compile for ArmV7s (iPad 4, iPhone 5C, iPad mini), run:
+- To cross-compile for iOS ArmV7s (iPad 4, iPhone 5C, iPad mini), run:
 
         $ ./make.sh ios_armv7s
 
-- To cross-compile for Arm64 (iPhone 5S, iPad mini Retina, iPad Air), run:
+- To cross-compile for iOS Arm64 (iPhone 5S, iPad mini Retina, iPad Air), run:
 
         $ ./make.sh ios_arm64
 
-- To cross-compile for all iDevices (armv7 + armv7s + arm64), run:
+- To cross-compile for all iOS devices (armv7 + armv7s + arm64), run:
 
         $ ./make.sh ios
 
@@ -115,11 +115,14 @@ be used on iOS devices.
 [4] Cross-compile for Android
 
 To cross-compile for Android (smartphone/tablet), Android NDK is required.
-NOTE: Only ARM and ARM64 are currently supported.
 
-        $ NDK=/android/android-ndk-r10e ./make.sh cross-android arm
-or
-        $ NDK=/android/android-ndk-r10e ./make.sh cross-android arm64
+- To cross-compile for Android Arm, run:
+
+        $ NDK=~/android/android-ndk-r20 ./make.sh cross-android_arm
+
+- To cross-compile for Android Arm64, run:
+
+        $ NDK=~/android/android-ndk-r20 ./make.sh cross-android_arm64
 
 Resulted files libunicorn.so, libunicorn.a & tests/test* can then
 be used on Android devices.

--- a/make.sh
+++ b/make.sh
@@ -17,11 +17,12 @@ OPTIONS:
     macos-universal-no      Build non-universal binaries that includes only 64-bit code on macOS
     cross-win32             Cross-compile Windows 32-bit binary with MinGW
     cross-win64             Cross-compile Windows 64-bit binary with MinGW
-    cross-android           Cross-compile for Android
-    ios                     Cross-compile for all iDevices (armv7 + armv7s + arm64)
-    ios_armv7               Cross-compile for ArmV7 (iPod 4, iPad 1/2/3, iPhone4, iPhone4S)
-    ios_armv7s              Cross-compile for ArmV7s (iPad 4, iPhone 5C, iPad mini)
-    ios_arm64               Cross-compile for Arm64 (iPhone 5S, iPad mini Retina, iPad Air)
+    cross-android32         Cross-compile for Android ArmV7
+    cross-android64         Cross-compile for Android Arm64
+    ios                     Cross-compile for all iOS devices (armv7 + armv7s + arm64)
+    ios_armv7               Cross-compile for iOS ArmV7 (iPod 4, iPad 1/2/3, iPhone4, iPhone4S)
+    ios_armv7s              Cross-compile for iOS ArmV7s (iPad 4, iPhone 5C, iPad mini)
+    ios_arm64               Cross-compile for iOS Arm64 (iPhone 5S, iPad mini Retina, iPad Air)
     linux32                 Cross-compile Unicorn on 64-bit Linux to target 32-bit binary
     msvc_update_genfiles    Generate files for MSVC projects
 EOF
@@ -150,7 +151,8 @@ case "$1" in
   "macos-universal-no" ) MACOS_UNIVERSAL=no ${MAKE};;
   "cross-win32" ) build_cross i686-w64-mingw32;;
   "cross-win64" ) build_cross x86_64-w64-mingw32;;
-  "cross-android" ) CROSS=arm-linux-androideabi ${MAKE};;
+  "cross-android32" ) CROSS=arm-linux-androideabi ${MAKE};;
+  "cross-android64" ) CROSS=aarch64-linux-android ${MAKE};;
   "ios" ) build_iOS;;
   "ios_armv7" ) build_iOS armv7;;
   "ios_armv7s" ) build_iOS armv7s;;

--- a/make.sh
+++ b/make.sh
@@ -17,8 +17,8 @@ OPTIONS:
     macos-universal-no      Build non-universal binaries that includes only 64-bit code on macOS
     cross-win32             Cross-compile Windows 32-bit binary with MinGW
     cross-win64             Cross-compile Windows 64-bit binary with MinGW
-    cross-android32         Cross-compile for Android ArmV7
-    cross-android64         Cross-compile for Android Arm64
+    cross-android_arm       Cross-compile for Android Arm
+    cross-android_arm64     Cross-compile for Android Arm64
     ios                     Cross-compile for all iOS devices (armv7 + armv7s + arm64)
     ios_armv7               Cross-compile for iOS ArmV7 (iPod 4, iPad 1/2/3, iPhone4, iPhone4S)
     ios_armv7s              Cross-compile for iOS ArmV7s (iPad 4, iPhone 5C, iPad mini)
@@ -151,8 +151,8 @@ case "$1" in
   "macos-universal-no" ) MACOS_UNIVERSAL=no ${MAKE};;
   "cross-win32" ) build_cross i686-w64-mingw32;;
   "cross-win64" ) build_cross x86_64-w64-mingw32;;
-  "cross-android32" ) CROSS=arm-linux-androideabi ${MAKE};;
-  "cross-android64" ) CROSS=aarch64-linux-android ${MAKE};;
+  "cross-android_arm" ) CROSS=arm-linux-androideabi ${MAKE};;
+  "cross-android_arm64" ) CROSS=aarch64-linux-android ${MAKE};;
   "ios" ) build_iOS;;
   "ios_armv7" ) build_iOS armv7;;
   "ios_armv7s" ) build_iOS armv7s;;


### PR DESCRIPTION
I noticed that building for Android ARM64 was not an option in make.sh, so here it is.