### PR TITLE
Handle serialization of cpu context save

### DIFF
--- a/bindings/python/unicorn/unicorn.py
+++ b/bindings/python/unicorn/unicorn.py
@@ -138,6 +138,7 @@ _setup_prototype(_uc, "uc_context_alloc", ucerr, uc_engine, ctypes.POINTER(uc_co
 _setup_prototype(_uc, "uc_free", ucerr, ctypes.c_void_p)
 _setup_prototype(_uc, "uc_context_save", ucerr, uc_engine, uc_context)
 _setup_prototype(_uc, "uc_context_restore", ucerr, uc_engine, uc_context)
+_setup_prototype(_uc, "uc_context_size", ctypes.c_uint64, uc_engine)
 _setup_prototype(_uc, "uc_mem_regions", ucerr, uc_engine, ctypes.POINTER(ctypes.POINTER(_uc_mem_region)), ctypes.POINTER(ctypes.c_uint32))
 
 # uc_hook_add is special due to variable number of arguments
@@ -582,24 +583,23 @@ class Uc(object):
         h = 0
 
     def context_save(self):
-        ptr = ctypes.cast(0, ctypes.c_voidp)
-        status = _uc.uc_context_alloc(self._uch, ctypes.byref(ptr))
+        size = _uc.uc_context_size(self._uch)
+
+        context = context_factory(size)
+
+        status = _uc.uc_context_save(self._uch, ctypes.byref(context))
         if status != uc.UC_ERR_OK:
             raise UcError(status)
 
-        status = _uc.uc_context_save(self._uch, ptr)
-        if status != uc.UC_ERR_OK:
-            raise UcError(status)
-
-        return SavedContext(ptr)
+        return ctypes.string_at(ctypes.byref(context), ctypes.sizeof(context))
 
     def context_update(self, context):
-        status = _uc.uc_context_save(self._uch, context.pointer)
+        status = _uc.uc_context_save(self._uch, context)
         if status != uc.UC_ERR_OK:
             raise UcError(status)
 
     def context_restore(self, context):
-        status = _uc.uc_context_restore(self._uch, context.pointer)
+        status = _uc.uc_context_restore(self._uch, context)
         if status != uc.UC_ERR_OK:
             raise UcError(status)
 
@@ -618,14 +618,15 @@ class Uc(object):
             _uc.uc_free(regions)
 
 
-class SavedContext(object):
-    def __init__(self, pointer):
-        self.pointer = pointer
-
-    def __del__(self):
-        status = _uc.uc_free(self.pointer)
-        if status != uc.UC_ERR_OK:
-            raise UcError(status)
+def context_factory(size):
+    class SavedContext(ctypes.Structure):
+        _fields_ = [
+            ('size', ctypes.c_uint64),
+            ('data', ctypes.c_char*size)
+            ]
+    ctxt = SavedContext()
+    ctxt.size = size
+    return ctxt
 
 # print out debugging info
 def debug():

--- a/bindings/python/unicorn/unicorn.py
+++ b/bindings/python/unicorn/unicorn.py
@@ -138,7 +138,7 @@ _setup_prototype(_uc, "uc_context_alloc", ucerr, uc_engine, ctypes.POINTER(uc_co
 _setup_prototype(_uc, "uc_free", ucerr, ctypes.c_void_p)
 _setup_prototype(_uc, "uc_context_save", ucerr, uc_engine, uc_context)
 _setup_prototype(_uc, "uc_context_restore", ucerr, uc_engine, uc_context)
-_setup_prototype(_uc, "uc_context_size", ctypes.c_uint64, uc_engine)
+_setup_prototype(_uc, "uc_context_size", ctypes.c_size_t, uc_engine)
 _setup_prototype(_uc, "uc_mem_regions", ucerr, uc_engine, ctypes.POINTER(ctypes.POINTER(_uc_mem_region)), ctypes.POINTER(ctypes.c_uint32))
 
 # uc_hook_add is special due to variable number of arguments
@@ -621,7 +621,7 @@ class Uc(object):
 def context_factory(size):
     class SavedContext(ctypes.Structure):
         _fields_ = [
-            ('size', ctypes.c_uint64),
+            ('size', ctypes.c_size_t),
             ('data', ctypes.c_char*size)
             ]
     ctxt = SavedContext()

--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -723,6 +723,18 @@ uc_err uc_context_save(uc_engine *uc, uc_context *context);
 UNICORN_EXPORT
 uc_err uc_context_restore(uc_engine *uc, uc_context *context);
 
+
+/*
+  Return the size needed to store the cpu context. Can be used to allocate a buffer
+  to contain the cpu context and directly call uc_context_save.
+
+  @uc: handle returned by uc_open()
+
+  @return the size for needed to store the cpu context as as size_t.
+*/
+UNICORN_EXPORT
+size_t uc_context_size(uc_engine *uc);
+
 #ifdef __cplusplus
 }
 #endif

--- a/uc.c
+++ b/uc.c
@@ -1303,6 +1303,12 @@ uc_err uc_free(void *mem)
 }
 
 UNICORN_EXPORT
+size_t uc_context_size(uc_engine *uc)
+{
+    return cpu_context_size(uc->arch, uc->mode);
+}
+
+UNICORN_EXPORT
 uc_err uc_context_save(uc_engine *uc, uc_context *context)
 {
     struct uc_context *_context = context;


### PR DESCRIPTION
The `context_save`, `context_update` and `context_restore` API of Unicorn are using directly C pointers in the bindings, that makes the result of a `context_save` unserializable.

The goal here is to be able to save the context of a cpu, write this state on the disk, and load this cpu context in another emulator of the same architecture and mode.
In simple words, be able to have a CPU snapshot across emulators.

This PR is a fix for the Python bindings. It doesn't break the API for other bindings.

Since the cpu context is just a big buffer, we can let the Python allocate the buffer, and pass it to `uc_context_save` function that will fill it with the cpu context data.
To be able to do this, we need to expose the `cpu_context_size` function to the bindings.

We can then let the Python handle the destruction of this object and we don't need to free a C pointer manually.

The context returned by the `context_save` API is a Python string that is serializable.

With this PR, the `uc_context_alloc` function is not needed anymore in Python bindings.

Tested on X86 emulation.