### PR TITLE
Timeout error

### DIFF
--- a/include/uc_priv.h
+++ b/include/uc_priv.h
@@ -227,6 +227,7 @@ struct uc_struct {
     bool stop_request;  // request to immediately stop emulation - for uc_emu_stop()
     bool quit_request;  // request to quit the current TB, but continue to emulate - for uc_mem_protect()
     bool emulation_done;  // emulation is done by uc_emu_start()
+    bool timed_out;     // emulation timed out, uc_emu_start() will result in EC_ERR_TIMEOUT
     QemuThread timer;   // timer for emulation timeout
     uint64_t timeout;   // timeout for uc_emu_start()
 

--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -163,7 +163,8 @@ typedef enum uc_err {
     UC_ERR_FETCH_UNALIGNED,  // Unaligned fetch
     UC_ERR_HOOK_EXIST,  // hook for this event already existed
     UC_ERR_RESOURCE,    // Insufficient resource: uc_emu_start()
-    UC_ERR_EXCEPTION // Unhandled CPU exception
+    UC_ERR_EXCEPTION, // Unhandled CPU exception
+    UC_ERR_TIMEOUT // Emulation timed out
 } uc_err;
 
 

--- a/samples/sample_x86.c
+++ b/samples/sample_x86.c
@@ -382,8 +382,8 @@ static void test_i386_loop(void)
     // emulate machine code in 2 seconds, so we can quit even
     // if the code loops
     err = uc_emu_start(uc, ADDRESS, ADDRESS + sizeof(X86_CODE32_LOOP) - 1, 2 * UC_SECOND_SCALE, 0);
-    if (err) {
-        printf("Failed on uc_emu_start() with error returned %u: %s\n",
+    if (err != UC_ERR_TIMEOUT) {
+        printf("Failed on uc_emu_start() with error returned %u: %s, expected UC_ERR_TIMEOUT\n",
                 err, uc_strerror(err));
     }
 

--- a/tests/unit/test_x86.c
+++ b/tests/unit/test_x86.c
@@ -379,7 +379,7 @@ static void test_i386_loop(void **state)
     // emulate machine code in 2 seconds, so we can quit even
     // if the code loops
     err = uc_emu_start(uc, address, address+sizeof(code), 2*UC_SECOND_SCALE, 0);
-    uc_assert_success(err);
+    uc_assert_err(err, UC_ERR_TIMEOUT);
 
     // verify register values
     uc_assert_success(uc_reg_read(uc, UC_X86_REG_ECX, &r_ecx));


### PR DESCRIPTION
I was working on a project where I had to measure generated code and noticed that I had no way of telling if the code runs for infinite time so I had to implement it myself, this PR is a side effect of my needs and maybe it provides to be useful in the main code base. This PR implements a new error code UC_ERR_TIMEOUT, to do that I had to add a new state variable which is reset in uc_emu_start and set in the timeout thread function. I also adjusted the sample to reflect the new change.