### PR TITLE
Expose uc_vmem_{read,write} to users

### DIFF
--- a/include/uc_priv.h
+++ b/include/uc_priv.h
@@ -54,6 +54,9 @@ typedef bool (*uc_write_mem_t)(AddressSpace *as, hwaddr addr, const uint8_t *buf
 
 typedef bool (*uc_read_mem_t)(AddressSpace *as, hwaddr addr, uint8_t *buf, int len);
 
+typedef bool (*uc_read_vmem_t)(CPUState *cpu, hwaddr addr, uint8_t *buf, int len);
+typedef bool (*uc_write_vmem_t)(CPUState *cpu, hwaddr addr, const uint8_t *buf, int len);
+
 typedef void (*uc_args_void_t)(void*);
 
 typedef void (*uc_args_uc_t)(struct uc_struct*);
@@ -158,6 +161,8 @@ struct uc_struct {
 
     uc_write_mem_t write_mem;
     uc_read_mem_t read_mem;
+    uc_read_vmem_t read_vmem;
+    uc_write_vmem_t write_vmem;
     uc_args_void_t release;     // release resource when uc_close()
     uc_args_uc_u64_t set_pc;  // set PC for tracecode
     uc_args_int_t stop_interrupt;   // check if the interrupt should stop emulation

--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -521,6 +521,38 @@ UNICORN_EXPORT
 uc_err uc_mem_read(uc_engine *uc, uint64_t address, void *bytes, size_t size);
 
 /*
+ Write to a range of bytes in virtual memory.
+
+ @uc: handle returned by uc_open()
+ @address: starting memory address of bytes to set.
+ @bytes:   pointer to a variable containing data to be written to memory.
+ @size:   size of memory to write to.
+
+ NOTE: @bytes must be big enough to contain @size bytes.
+
+ @return UC_ERR_OK on success, or other value on failure (refer to uc_err enum
+   for detailed error).
+*/
+UNICORN_EXPORT
+uc_err uc_vmem_write(uc_engine *uc, uint64_t address, const void *bytes, size_t size);
+
+/*
+ Read a range of bytes in virtual memory.
+
+ @uc: handle returned by uc_open()
+ @address: starting memory address of bytes to get.
+ @bytes:   pointer to a variable containing data copied from memory.
+ @size:   size of memory to read.
+
+ NOTE: @bytes must be big enough to contain @size bytes.
+
+ @return UC_ERR_OK on success, or other value on failure (refer to uc_err enum
+   for detailed error).
+*/
+UNICORN_EXPORT
+uc_err uc_vmem_read(uc_engine *uc, uint64_t address, void *bytes, size_t size);
+
+/*
  Emulate machine code in a specific duration of time.
 
  @uc: handle returned by uc_open()

--- a/qemu/unicorn_common.h
+++ b/qemu/unicorn_common.h
@@ -19,6 +19,18 @@ static inline bool cpu_physical_mem_write(AddressSpace *as, hwaddr addr,
     return !cpu_physical_memory_rw(as, addr, (void *)buf, len, 1);
 }
 
+static inline bool cpu_virtual_mem_read(CPUState *cpu, hwaddr addr,
+					uint8_t *buf, int len)
+{
+	return !cpu_memory_rw_debug(cpu, addr, (void *)buf, len, 0);
+}
+
+static inline bool cpu_virtual_mem_write(CPUState *cpu, hwaddr addr,
+					const uint8_t *buf, int len)
+{
+	return !cpu_memory_rw_debug(cpu, addr, (void *)buf, len, 1);
+}
+
 void tb_cleanup(struct uc_struct *uc);
 void free_code_gen_buffer(struct uc_struct *uc);
 
@@ -70,6 +82,8 @@ static inline void uc_common_init(struct uc_struct* uc)
     memory_register_types(uc);
     uc->write_mem = cpu_physical_mem_write;
     uc->read_mem = cpu_physical_mem_read;
+    uc->write_vmem = cpu_virtual_mem_write;
+    uc->read_vmem = cpu_virtual_mem_read;
     uc->tcg_enabled = tcg_enabled;
     uc->tcg_exec_init = tcg_exec_init;
     uc->cpu_exec_init_all = cpu_exec_init_all;

--- a/uc.c
+++ b/uc.c
@@ -414,6 +414,23 @@ static bool check_mem_area(uc_engine *uc, uint64_t address, size_t size)
     return (count == size);
 }
 
+UNICORN_EXPORT
+uc_err uc_vmem_read(uc_engine *uc, uint64_t address, void *_bytes, size_t size)
+{
+       bool res = uc->read_vmem(uc->cpu, address, _bytes, size);
+       if (res) return UC_ERR_OK;
+       else return UC_ERR_MAP;
+
+}
+
+UNICORN_EXPORT
+uc_err uc_vmem_write(uc_engine *uc, uint64_t address, const void *_bytes, size_t size)
+{
+       bool res = uc->write_vmem(uc->cpu, address, _bytes, size);
+       if (res) return UC_ERR_OK;
+       else return UC_ERR_MAP;
+}
+
 
 UNICORN_EXPORT
 uc_err uc_mem_read(uc_engine *uc, uint64_t address, void *_bytes, size_t size)


### PR DESCRIPTION
Uses `cpu_memory_rw_debug()` to resolve a virtual address and perform some read/write. 
I've only tested this on 32-bit ARM - don't know if this particular path works for other guest architectures.