### PR TITLE
Fix block hooks being called twice after an early exit from execution.

### DIFF
--- a/qemu/cpu-exec.c
+++ b/qemu/cpu-exec.c
@@ -291,6 +291,9 @@ int cpu_exec(struct uc_struct *uc, CPUArchState *env)   // qq
         }
     } /* for(;;) */
 
+    // Unicorn: Clear any TCG exit flag that might have been left set by exit requests
+    uc->current_cpu->tcg_exit_req = 0;
+
     cc->cpu_exec_exit(cpu);
 
     // Unicorn: flush JIT cache to because emulation might stop in


### PR DESCRIPTION
Ensure the TCG exit flag is cleared at the end of cpu_exec. This ensures
that subsequent calls are not polluted by the prior call to request an
early exit. The symptoms of the problem being addressed here are that
after a cpu_exit call triggered within a hook there may still be a
pending tcg_exit_req flag set. This then causes a block to start its
execution and then be aborted (from which point it'll continue because
there's no other condition to service). The start of the execution
causes the block hook to be called, no actual code to be run, and then
the block started again with another block hook call.

This change is discussed in ticket 1193:
    https://github.com/unicorn-engine/unicorn/issues/1193