### PR TITLE
fix binding install on python2

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -174,7 +174,10 @@ def build_libraries():
 
         if SYSTEM == 'darwin':
             for file in glob.glob(MAC_LIBRARY_FILE):
-                shutil.copy(file, LIBS_DIR, follow_symlinks=False)
+                try:
+                    shutil.copy(file, LIBS_DIR, follow_symlinks=False)
+                except:
+                    shutil.copy(file, LIBS_DIR)
         else:
             shutil.copy(LIBRARY_FILE, LIBS_DIR)
         try:


### PR DESCRIPTION
Installing the python binding with python2 errors as the `shutil.copy` function doesn't have this parameters[1].

[1] https://docs.python.org/2.7/library/shutil.html