### PR TITLE
Specify python for building QEMU on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,8 @@ LIBRARY_SYMLINK = lib$(LIBNAME).$(EXT)
 endif
 endif
 
+UNICORN_QEMU_FLAGS += --python=$(shell which python2 || which /usr/bin/python || which python)
+
 ifeq ($(UNICORN_STATIC),yes)
 ifneq ($(filter MINGW%,$(UNAME_S)),)
 ARCHIVE = $(LIBNAME).$(AR_EXT)


### PR DESCRIPTION
This is necessary for use in python3 virtualenvs. macOS doesn't have a python2 binary, so we have to hardcode the path here to circumvent the virtualenv.