### PR TITLE
fix oss-fuzz issue 10334

### DIFF
--- a/qemu/target-i386/unicorn.c
+++ b/qemu/target-i386/unicorn.c
@@ -35,6 +35,8 @@ void x86_release(void *ctx)
     int i;
     TCGContext *s = (TCGContext *) ctx;
 
+    cpu_breakpoint_remove_all(s->uc->cpu, BP_CPU);
+
     release_common(ctx);
 
     // arch specific


### PR DESCRIPTION
fix oss-fuzz issue 10334: unicorn/fuzz_emu_x86_32: Direct-leak in g_malloc.