### PR TITLE
Cmpxchg16b Backport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.fuse*
 *.swp
 *.d
 *.o

--- a/qemu/target-i386/helper.h
+++ b/qemu/target-i386/helper.h
@@ -17,6 +17,7 @@ DEF_HELPER_2(idivl_EAX, void, env, tl)
 DEF_HELPER_2(divq_EAX, void, env, tl)
 DEF_HELPER_2(idivq_EAX, void, env, tl)
 #endif
+DEF_HELPER_FLAGS_2(cr4_testbit, TCG_CALL_NO_WG, void, env, i32)
 
 DEF_HELPER_2(aam, void, env, int)
 DEF_HELPER_2(aad, void, env, int)
@@ -73,9 +74,11 @@ DEF_HELPER_3(boundw, void, env, tl, int)
 DEF_HELPER_3(boundl, void, env, tl, int)
 DEF_HELPER_1(rsm, void, env)
 DEF_HELPER_2(into, void, env, int)
-DEF_HELPER_2(cmpxchg8b, void, env, tl)
+DEF_HELPER_2(cmpxchg8b_unlocked, void, env, tl)
+//DEF_HELPER_2(cmpxchg8b, void, env, tl)
 #ifdef TARGET_X86_64
-DEF_HELPER_2(cmpxchg16b, void, env, tl)
+DEF_HELPER_2(cmpxchg16b_unlocked, void, env, tl)
+//DEF_HELPER_2(cmpxchg16b, void, env, tl)
 #endif
 DEF_HELPER_1(single_step, void, env)
 DEF_HELPER_1(cpuid, void, env)
@@ -225,3 +228,5 @@ DEF_HELPER_3(rcrl, tl, env, tl, tl)
 DEF_HELPER_3(rclq, tl, env, tl, tl)
 DEF_HELPER_3(rcrq, tl, env, tl, tl)
 #endif
+
+DEF_HELPER_1(rdrand, tl, env)

--- a/qemu/target-i386/int_helper.c
+++ b/qemu/target-i386/int_helper.c
@@ -469,3 +469,36 @@ target_ulong helper_pext(target_ulong src, target_ulong mask)
 #include "shift_helper_template.h"
 #undef SHIFT
 #endif
+
+
+/* Test that BIT is enabled in CR4.  If not, raise an illegal opcode
+   exception.  This reduces the requirements for rare CR4 bits being
+   mapped into HFLAGS.  */
+void helper_cr4_testbit(CPUX86State *env, uint32_t bit)
+{
+    if (unlikely((env->cr[4] & bit) == 0)) {
+        raise_exception(env, EXCP06_ILLOP);
+    }
+}
+
+target_ulong HELPER(rdrand)(CPUX86State *env)
+{
+    Error *err = NULL;
+    target_ulong ret;
+
+    /* Currently no rdrand Support in Unicorn - always fail. 
+    Could implement $something here:
+
+    if (qemu_guest_getrandom(&ret, sizeof(ret), &err) < 0) {
+        qemu_log_mask(LOG_UNIMP, "rdrand: Crypto failure: %s",
+                      error_get_pretty(err));
+        error_free(err);
+        /* Failure clears CF and all other flags, and returns 0.  */
+        env->cc_src = 0;
+        return 0;
+    //}
+
+    /* Success sets CF and clears all others.  */
+    env->cc_src = CC_C;
+    return ret;
+}

--- a/qemu/target-i386/mem_helper.c
+++ b/qemu/target-i386/mem_helper.c
@@ -20,8 +20,11 @@
 #include "cpu.h"
 #include "exec/helper-proto.h"
 #include "exec/cpu_ldst.h"
+#include "qemu/int128.h"
 
 #include "uc_priv.h"
+
+#define CONFIG_ATOMIC64
 
 /* broken thread support */
 
@@ -33,48 +36,64 @@ void helper_unlock(CPUX86State *env)
 {
 }
 
-void helper_cmpxchg8b(CPUX86State *env, target_ulong a0)
+
+void helper_cmpxchg8b_unlocked(CPUX86State *env, target_ulong a0)
 {
-    uint64_t d;
+    uint64_t oldv, cmpv, newv;
     int eflags;
 
     eflags = cpu_cc_compute_all(env, CC_OP);
-    d = cpu_ldq_data(env, a0);
-    if (d == (((uint64_t)env->regs[R_EDX] << 32) | (uint32_t)env->regs[R_EAX])) {
-        cpu_stq_data(env, a0, ((uint64_t)env->regs[R_ECX] << 32) | (uint32_t)env->regs[R_EBX]);
+
+    cmpv = deposit64(env->regs[R_EAX], 32, 32, env->regs[R_EDX]);
+    newv = deposit64(env->regs[R_EBX], 32, 32, env->regs[R_ECX]);
+
+    oldv = cpu_ldq_data(env, a0);
+    newv = (cmpv == oldv ? newv : oldv);
+    /* always do the store */
+    cpu_stq_data(env, a0, newv);
+
+    if (oldv == cmpv) {
         eflags |= CC_Z;
     } else {
-        /* always do the store */
-        cpu_stq_data(env, a0, d);
-        env->regs[R_EDX] = (uint32_t)(d >> 32);
-        env->regs[R_EAX] = (uint32_t)d;
+        env->regs[R_EAX] = (uint32_t)oldv;
+        env->regs[R_EDX] = (uint32_t)(oldv >> 32);
         eflags &= ~CC_Z;
     }
     CC_SRC = eflags;
 }
 
 #ifdef TARGET_X86_64
-void helper_cmpxchg16b(CPUX86State *env, target_ulong a0)
+void helper_cmpxchg16b_unlocked(CPUX86State *env, target_ulong a0)
 {
-    uint64_t d0, d1;
+    uint64_t o0, o1;
     int eflags;
+    bool success;
 
     if ((a0 & 0xf) != 0) {
         raise_exception(env, EXCP0D_GPF);
     }
     eflags = cpu_cc_compute_all(env, CC_OP);
-    d0 = cpu_ldq_data(env, a0);
-    d1 = cpu_ldq_data(env, a0 + 8);
-    if (d0 == env->regs[R_EAX] && d1 == env->regs[R_EDX]) {
-        cpu_stq_data(env, a0, env->regs[R_EBX]);
-        cpu_stq_data(env, a0 + 8, env->regs[R_ECX]);
+
+    Int128 cmpv = {.lo = env->regs[R_EAX], .hi = env->regs[R_EDX]};
+    Int128 newv = {.lo = env->regs[R_EBX], .hi = env->regs[R_ECX]};
+
+    o0 = cpu_ldq_data(env, a0 + 0);
+    o1 = cpu_ldq_data(env, a0 + 8);
+
+    Int128 oldv = {.lo = o0, .hi = o1};
+    success = int128_eq(oldv, cmpv);
+    if (!success) {
+        newv = oldv;
+    }
+
+    cpu_stq_data(env, a0 + 0, newv.lo);
+    cpu_stq_data(env, a0 + 8, newv.hi);
+
+    if (success) {
         eflags |= CC_Z;
     } else {
-        /* always do the store */
-        cpu_stq_data(env, a0, d0);
-        cpu_stq_data(env, a0 + 8, d1);
-        env->regs[R_EDX] = d1;
-        env->regs[R_EAX] = d0;
+        env->regs[R_EAX] = oldv.lo;
+        env->regs[R_EDX] = oldv.hi;
         eflags &= ~CC_Z;
     }
     CC_SRC = eflags;
@@ -103,28 +122,3 @@ void helper_boundl(CPUX86State *env, target_ulong a0, int v)
         raise_exception(env, EXCP05_BOUND);
     }
 }
-
-#if !defined(CONFIG_USER_ONLY)
-/* try to fill the TLB and return an exception if error. If retaddr is
- * NULL, it means that the function was called in C code (i.e. not
- * from generated code or from helper.c)
- */
-/* XXX: fix it to restore all registers */
-void tlb_fill(CPUState *cs, target_ulong addr, int is_write, int mmu_idx,
-              uintptr_t retaddr)
-{
-    int ret;
-
-    ret = x86_cpu_handle_mmu_fault(cs, addr, is_write, mmu_idx);
-    if (ret) {
-        X86CPU *cpu = X86_CPU(cs->uc, cs);
-        CPUX86State *env = &cpu->env;
-
-        if (retaddr) {
-            /* now we have a real cpu fault */
-            cpu_restore_state(cs, retaddr);
-        }
-        raise_exception_err(env, cs->exception_index, env->error_code);
-    }
-}
-#endif

--- a/qemu/target-i386/mem_helper.c
+++ b/qemu/target-i386/mem_helper.c
@@ -122,3 +122,29 @@ void helper_boundl(CPUX86State *env, target_ulong a0, int v)
         raise_exception(env, EXCP05_BOUND);
     }
 }
+
+
+#if !defined(CONFIG_USER_ONLY)
+/* try to fill the TLB and return an exception if error. If retaddr is
+ * NULL, it means that the function was called in C code (i.e. not
+ * from generated code or from helper.c)
+ */
+/* XXX: fix it to restore all registers */
+void tlb_fill(CPUState *cs, target_ulong addr, int is_write, int mmu_idx,
+              uintptr_t retaddr)
+{
+    int ret;
+
+    ret = x86_cpu_handle_mmu_fault(cs, addr, is_write, mmu_idx);
+    if (ret) {
+        X86CPU *cpu = X86_CPU(cs->uc, cs);
+        CPUX86State *env = &cpu->env;
+
+        if (retaddr) {
+            /* now we have a real cpu fault */
+            cpu_restore_state(cs, retaddr);
+        }
+        raise_exception_err(env, cs->exception_index, env->error_code);
+    }
+}
+#endif

--- a/qemu/target-i386/translate.c
+++ b/qemu/target-i386/translate.c
@@ -5842,7 +5842,7 @@ static target_ulong disas_insn(CPUX86State *env, DisasContext *s,
         }
         break;
     case 0x1c7: /* cmpxchg8b */
-        modrm = cpu_ldub_code(env, s->pc);
+        modrm = cpu_ldub_code(env, s->pc++);
         mod = (modrm >> 6) & 3;
         switch ((modrm >> 3) & 7) {
         case 1: /* CMPXCHG8, CMPXCHG16 */


### PR DESCRIPTION
With regard to issue #1095 I have backported `cmpxchg8b` and `16b` from the current qemu master to play around with.
I have disregarded the non-`unlocked` versions of both functions, since they rely on atomic functionality and I assumed Unicorn will run single-threaded always (?)

This has not been tested thoroughly and very likely needs more test cases.
If anybody feels like writing tests, feel free to to use this unicorn hook recreating some of the cmpxchg16b-functionality in pure python. https://github.com/fgsect/unicorefuzz/blob/dc59271dc73c26323301c7a69efc3efa68ec4c1f/util.py#L152

Also, the current qemu includes support for `rdrand` in the same opcode range which I have not implemented fully (will always return 0 -> rdrand failed)  as it would need more thought (add hooks? seeds?)
Alternatively this could always throw an illegal insn for now.
