### PR TITLE
The expression(args[i] < 0) always returns false

### DIFF
--- a/qemu/tcg/optimize.c
+++ b/qemu/tcg/optimize.c
@@ -1370,7 +1370,7 @@ static TCGArg *tcg_constant_folding(TCGContext *s, uint16_t *tcg_opc_ptr,
             } else {
         do_reset_output:
                 for (i = 0; i < nb_oargs; i++) {
-                    if (args[i] < 0 || args[i] >= TCG_MAX_TEMPS) {
+                    if (args[i] >= TCG_MAX_TEMPS) {
                         continue;
                     }
                     reset_temp(s, args[i]);

--- a/qemu/tcg/tcg.c
+++ b/qemu/tcg/tcg.c
@@ -1719,7 +1719,7 @@ static void tcg_liveness_analysis(TCGContext *s)
                implies side effects */
             if (!(def->flags & TCG_OPF_SIDE_EFFECTS) && nb_oargs != 0) {
                 for(i = 0; i < nb_oargs; i++) {
-                    if (args[i] < 0 || args[i] >= TCG_MAX_TEMPS) {
+                    if (args[i] >= TCG_MAX_TEMPS) {
                         continue;
                     }
                     arg = args[i];


### PR DESCRIPTION
`typedef uint64_t tcg_target_ulong;
typedef tcg_target_ulong TCGArg;
TCGArg *args`

`} else { do_reset_output: for (i = 0; i < nb_oargs; i++) { if (args[i] < 0 || args[i] >= TCG_MAX_TEMPS) {`

`if (!(def->flags & TCG_OPF_SIDE_EFFECTS) && nb_oargs != 0) { for(i = 0; i < nb_oargs; i++) { for(i = 0; i < nb_oargs; i++) { if (args[i] < 0 || args[i] >= TCG_MAX_TEMPS) {`

The expression(args[i] < 0) always returns false.So i deleted it