### PR TITLE
Calling emu_stop in the hook_code of the arm causes the pc to be inconsistent.

### DIFF
--- a/qemu/cpu-exec.c
+++ b/qemu/cpu-exec.c
@@ -327,7 +327,8 @@ static tcg_target_ulong cpu_tb_exec(CPUState *cpu, uint8_t *tb_ptr)
         } else {
             assert(cc->set_pc);
             // avoid sync twice when helper_uc_tracecode() already did this.
-            if (env->uc->emu_counter <= env->uc->emu_count && !env->uc->quit_request)
+            if (env->uc->emu_counter <= env->uc->emu_count &&
+                    !env->uc->stop_request && !env->uc->quit_request)
                 cc->set_pc(cpu, tb->pc);
         }
     }


### PR DESCRIPTION
Fix the error in the hook_code of the arm, calling emu_stop and causing the pc value to be incorrect after the end of the run.
poc :
```
from unicorn import *
from unicorn.arm_const import *
# import regress

# code to be emulated

def hook_fuc(mu, addr, size, data):
    pc = mu.reg_read(UC_ARM_REG_PC)
    print("hook pc is : 0x%x" % pc)
    if pc == 0x8034:
        mu.emu_stop()


CODE_ADDRESS = 0x8000
code = '''
    mov r0, 0
    bl fuc1
    nop
    nop
    bl fuc2
    nop
    nop
    bl fuc3
    nop
    nop
    b end

fuc1:
    add r0, 1
    add r0, 1
    bx lr

fuc2:
    add r0, 2
    add r0, 2
    bx lr

fuc3:
    add r0, r0
    add r0, r0
    bx lr

end:
    nop
    nop
'''
code = b'\x00\x00\xa0\xe3\x08\x00\x00\xeb\x00\xf0 \xe3\x00\xf0 \xe3\x08\x00\x00\xeb\x00\xf0 \xe3\x00\xf0 \xe3\x08\x00\x00\xeb\x00\xf0 \xe3\x00\xf0 \xe3\x08\x00\x00\xea\x01\x00\x80\xe2\x01\x00\x80\xe2\x1e\xff/\xe1\x02\x00\x80\xe2\x02\x00\x80\xe2\x1e\xff/\xe1\x00\x00\x80\xe0\x00\x00\x80\xe0\x1e\xff/\xe1\x00\xf0 \xe3\x00\xf0 \xe3'

try:
    mu = Uc(UC_ARCH_ARM, UC_MODE_ARM)
    mu.mem_map(CODE_ADDRESS, 2 * 1024 * 1024)
    mu.mem_write(CODE_ADDRESS, code)

    mu.hook_add(UC_HOOK_CODE, hook_fuc)

    print("Starting emulation")

    mu.emu_start(CODE_ADDRESS, CODE_ADDRESS + len(code))

    print("Emulation done")

    pc = mu.reg_read(UC_ARM_REG_PC)
    print(">>> pc: 0x%x" % (pc))

except UcError as e:
    print("ERROR: %s" % e)
```
result:
```
Starting emulation
hook pc is : 0x8000
hook pc is : 0x8004
hook pc is : 0x802c
hook pc is : 0x8030
hook pc is : 0x8034
Emulation done
>>> pc: 0x802c
```
The result of the final output would have been 0x8034, but it was 0x802c.
I found out by reading the code that the program ends when emu_stop is set by setting uc->stop_request to true.
code : 
```
UNICORN_EXPORT
uc_err uc_emu_stop(uc_engine *uc)
{
    if (uc->emulation_done)
        return UC_ERR_OK;

    uc->stop_request = true;
    // TODO: make this atomic somehow?
    if (uc->current_cpu) {
        // exit the current TB
        cpu_exit(uc->current_cpu);
    }

    return UC_ERR_OK;
}
```
However, after running a basic block, when updating the pc, I found that when calling cc->set_pc, it did not judge whether env->uc->stop_request is True, which caused the pc to be updated twice. The entry address of the basic block, which caused this bug.
```
static tcg_target_ulong cpu_tb_exec(CPUState *cpu, uint8_t *tb_ptr)
{
    CPUArchState *env = cpu->env_ptr;
    TCGContext *tcg_ctx = env->uc->tcg_ctx;
    uintptr_t next_tb;

    next_tb = tcg_qemu_tb_exec(env, tb_ptr);

    if ((next_tb & TB_EXIT_MASK) > TB_EXIT_IDX1) {
        /* We didn't start executing this TB (eg because the instruction
         * counter hit zero); we must restore the guest PC to the address
         * of the start of the TB.
         */
        CPUClass *cc = CPU_GET_CLASS(env->uc, cpu);
        TranslationBlock *tb = (TranslationBlock *)(next_tb & ~TB_EXIT_MASK);
        if (cc->synchronize_from_tb) {
            // avoid sync twice when helper_uc_tracecode() already did this.
            if (env->uc->emu_counter <= env->uc->emu_count &&
                    !env->uc->stop_request && !env->uc->quit_request)
                cc->synchronize_from_tb(cpu, tb);
        } else {
            assert(cc->set_pc);
            // avoid sync twice when helper_uc_tracecode() already did this.
            if (env->uc->emu_counter <= env->uc->emu_count && !env->uc->quit_request)
                cc->set_pc(cpu, tb->pc);
        }
    }
    if ((next_tb & TB_EXIT_MASK) == TB_EXIT_REQUESTED) {
        /* We were asked to stop executing TBs (probably a pending
         * interrupt. We've now stopped, so clear the flag.
         */
        cpu->tcg_exit_req = 0;
    }
    return next_tb;
}
```