### PR TITLE
Fix a UAF bug when uc_hook_del is called in the hook callback function

### DIFF
--- a/uc.c
+++ b/uc.c
@@ -1180,10 +1180,10 @@ void helper_uc_tracecode(int32_t size, uc_hook_type type, void *handle, int64_t 
 
     while (cur != NULL && !uc->stop_request) {
         hook = (struct hook *)cur->data;
+        cur = cur->next;
         if (HOOK_BOUND_CHECK(hook, (uint64_t)address)) {
             ((uc_cb_hookcode_t)hook->callback)(uc, address, size, hook->user_data);
         }
-        cur = cur->next;
     }
 }
 


### PR DESCRIPTION
The following PoC will crash Unicorn. 

When `uc_hook_del` is called in callback, `uc_hook_del` will free the `cur` pointer in `helper_uc_tracecode`, but the `cur` pointer will be used (`cur = cur->next`) after the callback is executed, which results in a UAF bug.


PoC:

```c
#include <unicorn/unicorn.h>
#include <string.h>

static uc_hook trace1;

// code to be emulated
#define ARM_CODE "\x37\x00\xa0\xe3\x03\x10\x42\xe0\x37\x00\xa0\xe3\x03\x10\x42\xe0" // mov r0, #0x37; sub r1, r2, r3

// memory address where emulation starts
#define ADDRESS 0x10000

static void hook_code(uc_engine *uc, uint64_t address, uint32_t size, void *user_data)
{
    printf(">>> Tracing instruction at 0x%"PRIx64 ", instruction size = 0x%x\n", address, size);
    uc_hook_del(uc, trace1);
}

static void test_arm(void)
{
    uc_engine *uc;
    uc_err err;

    int r0 = 0x1234;     // R0 register
    int r2 = 0x6789;     // R1 register
    int r3 = 0x3333;     // R2 register
    int r1;     // R1 register

    printf("Emulate ARM code\n");

    // Initialize emulator in ARM mode
    err = uc_open(UC_ARCH_ARM, UC_MODE_ARM, &uc);
    if (err) {
        printf("Failed on uc_open() with error returned: %u (%s)\n",
                err, uc_strerror(err));
        return;
    }

    // map 2MB memory for this emulation
    uc_mem_map(uc, ADDRESS, 2 * 1024 * 1024, UC_PROT_ALL);

    // write machine code to be emulated to memory
    uc_mem_write(uc, ADDRESS, ARM_CODE, sizeof(ARM_CODE) - 1);

    // initialize machine registers
    uc_reg_write(uc, UC_ARM_REG_R0, &r0);
    uc_reg_write(uc, UC_ARM_REG_R2, &r2);
    uc_reg_write(uc, UC_ARM_REG_R3, &r3);

    // tracing one instruction at ADDRESS with customized callback
    uc_hook_add(uc, &trace1, UC_HOOK_CODE, hook_code, NULL, ADDRESS, ADDRESS + sizeof(ARM_CODE) -1);

    // emulate machine code in infinite time (last param = 0), or when
    // finishing all the code.
    err = uc_emu_start(uc, ADDRESS, ADDRESS + sizeof(ARM_CODE) -1, 0, 0);
    if (err) {
        printf("Failed on uc_emu_start() with error returned: %u\n", err);
    }

    // now print out some registers
    printf(">>> Emulation done. Below is the CPU context\n");

    uc_reg_read(uc, UC_ARM_REG_R0, &r0);
    uc_reg_read(uc, UC_ARM_REG_R1, &r1);
    printf(">>> R0 = 0x%x\n", r0);
    printf(">>> R1 = 0x%x\n", r1);

    uc_close(uc);
}

int main(int argc, char **argv, char **envp)
{
    
    test_arm();    
    return 0;
}
```

Output of the PoC:
```
root@ede9cacb5ba0:~/share# ./crash
Emulate ARM code
>>> Tracing instruction at 0x10000, instruction size = 0x4
Segmentation fault
```

After applying this PR:
```
root@99836e82473b:~/share# ./crash
Emulate ARM code
>>> Tracing instruction at 0x10000, instruction size = 0x4
>>> Emulation done. Below is the CPU context
>>> R0 = 0x37
>>> R1 = 0x3456
```

I found someone already opened a issue https://github.com/unicorn-engine/unicorn/issues/1127 and PR https://github.com/unicorn-engine/unicorn/pull/1130

But maybe my PR is a better solution