### PR TITLE
Two fixes to get unicorn build better with MSVC.

### DIFF
--- a/msvc/samples/sample_x86/sample_x86.vcxproj
+++ b/msvc/samples/sample_x86/sample_x86.vcxproj
@@ -116,6 +116,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalIncludeDirectories>../../../include</AdditionalIncludeDirectories>
       <ExceptionHandling>false</ExceptionHandling>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/msvc/unicorn/aarch64-softmmu/aarch64-softmmu.vcxproj
+++ b/msvc/unicorn/aarch64-softmmu/aarch64-softmmu.vcxproj
@@ -170,6 +170,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
       <ForcedIncludeFiles>aarch64.h</ForcedIncludeFiles>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/msvc/unicorn/aarch64eb-softmmu/aarch64eb-softmmu.vcxproj
+++ b/msvc/unicorn/aarch64eb-softmmu/aarch64eb-softmmu.vcxproj
@@ -170,6 +170,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
       <ForcedIncludeFiles>aarch64eb.h</ForcedIncludeFiles>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/msvc/unicorn/arm-softmmu/arm-softmmu.vcxproj
+++ b/msvc/unicorn/arm-softmmu/arm-softmmu.vcxproj
@@ -166,6 +166,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
       <ForcedIncludeFiles>arm.h</ForcedIncludeFiles>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/msvc/unicorn/armeb-softmmu/armeb-softmmu.vcxproj
+++ b/msvc/unicorn/armeb-softmmu/armeb-softmmu.vcxproj
@@ -166,6 +166,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
       <ForcedIncludeFiles>armeb.h</ForcedIncludeFiles>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/msvc/unicorn/m68k-softmmu/m68k-softmmu.vcxproj
+++ b/msvc/unicorn/m68k-softmmu/m68k-softmmu.vcxproj
@@ -157,6 +157,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
       <ForcedIncludeFiles>m68k.h</ForcedIncludeFiles>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/msvc/unicorn/mips-softmmu/mips-softmmu.vcxproj
+++ b/msvc/unicorn/mips-softmmu/mips-softmmu.vcxproj
@@ -168,6 +168,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
       <ForcedIncludeFiles>mips.h</ForcedIncludeFiles>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/msvc/unicorn/mips64-softmmu/mips64-softmmu.vcxproj
+++ b/msvc/unicorn/mips64-softmmu/mips64-softmmu.vcxproj
@@ -168,6 +168,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
       <ForcedIncludeFiles>mips64.h</ForcedIncludeFiles>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/msvc/unicorn/mips64el-softmmu/mips64el-softmmu.vcxproj
+++ b/msvc/unicorn/mips64el-softmmu/mips64el-softmmu.vcxproj
@@ -168,6 +168,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
       <ForcedIncludeFiles>mips64el.h</ForcedIncludeFiles>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/msvc/unicorn/mipsel-softmmu/mipsel-softmmu.vcxproj
+++ b/msvc/unicorn/mipsel-softmmu/mipsel-softmmu.vcxproj
@@ -168,6 +168,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
       <ForcedIncludeFiles>mipsel.h</ForcedIncludeFiles>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/msvc/unicorn/sparc-softmmu/sparc-softmmu.vcxproj
+++ b/msvc/unicorn/sparc-softmmu/sparc-softmmu.vcxproj
@@ -161,6 +161,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
       <ForcedIncludeFiles>sparc.h</ForcedIncludeFiles>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/msvc/unicorn/sparc64-softmmu/sparc64-softmmu.vcxproj
+++ b/msvc/unicorn/sparc64-softmmu/sparc64-softmmu.vcxproj
@@ -162,6 +162,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
       <ForcedIncludeFiles>sparc64.h</ForcedIncludeFiles>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/msvc/unicorn/unicorn/unicorn.vcxproj
+++ b/msvc/unicorn/unicorn/unicorn.vcxproj
@@ -113,6 +113,7 @@
       <AdditionalOptions>/wd4018 /wd4244 /wd4267 %(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/msvc/unicorn/unicorn_static/unicorn_static.vcxproj
+++ b/msvc/unicorn/unicorn_static/unicorn_static.vcxproj
@@ -267,6 +267,7 @@
       <AdditionalIncludeDirectories>.;..;../../../include;../../../qemu;../../../qemu/include;../../../qemu/tcg</AdditionalIncludeDirectories>
       <AdditionalOptions>/wd4018 /wd4244 /wd4267 %(AdditionalOptions)</AdditionalOptions>
       <ExceptionHandling>false</ExceptionHandling>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/msvc/unicorn/x86_64-softmmu/x86_64-softmmu.vcxproj
+++ b/msvc/unicorn/x86_64-softmmu/x86_64-softmmu.vcxproj
@@ -174,6 +174,7 @@
       <ForcedIncludeFiles>x86_64.h</ForcedIncludeFiles>
       <AdditionalOptions>/wd4018 /wd4244 /wd4267 %(AdditionalOptions)</AdditionalOptions>
       <ExceptionHandling>false</ExceptionHandling>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/qemu/include/hw/qdev-core.h
+++ b/qemu/include/hw/qdev-core.h
@@ -276,9 +276,9 @@ DeviceState *qdev_find_recursive(BusState *bus, const char *id);
 typedef int (qbus_walkerfn)(BusState *bus, void *opaque);
 typedef int (qdev_walkerfn)(DeviceState *dev, void *opaque);
 
-void qbus_create_inplace(void *bus, size_t size, const char *typename,
+void qbus_create_inplace(void *bus, size_t size, const char *typename_,
                          DeviceState *parent, const char *name);
-BusState *qbus_create(const char *typename, DeviceState *parent, const char *name);
+BusState *qbus_create(const char *typename_, DeviceState *parent, const char *name);
 /* Returns > 0 if either devfn or busfn skip walk somewhere in cursion,
  *         < 0 if either devfn or busfn terminate walk somewhere in cursion,
  *           0 otherwise. */

--- a/qemu/include/qom/cpu.h
+++ b/qemu/include/qom/cpu.h
@@ -402,7 +402,7 @@ void cpu_reset(CPUState *cpu);
  *
  * Returns: A #CPUClass or %NULL if not matching class is found.
  */
-ObjectClass *cpu_class_by_name(struct uc_struct *uc, const char *typename, const char *cpu_model);
+ObjectClass *cpu_class_by_name(struct uc_struct *uc, const char *typename_, const char *cpu_model);
 
 /**
  * cpu_generic_init:
@@ -413,7 +413,7 @@ ObjectClass *cpu_class_by_name(struct uc_struct *uc, const char *typename, const
  *
  * Returns: A #CPUState or %NULL if an error occurred.
  */
-CPUState *cpu_generic_init(struct uc_struct *uc, const char *typename, const char *cpu_model);
+CPUState *cpu_generic_init(struct uc_struct *uc, const char *typename_, const char *cpu_model);
 
 /**
  * cpu_has_work:

--- a/qemu/include/qom/object.h
+++ b/qemu/include/qom/object.h
@@ -409,7 +409,7 @@ struct ObjectClass
 struct Object
 {
     /*< private >*/
-    ObjectClass *class;
+    ObjectClass *class_;
     ObjectFree *free;
     QTAILQ_HEAD(, ObjectProperty) properties;
     uint32_t ref;
@@ -478,7 +478,7 @@ struct TypeInfo
     bool abstract;
 
     void *parent_type;
-    ObjectClass *class;
+    ObjectClass *class_;
 
     InterfaceInfo *interfaces;
 };
@@ -604,7 +604,7 @@ struct InterfaceClass
  *
  * Returns: The newly allocated and instantiated object.
  */
-Object *object_new(struct uc_struct *, const char *typename);
+Object *object_new(struct uc_struct *, const char *typename_);
 
 /**
  * object_initialize:
@@ -616,7 +616,7 @@ Object *object_new(struct uc_struct *, const char *typename);
  * have already been allocated.  The returned object has a reference count of 1,
  * and will be finalized when the last reference is dropped.
  */
-void object_initialize(struct uc_struct *uc, void *obj, size_t size, const char *typename);
+void object_initialize(struct uc_struct *uc, void *obj, size_t size, const char *typename_);
 
 /**
  * object_dynamic_cast:
@@ -628,7 +628,7 @@ void object_initialize(struct uc_struct *uc, void *obj, size_t size, const char 
  *
  * Returns: This function returns @obj on success or #NULL on failure.
  */
-Object *object_dynamic_cast(struct uc_struct *uc, Object *obj, const char *typename);
+Object *object_dynamic_cast(struct uc_struct *uc, Object *obj, const char *typename_);
 
 /**
  * object_dynamic_cast_assert:
@@ -639,7 +639,7 @@ Object *object_dynamic_cast(struct uc_struct *uc, Object *obj, const char *typen
  * This function is not meant to be called directly, but only through
  * the wrapper macro OBJECT_CHECK.
  */
-Object *object_dynamic_cast_assert(struct uc_struct *uc, Object *obj, const char *typename,
+Object *object_dynamic_cast_assert(struct uc_struct *uc, Object *obj, const char *typename_,
                                    const char *file, int line, const char *func);
 
 /**
@@ -692,7 +692,7 @@ Type type_register(struct uc_struct *uc, const TypeInfo *info);
  * the wrapper macros OBJECT_CLASS_CHECK and INTERFACE_CHECK.
  */
 ObjectClass *object_class_dynamic_cast_assert(struct uc_struct *uc, ObjectClass *klass,
-                                              const char *typename,
+                                              const char *typename_,
                                               const char *file, int line,
                                               const char *func);
 
@@ -711,7 +711,7 @@ ObjectClass *object_class_dynamic_cast_assert(struct uc_struct *uc, ObjectClass 
  * it.  (FIXME: perhaps this can be detected at type definition time?)
  */
 ObjectClass *object_class_dynamic_cast(struct uc_struct *uc, ObjectClass *klass,
-                                       const char *typename);
+                                       const char *typename_);
 
 /**
  * object_class_get_parent:
@@ -743,7 +743,7 @@ bool object_class_is_abstract(ObjectClass *klass);
  *
  * Returns: The class for @typename or %NULL if not found.
  */
-ObjectClass *object_class_by_name(struct uc_struct *uc, const char *typename);
+ObjectClass *object_class_by_name(struct uc_struct *uc, const char *typename_);
 
 void object_class_foreach(struct uc_struct *uc, void (*fn)(ObjectClass *klass, void *opaque),
                           const char *implements_type, bool include_abstract,
@@ -1034,7 +1034,7 @@ Object *object_resolve_path(struct uc_struct *uc, const char *path, bool *ambigu
  *
  * Returns: The matched object or NULL on path lookup failure.
  */
-Object *object_resolve_path_type(struct uc_struct *uc, const char *path, const char *typename,
+Object *object_resolve_path_type(struct uc_struct *uc, const char *path, const char *typename_,
                                  bool *ambiguous);
 
 /**

--- a/qemu/qom/object.c
+++ b/qemu/qom/object.c
@@ -333,7 +333,7 @@ static void object_initialize_with_type(struct uc_struct *uc, void *data, size_t
     g_assert(size >= type->instance_size);
 
     memset(obj, 0, type->instance_size);
-    obj->class = type->class;
+    obj->class_ = type->class;
     object_ref(obj);
     QTAILQ_INIT(&obj->properties);
     object_init_with_type(uc, obj, type);
@@ -403,7 +403,7 @@ static void object_deinit(struct uc_struct *uc, Object *obj, TypeImpl *type)
 static void object_finalize(struct uc_struct *uc, void *data)
 {
     Object *obj = data;
-    TypeImpl *ti = obj->class->type;
+    TypeImpl *ti = obj->class_->type;
 
     object_property_del_all(uc, obj);
     object_deinit(uc, obj, ti);
@@ -571,12 +571,12 @@ out:
 
 const char *object_get_typename(Object *obj)
 {
-    return obj->class->type->name;
+    return obj->class_->type->name;
 }
 
 ObjectClass *object_get_class(Object *obj)
 {
-    return obj->class;
+    return obj->class_;
 }
 
 bool object_class_is_abstract(ObjectClass *klass)
@@ -1002,8 +1002,8 @@ static void object_finalize_child_property(struct uc_struct *uc, Object *obj, co
 {
     Object *child = opaque;
 
-    if (child->class->unparent) {
-        (child->class->unparent)(uc, child);
+    if (child->class_->unparent) {
+        (child->class_->unparent)(uc, child);
     }
     child->parent = NULL;
     object_unref(uc, child);

--- a/uc.c
+++ b/uc.c
@@ -28,7 +28,7 @@
 static void free_table(gpointer key, gpointer value, gpointer data)
 {
     TypeInfo *ti = (TypeInfo*) value;
-    g_free((void *) ti->class);
+    g_free((void *) ti->class_);
     g_free((void *) ti->name);
     g_free((void *) ti->parent);
     g_free((void *) ti);


### PR DESCRIPTION
- typename, class, and class are all keywords for MSVC. Adding a suffix to all of them to avoid potential conflicts.
- Switching program database options for DEBUG builds from /ZI to /Zi to avoid crashes at longjmps (see [explanation](https://developercommunity.visualstudio.com/content/problem/282418/unicorn-library-crashes-when-calling-longjmp-and-c.html)).

Successfully compiled and tested under VC 2017 (15.9) after upgrading the build target to v141_xp. Confirmed with @rhelmot and got her approval.