### PR TITLE
fix oss-fuzz issue 10578.

### DIFF
--- a/qemu/target-i386/ops_sse.h
+++ b/qemu/target-i386/ops_sse.h
@@ -2037,10 +2037,14 @@ static inline unsigned pcmpxstrx(CPUX86State *env, Reg *d, Reg *s,
         }
         break;
     case 3:
+        if (validd == -1) {
+            res = (2 << upper) - 1;
+            break;
+        }
         for (j = valids - validd; j >= 0; j--) {
             res <<= 1;
             v = 1;
-            for (i = MIN(upper - j, validd); i >= 0; i--) {
+            for (i = validd; i >= 0; i--) {
                 v &= (pcmp_val(s, ctrl, i + j) == pcmp_val(d, ctrl, i));
             }
             res |= v;


### PR DESCRIPTION
fix oss-fuzz issue 10578.
Issue 10578: unicorn/fuzz_emu_x86_32: Crash in helper_pcmpestrm_xmm.