### PR TITLE
fix macro/struct redefinition from winsock2.h

### DIFF
--- a/include/unicorn/platform.h
+++ b/include/unicorn/platform.h
@@ -155,17 +155,7 @@ typedef _W64 unsigned int  uintptr_t;
 // sys/time.h compatibility
 #if defined(_MSC_VER)
 #include <sys/timeb.h>
-#include <winsock2.h>
 #include <windows.h>
-
-static int gettimeofday(struct timeval* t, void* timezone)
-{
-    struct _timeb timebuffer;
-    _ftime( &timebuffer );
-    t->tv_sec = (long)timebuffer.time;
-    t->tv_usec = 1000*timebuffer.millitm;
-    return 0;
-}
 #else
 #include <sys/time.h>
 #endif

--- a/qemu/include/qemu/timer.h
+++ b/qemu/include/qemu/timer.h
@@ -158,6 +158,30 @@ static inline int64_t get_ticks_per_sec(void)
  */
 
 /* real time host monotonic timer */
+#ifdef _WIN32
+static inline int64_t get_clock_realtime(void)
+{
+    // code from https://stackoverflow.com/questions/10905892/equivalent-of-gettimeday-for-windows
+    // >>>>>>>>>
+    const uint64_t EPOCH = ((uint64_t)116444736000000000ULL);
+
+    long tv_sec, tv_usec;
+    SYSTEMTIME system_time;
+    FILETIME file_time;
+    uint64_t time;
+
+    GetSystemTime(&system_time);
+    SystemTimeToFileTime(&system_time, &file_time);
+    time = ((uint64_t)file_time.dwLowDateTime);
+    time += ((uint64_t)file_time.dwHighDateTime) << 32;
+
+    tv_sec = (long)((time - EPOCH) / 10000000L);
+    tv_usec = (long)(system_time.wMilliseconds * 1000);
+    // <<<<<<<<<
+
+    return tv_sec * 1000000000LL + (tv_usec * 1000);
+}
+#else
 static inline int64_t get_clock_realtime(void)
 {
     struct timeval tv;
@@ -165,6 +189,7 @@ static inline int64_t get_clock_realtime(void)
     gettimeofday(&tv, NULL);
     return tv.tv_sec * 1000000000LL + (tv.tv_usec * 1000);
 }
+#endif
 
 /* Warning: don't insert tracepoints into these functions, they are
    also used by simpletrace backend and tracepoints would cause
@@ -180,7 +205,6 @@ static inline int64_t get_clock(void)
 }
 
 #else
-
 extern int use_rt_clock;
 
 static inline int64_t get_clock(void)

--- a/qemu/include/qemu/timer.h
+++ b/qemu/include/qemu/timer.h
@@ -181,9 +181,19 @@ static inline int64_t get_clock(void)
 
 #else
 
+extern int use_rt_clock;
+
 static inline int64_t get_clock(void)
 {
-    return get_clock_realtime();
+    if (use_rt_clock) {
+        struct timespec ts;
+        clock_gettime(CLOCK_MONOTONIC, &ts);
+        return ts.tv_sec * 1000000000LL + ts.tv_nsec;
+    } else {
+        /* XXX: using gettimeofday leads to problems if the date
+           changes, so it should be avoided. */
+        return get_clock_realtime();
+    }
 }
 #endif
 

--- a/qemu/util/qemu-timer-common.c
+++ b/qemu/util/qemu-timer-common.c
@@ -40,4 +40,17 @@ INITIALIZER(init_get_clock)
     }
     clock_freq = freq.QuadPart;
 }
+
+#else
+int use_rt_clock;
+
+INITIALIZER(init_get_clock)
+{
+    struct timespec ts;
+
+    use_rt_clock = 0;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
+        use_rt_clock = 1;
+    }
+}
 #endif


### PR DESCRIPTION
A new fix for issue #1214. No new macro is introduced this time. 

I have to say it is hard to decide which internal header file `gettimeofday()` moves to. But I found `gettimeofday()` is called at only one place, so I choose to inline it manually. 

BTW, I also fixed a very old issue #635. Just merge code from upstream.