### PR TITLE
Python 3.8 compatibility

### DIFF
--- a/qemu/scripts/ordereddict.py
+++ b/qemu/scripts/ordereddict.py
@@ -25,7 +25,10 @@ try:
     from UserDict import DictMixin
 except ImportError:
     from collections import UserDict
-    from collections import MutableMapping as DictMixin
+    try:
+        from collections import MutableMapping as DictMixin
+    except ImportError:
+        from collections.abc import MutableMapping as DictMixin
 
 class OrderedDict(dict, DictMixin):
 


### PR DESCRIPTION
Python 3.8 moved some types from `collections` to `collections.abc`.