### PR TITLE
Make it easier to link against libunicorn on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ API_MAJOR=$(shell echo `grep -e UC_API_MAJOR include/unicorn/unicorn.h | grep -v
 ifeq ($(UNAME_S),Darwin)
 EXT = dylib
 VERSION_EXT = $(API_MAJOR).$(EXT)
-$(LIBNAME)_LDFLAGS += -dynamiclib -install_name lib$(LIBNAME).$(VERSION_EXT) -current_version $(PKG_MAJOR).$(PKG_MINOR).$(PKG_EXTRA) -compatibility_version $(PKG_MAJOR).$(PKG_MINOR)
+$(LIBNAME)_LDFLAGS += -dynamiclib -install_name @rpath/lib$(LIBNAME).$(VERSION_EXT) -current_version $(PKG_MAJOR).$(PKG_MINOR).$(PKG_EXTRA) -compatibility_version $(PKG_MAJOR).$(PKG_MINOR)
 AR_EXT = a
 UNICORN_CFLAGS += -fvisibility=hidden
 

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -60,6 +60,7 @@ else:
 
 if SYSTEM == 'darwin':
     LIBRARY_FILE = "libunicorn.dylib"
+    MAC_LIBRARY_FILE = "libunicorn*.dylib"
     STATIC_LIBRARY_FILE = None
 elif SYSTEM in ('win32', 'cygwin'):
     LIBRARY_FILE = "unicorn.dll"
@@ -171,7 +172,11 @@ def build_libraries():
 
         subprocess.call(cmd, env=new_env)
 
-        shutil.copy(LIBRARY_FILE, LIBS_DIR)
+        if SYSTEM == 'darwin':
+            for file in glob.glob(MAC_LIBRARY_FILE):
+                shutil.copy(file, LIBS_DIR, follow_symlinks=False)
+        else:
+            shutil.copy(LIBRARY_FILE, LIBS_DIR)
         try:
             # static library may fail to build on windows if user doesn't have visual studio installed. this is fine.
             if STATIC_LIBRARY_FILE is not None:


### PR DESCRIPTION
libunicorn.dylib is currently installed on macOS as unversioned but its install name is versioned and lacking an @rpath, making it difficult to use from clients without modifying it with `install_name_tool`. This change makes it easier to link against because now binaries that want to do so can adapt *their* `LC_RPATH` to match Unicorn's install location and the actual library does not have to be modified. See https://github.com/angr/angr/pull/1932 for how this is being used.