### PR TITLE
Fix timeout race bug in unicorn.

### DIFF
--- a/include/uc_priv.h
+++ b/include/uc_priv.h
@@ -225,6 +225,7 @@ struct uc_struct {
 
     bool init_tcg;      // already initialized local TCGv variables?
     bool stop_request;  // request to immediately stop emulation - for uc_emu_stop()
+    bool timeout_request;  // request to timeout - for _timeout_fn()
     bool quit_request;  // request to quit the current TB, but continue to emulate - for uc_mem_protect()
     bool emulation_done;  // emulation is done by uc_emu_start()
     QemuThread timer;   // timer for emulation timeout

--- a/qemu/cpu-exec.c
+++ b/qemu/cpu-exec.c
@@ -219,6 +219,9 @@ int cpu_exec(struct uc_struct *uc, CPUArchState *env)   // qq
                 if (unlikely(cpu->exit_request)) {
                     cpu->exit_request = 0;
                     cpu->exception_index = EXCP_INTERRUPT;
+                    if(uc->timeout_request){
+                        uc->stop_request = true;
+                    }
                     cpu_loop_exit(cpu);
                 }
 
@@ -322,13 +325,13 @@ static tcg_target_ulong cpu_tb_exec(CPUState *cpu, uint8_t *tb_ptr)
         if (cc->synchronize_from_tb) {
             // avoid sync twice when helper_uc_tracecode() already did this.
             if (env->uc->emu_counter <= env->uc->emu_count &&
-                    !env->uc->stop_request && !env->uc->quit_request)
+                    !env->uc->stop_request && !env->uc->quit_request && !!env->uc->timeout_request)
                 cc->synchronize_from_tb(cpu, tb);
         } else {
             assert(cc->set_pc);
             // avoid sync twice when helper_uc_tracecode() already did this.
             if (env->uc->emu_counter <= env->uc->emu_count &&
-                    !env->uc->stop_request && !env->uc->quit_request)
+                    !env->uc->stop_request && !env->uc->quit_request && !!env->uc->timeout_request)
                 cc->set_pc(cpu, tb->pc);
         }
     }

--- a/uc.c
+++ b/uc.c
@@ -505,7 +505,15 @@ static void *_timeout_fn(void *arg)
     // timeout before emulation is done?
     if (!uc->emulation_done) {
         // force emulation to stop
-        uc_emu_stop(uc);
+        uc->timeout_request = true;
+        
+        if (uc->current_cpu) {
+            // exit the current TB
+            cpu_exit(uc->current_cpu);
+        }else{
+            uc->stop_request = true;
+        }
+
     }
 
     return NULL;
@@ -593,6 +601,7 @@ uc_err uc_emu_start(uc_engine* uc, uint64_t begin, uint64_t until, uint64_t time
     }
 
     uc->stop_request = false;
+    uc->timeout_request = false;
 
     uc->emu_count = count;
     // remove count hook if counting isn't necessary


### PR DESCRIPTION
When unicorn uses the timeout function, there are two competing bugs.
example 1：
When timeout is set and an interrupt is triggered, there is a certain probability that the UC_ERR_EXCEPTION abnormal behavior is triggered.
poc:
```
from unicorn import *
from unicorn.arm_const import *

def hook_intr(uc, intno, user_data):
    global intr_num, last_pc
    intr_num += 1
    pc = mu.reg_read(UC_ARM_REG_PC)
    last_pc = pc
    print("intr pc is : 0x%x" % pc)

def hook_code(mu, addr, size, data):
    pc = mu.reg_read(UC_ARM_REG_PC)
    print("hook pc is : 0x%x" % pc)

CODE_ADDRESS = 0x8000
code = '''
    mov r0, 0
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    swi 0
'''
code = b'\x00\x00\xa0\xe3' + b'\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x00\x00\x00\xef' * 40

try_number = 0x2000

while True:
    try:
        try_number -= 1
        if try_number == 0:
            break
        global intr_num
        global last_pc

        intr_pc = [0x804c, 0x8094, 0x80dc, 0x8124, 0x816c, 0x81b4, 0x81fc, 0x8244, 0x828c, 0x82d4, 0x831c, 0x8364, 0x83ac, 0x83f4, 0x843c, 0x8484, 0x84cc, 0x8514, 0x855c, 0x85a4, 0x85ec, 0x8634, 0x867c, 0x86c4, 0x870c, 0x8754, 0x879c, 0x87e4, 0x882c, 0x8874, 0x88bc, 0x8904, 0x894c, 0x8994, 0x89dc, 0x8a24, 0x8a6c, 0x8ab4, 0x8afc, 0x8b44]

        intr_num = 0
        mu = Uc(UC_ARCH_ARM, UC_MODE_ARM)
        mu.mem_map(CODE_ADDRESS, 2 * 1024 * 1024)
        mu.mem_write(CODE_ADDRESS, code)

        mu.hook_add(UC_HOOK_INTR, hook_intr)
        # mu.hook_add(UC_HOOK_CODE, hook_code)

        print("Starting emulation")

        mu.emu_start(CODE_ADDRESS, CODE_ADDRESS + len(code), timeout = 1000)

        print("Emulation done")

        pc = mu.reg_read(UC_ARM_REG_PC)

        print(">>> pc: 0x%x" % (pc))
        print("intr number is : ", intr_num)

        del mu
    except UcError as e:
        print("ERROR: %s" % e)
        pc = mu.reg_read(UC_ARM_REG_PC)

        print(">>> pc: 0x%x" % (pc))
        print("intr number is : ", intr_num)
        break

if try_number == 0:
    print("good job!")
```

result:
```
intr pc is : 0x8244
intr pc is : 0x828c
intr pc is : 0x82d4
intr pc is : 0x831c
intr pc is : 0x8364
intr pc is : 0x83ac
ERROR: Unhandled CPU exception (UC_ERR_EXCEPTION)
>>> pc: 0x83f4
intr number is :  13
```
Cause Analysis:When setting timeout, there is a certain probability that emu_stop () will be triggered in the following code snippet.
```
                    bool catched = false;
#if defined(CONFIG_USER_ONLY)
                    /* if user mode only, we simulate a fake exception
                       which will be handled outside the cpu execution
                       loop */
#if defined(TARGET_I386)
                    cc->do_interrupt(cpu);
#endif
                    ret = cpu->exception_index;
                    break;
#else
                    if (uc->stop_interrupt && uc->stop_interrupt(cpu->exception_index)) {
                        // Unicorn: call registered invalid instruction callbacks
                        HOOK_FOREACH_VAR_DECLARE;
                        HOOK_FOREACH(uc, hook, UC_HOOK_INSN_INVALID) {
                            catched = ((uc_cb_hookinsn_invalid_t)hook->callback)(uc, hook->user_data);
                            if (catched)
                                break;
                        }
                        if (!catched)
                            uc->invalid_error = UC_ERR_INSN_INVALID;
                    } else {
                        // Unicorn: call registered interrupt callbacks
                        HOOK_FOREACH_VAR_DECLARE;
                        HOOK_FOREACH(uc, hook, UC_HOOK_INTR) {
                            ((uc_cb_hookintr_t)hook->callback)(uc, cpu->exception_index, hook->user_data);
                            catched = true;
                        }
                        if (!catched)
                            uc->invalid_error = UC_ERR_EXCEPTION;
                    }
```
After the emu_stop () is triggered, the HOOK program will not be executed again, which causes catched to fail, so the UC_ERR_EXCEPTION exception is triggered.

example 2：
After unicorn set timeout, there is a probability that the interrupt instruction has been executed, but hook_interrupt has not been executed.
poc:
```
from unicorn import *
from unicorn.arm_const import *

def hook_intr(uc, intno, user_data):
    global intr_num, last_pc
    intr_num += 1
    pc = mu.reg_read(UC_ARM_REG_PC)
    last_pc = pc
    print("intr pc is : 0x%x" % pc)

def hook_code(mu, addr, size, data):
    pc = mu.reg_read(UC_ARM_REG_PC)
    print("hook pc is : 0x%x" % pc)

CODE_ADDRESS = 0x8000
code = '''
    mov r0, 0
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    add r0, 1
    swi 0
'''
code = b'\x00\x00\xa0\xe3' + b'\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x01\x00\x80\xe2\x00\x00\x00\xef' * 40

try_number = 0x2000

while True:
    try:
        try_number -= 1
        if try_number == 0:
            break
        global intr_num
        global last_pc

        intr_pc = [0x804c, 0x8094, 0x80dc, 0x8124, 0x816c, 0x81b4, 0x81fc, 0x8244, 0x828c, 0x82d4, 0x831c, 0x8364, 0x83ac, 0x83f4, 0x843c, 0x8484, 0x84cc, 0x8514, 0x855c, 0x85a4, 0x85ec, 0x8634, 0x867c, 0x86c4, 0x870c, 0x8754, 0x879c, 0x87e4, 0x882c, 0x8874, 0x88bc, 0x8904, 0x894c, 0x8994, 0x89dc, 0x8a24, 0x8a6c, 0x8ab4, 0x8afc, 0x8b44]

        intr_num = 0
        mu = Uc(UC_ARCH_ARM, UC_MODE_ARM)
        mu.mem_map(CODE_ADDRESS, 2 * 1024 * 1024)
        mu.mem_write(CODE_ADDRESS, code)

        mu.hook_add(UC_HOOK_INTR, hook_intr)
        # mu.hook_add(UC_HOOK_CODE, hook_code)

        print("Starting emulation")

        mu.emu_start(CODE_ADDRESS, CODE_ADDRESS + len(code), timeout = 1000)

        print("Emulation done")

        pc = mu.reg_read(UC_ARM_REG_PC)

        print(">>> pc: 0x%x" % (pc))
        print("intr number is : ", intr_num)
        
        if (pc in intr_pc) and last_pc != pc:
            break

        del mu
    except UcError as e:
        print("ERROR: %s" % e)
        pc = mu.reg_read(UC_ARM_REG_PC)

        print(">>> pc: 0x%x" % (pc))
        print("intr number is : ", intr_num)
        break

if try_number == 0:
    print("good job!")
```
The program returns to the soft interrupt of the hook arm and processes the soft interrupt. When unicorn processes the interrupt in the program, it will execute the interrupted instruction first, and then execute the interrupted processing program after executing the instruction. This also causes the pc value obtained in the re-interrupt to be the next instruction of the interrupt instruction.
The intr_pc in the code stores the next instruction of all soft interrupts. It ends when the program triggers to the execution of the interrupt instruction, but does not capture the interrupt instruction.

result:
```
Starting emulation
intr pc is : 0x804c
intr pc is : 0x8094
intr pc is : 0x80dc
intr pc is : 0x8124
intr pc is : 0x816c
intr pc is : 0x81b4
intr pc is : 0x81fc
intr pc is : 0x8244
intr pc is : 0x828c
intr pc is : 0x82d4
intr pc is : 0x831c
intr pc is : 0x8364
intr pc is : 0x83ac
intr pc is : 0x83f4
intr pc is : 0x843c
intr pc is : 0x8484
intr pc is : 0x84cc
intr pc is : 0x8514
intr pc is : 0x855c
intr pc is : 0x85a4
intr pc is : 0x85ec
intr pc is : 0x8634
intr pc is : 0x867c
intr pc is : 0x86c4
intr pc is : 0x870c
intr pc is : 0x8754
Emulation done
>>> pc: 0x879c
intr number is :  26
```
As can be seen from the results of the program, the 27th interrupt was executed, but it was not captured.
The root cause is that when an interrupt is triggered, unicorn will execute cpu_loop_exit (cpu), and this will jump to the following code snippet:
```
if (sigsetjmp(cpu->jmp_env, 0) == 0) {
            if (uc->stop_request || uc->invalid_error) {
                break;
            }
```
If emu_stop is called before this, stop_request will be set to true, which will directly jump out of the large loop here, resulting in interrupts that cannot be captured.
The fix here is that unicorn can be ended only when the cpu exits.
Therefore, a new flag bit timeout_request is created. When the CPU exits, the flag bit will be detected to determine whether to end the simulation.