### PR TITLE
Java Binding Makefile Updated

### DIFF
--- a/bindings/java/Makefile.build
+++ b/bindings/java/Makefile.build
@@ -3,7 +3,7 @@
 
 JAVA_HOME := $(shell jrunscript -e 'java.lang.System.out.println(java.lang.System.getProperty("java.home"));')
 
-JAVA_INC := $(shell realpath $(JAVA_HOME)/../include)
+JAVA_INC := $(shell realpath $(JAVA_HOME)/include)
 
 JAVA_PLATFORM_INC := $(shell dirname `find $(JAVA_INC) -name jni_md.h`)
 
@@ -46,7 +46,7 @@ all: lib jar samples
 	$(CC) -c $(CFLAGS) $(INCS) $< -o $@
 
 unicorn_Unicorn.h: unicorn/Unicorn.java
-	javah unicorn.Unicorn
+	javac -h . unicorn/Unicorn.java
 
 unicorn_Unicorn.o: unicorn_Unicorn.c unicorn_Unicorn.h
 	$(CC) -c $(CFLAGS) $(INCS) $< -o $@


### PR DESCRIPTION
New versions of Java JDK are not using javah anymore for generating header files. Instead now javac is used with the -h option.

Last commit not updated.