### PR TITLE
cmake: fix static linking due to cyclic deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ set(UNICORN_VERSION_PATCH 2)
 
 option(UNICORN_BUILD_SHARED "Build shared instead of static library" ON)
 
-if(NOT UNICORN_ARCH)
+if (NOT UNICORN_ARCH)
     # build all architectures
     set(UNICORN_ARCH "x86 arm aarch64 m68k mips sparc")
 endif()
@@ -293,6 +293,9 @@ add_library(x86_64-softmmu
     qemu/tcg/tcg.c
     qemu/translate-all.c
 )
+if (NOT UNICORN_BUILD_SHARED)
+    target_link_libraries(x86_64-softmmu unicorn)
+endif()
 
 if(MSVC)
     target_compile_options(x86_64-softmmu PRIVATE
@@ -336,6 +339,9 @@ add_library(arm-softmmu
     qemu/tcg/tcg.c
     qemu/translate-all.c
 )
+if (NOT UNICORN_BUILD_SHARED)
+    target_link_libraries(arm-softmmu unicorn)
+endif()
 
 if(MSVC)
     target_compile_options(arm-softmmu PRIVATE
@@ -377,6 +383,9 @@ add_library(armeb-softmmu
     qemu/tcg/tcg.c
     qemu/translate-all.c
 )
+if (NOT UNICORN_BUILD_SHARED)
+    target_link_libraries(armeb-softmmu unicorn)
+endif()
 
 if(MSVC)
     target_compile_options(armeb-softmmu PRIVATE
@@ -423,6 +432,9 @@ add_library(aarch64-softmmu
     qemu/tcg/tcg.c
     qemu/translate-all.c
 )
+if (NOT UNICORN_BUILD_SHARED)
+    target_link_libraries(aarch64-softmmu unicorn)
+endif()
 
 if(MSVC)
     target_compile_options(aarch64-softmmu PRIVATE
@@ -467,6 +479,9 @@ add_library(aarch64eb-softmmu
     qemu/tcg/tcg.c
     qemu/translate-all.c
 )
+if (NOT UNICORN_BUILD_SHARED)
+    target_link_libraries(aarch64eb-softmmu unicorn)
+endif()
 
 if(MSVC)
     target_compile_options(aarch64eb-softmmu PRIVATE
@@ -505,6 +520,9 @@ add_library(m68k-softmmu
     qemu/tcg/tcg.c
     qemu/translate-all.c
 )
+if (NOT UNICORN_BUILD_SHARED)
+    target_link_libraries(m68k-softmmu unicorn)
+endif()
 
 if(MSVC)
     target_compile_options(m68k-softmmu PRIVATE
@@ -548,6 +566,9 @@ add_library(mips-softmmu
     qemu/tcg/tcg.c
     qemu/translate-all.c
 )
+if (NOT UNICORN_BUILD_SHARED)
+    target_link_libraries(mips-softmmu unicorn)
+endif()
 
 if(MSVC)
     target_compile_options(mips-softmmu PRIVATE
@@ -589,6 +610,9 @@ add_library(mipsel-softmmu
     qemu/tcg/tcg.c
     qemu/translate-all.c
 )
+if (NOT UNICORN_BUILD_SHARED)
+    target_link_libraries(mipsel-softmmu unicorn)
+endif()
 
 if(MSVC)
     target_compile_options(mipsel-softmmu PRIVATE
@@ -630,6 +654,9 @@ add_library(mips64-softmmu
     qemu/tcg/tcg.c
     qemu/translate-all.c
 )
+if (NOT UNICORN_BUILD_SHARED)
+    target_link_libraries(mips64-softmmu unicorn)
+endif()
 
 if(MSVC)
     target_compile_options(mips64-softmmu PRIVATE
@@ -671,6 +698,9 @@ add_library(mips64el-softmmu
     qemu/tcg/tcg.c
     qemu/translate-all.c
 )
+if (NOT UNICORN_BUILD_SHARED)
+    target_link_libraries(mips64el-softmmu unicorn)
+endif()
 
 if(MSVC)
     target_compile_options(mips64el-softmmu PRIVATE
@@ -714,6 +744,9 @@ add_library(sparc-softmmu
     qemu/tcg/tcg.c
     qemu/translate-all.c
 )
+if (NOT UNICORN_BUILD_SHARED)
+    target_link_libraries(sparc-softmmu unicorn)
+endif()
 
 if(MSVC)
     target_compile_options(sparc-softmmu PRIVATE
@@ -756,6 +789,9 @@ add_library(sparc64-softmmu
     qemu/tcg/tcg.c
     qemu/translate-all.c
 )
+if (NOT UNICORN_BUILD_SHARED)
+    target_link_libraries(sparc64-softmmu unicorn)
+endif()
 
 if(MSVC)
     target_compile_options(sparc64-softmmu PRIVATE


### PR DESCRIPTION
linking of samples like sample_arm do fail due to cyclic references in
the archives

<details><summary>Failing log for reference</summary>
```
[1/2] : && /usr/lib/ccache/bin/clang   -rdynamic CMakeFiles/sample_arm.dir/samples/sample_arm.c.o  -o sample_arm  libunicorn.a  -lpthread  libarm-softmmu.a  libarmeb-softmmu.a  -lm && :
FAILED: sample_arm 
: && /usr/lib/ccache/bin/clang   -rdynamic CMakeFiles/sample_arm.dir/samples/sample_arm.c.o  -o sample_arm  libunicorn.a  -lpthread  libarm-softmmu.a  libarmeb-softmmu.a  -lm && :
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(tcg.c.o):(.data.rel.ro+0x2f88): undefined reference to `helper_div_i32'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(tcg.c.o):(.data.rel.ro+0x2fa0): undefined reference to `helper_rem_i32'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(tcg.c.o):(.data.rel.ro+0x2fb8): undefined reference to `helper_divu_i32'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(tcg.c.o):(.data.rel.ro+0x2fd0): undefined reference to `helper_remu_i32'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(tcg.c.o):(.data.rel.ro+0x2fe8): undefined reference to `helper_div_i64'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(tcg.c.o):(.data.rel.ro+0x3000): undefined reference to `helper_rem_i64'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(tcg.c.o):(.data.rel.ro+0x3018): undefined reference to `helper_divu_i64'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(tcg.c.o):(.data.rel.ro+0x3030): undefined reference to `helper_remu_i64'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(tcg.c.o):(.data.rel.ro+0x3048): undefined reference to `helper_shl_i64'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(tcg.c.o):(.data.rel.ro+0x3060): undefined reference to `helper_shr_i64'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(tcg.c.o):(.data.rel.ro+0x3078): undefined reference to `helper_sar_i64'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(tcg.c.o):(.data.rel.ro+0x3090): undefined reference to `helper_mulsh_i64'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(tcg.c.o):(.data.rel.ro+0x30a8): undefined reference to `helper_muluh_i64'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(cputlb.c.o): in function `tlb_set_page_arm':
cputlb.c:(.text+0xb6b): undefined reference to `find_next_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(exec.c.o): in function `cpu_physical_memory_reset_dirty_arm':
exec.c:(.text+0x9e3): undefined reference to `bitmap_clear'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(exec.c.o): in function `qemu_ram_alloc_from_ptr_arm':
exec.c:(.text+0xfc8): undefined reference to `bitmap_clear'
/usr/bin/x86_64-unknown-linux-musl-ld: exec.c:(.text+0x1001): undefined reference to `bitmap_set'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(exec.c.o): in function `qemu_ram_free_arm':
exec.c:(.text+0x11a9): undefined reference to `qemu_anon_ram_free'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(exec.c.o): in function `qemu_ram_remap_arm':
exec.c:(.text+0x124c): undefined reference to `qemu_anon_ram_alloc'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(exec.c.o): in function `address_space_rw_arm':
exec.c:(.text+0x1e0e): undefined reference to `find_next_zero_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(exec.c.o): in function `cpu_physical_memory_write_rom_arm':
exec.c:(.text+0x2337): undefined reference to `find_next_zero_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(exec.c.o): in function `address_space_map_arm':
exec.c:(.text+0x2b3b): undefined reference to `qemu_memalign'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(exec.c.o): in function `address_space_unmap_arm':
exec.c:(.text+0x2c6e): undefined reference to `find_next_zero_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: exec.c:(.text+0x2cc4): undefined reference to `qemu_vfree'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(exec.c.o): in function `stl_phys_arm':
exec.c:(.text+0x4106): undefined reference to `find_next_zero_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(exec.c.o): in function `stl_le_phys_arm':
exec.c:(.text+0x4316): undefined reference to `find_next_zero_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(exec.c.o): in function `stl_be_phys_arm':
exec.c:(.text+0x4534): undefined reference to `find_next_zero_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(exec.c.o): in function `stw_phys_arm':
exec.c:(.text+0x4766): undefined reference to `find_next_zero_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(exec.c.o): in function `stw_le_phys_arm':
exec.c:(.text+0x4976): undefined reference to `find_next_zero_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(exec.c.o):exec.c:(.text+0x4b91): more undefined references to `find_next_zero_bit' follow
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(exec.c.o): in function `notdirty_mem_write':
exec.c:(.text+0x5807): undefined reference to `find_next_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: exec.c:(.text+0x58d3): undefined reference to `find_next_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(exec.c.o):(.data+0x0): undefined reference to `qemu_anon_ram_alloc'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(crypto_helper.c.o):(.data.rel.ro+0x0): undefined reference to `AES_sbox'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(crypto_helper.c.o):(.data.rel.ro+0x8): undefined reference to `AES_isbox'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(crypto_helper.c.o):(.data.rel.ro+0x10): undefined reference to `AES_shifts'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(crypto_helper.c.o):(.data.rel.ro+0x18): undefined reference to `AES_ishifts'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(helper.c.o): in function `pmccntr_sync_arm':
helper.c:(.text+0x5cd): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(helper.c.o): in function `arm_gt_ptimer_cb_arm':
helper.c:(.text+0x68b): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(helper.c.o): in function `arm_gt_vtimer_cb_arm':
helper.c:(.text+0x6eb): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(helper.c.o): in function `pmcr_write_arm':
helper.c:(.text+0x36b4): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: helper.c:(.text+0x3776): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(helper.c.o): in function `helper_crc32c_arm':
helper.c:(.text+0x946b): undefined reference to `crc32c'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(helper.c.o): in function `pmccntr_read_arm':
helper.c:(.text+0x96cc): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(helper.c.o): in function `pmccntr_write32_arm':
helper.c:(.text+0x979d): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: helper.c:(.text+0x9848): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(helper.c.o): in function `pmccntr_write_arm':
helper.c:(.text+0x98fd): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(helper.c.o): in function `pmccfiltr_write_arm':
helper.c:(.text+0x99b4): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: libarm-softmmu.a(helper.c.o):helper.c:(.text+0x9a62): more undefined references to `qemu_clock_get_ns' follow
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(tcg.c.o):(.data.rel.ro+0x2f88): undefined reference to `helper_div_i32'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(tcg.c.o):(.data.rel.ro+0x2fa0): undefined reference to `helper_rem_i32'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(tcg.c.o):(.data.rel.ro+0x2fb8): undefined reference to `helper_divu_i32'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(tcg.c.o):(.data.rel.ro+0x2fd0): undefined reference to `helper_remu_i32'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(tcg.c.o):(.data.rel.ro+0x2fe8): undefined reference to `helper_div_i64'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(tcg.c.o):(.data.rel.ro+0x3000): undefined reference to `helper_rem_i64'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(tcg.c.o):(.data.rel.ro+0x3018): undefined reference to `helper_divu_i64'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(tcg.c.o):(.data.rel.ro+0x3030): undefined reference to `helper_remu_i64'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(tcg.c.o):(.data.rel.ro+0x3048): undefined reference to `helper_shl_i64'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(tcg.c.o):(.data.rel.ro+0x3060): undefined reference to `helper_shr_i64'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(tcg.c.o):(.data.rel.ro+0x3078): undefined reference to `helper_sar_i64'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(tcg.c.o):(.data.rel.ro+0x3090): undefined reference to `helper_mulsh_i64'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(tcg.c.o):(.data.rel.ro+0x30a8): undefined reference to `helper_muluh_i64'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(cputlb.c.o): in function `tlb_set_page_armeb':
cputlb.c:(.text+0xb6b): undefined reference to `find_next_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(exec.c.o): in function `cpu_physical_memory_reset_dirty_armeb':
exec.c:(.text+0x9e3): undefined reference to `bitmap_clear'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(exec.c.o): in function `qemu_ram_alloc_from_ptr_armeb':
exec.c:(.text+0xfc8): undefined reference to `bitmap_clear'
/usr/bin/x86_64-unknown-linux-musl-ld: exec.c:(.text+0x1001): undefined reference to `bitmap_set'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(exec.c.o): in function `qemu_ram_free_armeb':
exec.c:(.text+0x11a9): undefined reference to `qemu_anon_ram_free'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(exec.c.o): in function `qemu_ram_remap_armeb':
exec.c:(.text+0x124c): undefined reference to `qemu_anon_ram_alloc'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(exec.c.o): in function `address_space_rw_armeb':
exec.c:(.text+0x1e0e): undefined reference to `find_next_zero_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(exec.c.o): in function `cpu_physical_memory_write_rom_armeb':
exec.c:(.text+0x2367): undefined reference to `find_next_zero_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(exec.c.o): in function `address_space_map_armeb':
exec.c:(.text+0x2b6b): undefined reference to `qemu_memalign'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(exec.c.o): in function `address_space_unmap_armeb':
exec.c:(.text+0x2c9e): undefined reference to `find_next_zero_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: exec.c:(.text+0x2cf4): undefined reference to `qemu_vfree'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(exec.c.o): in function `stl_phys_armeb':
exec.c:(.text+0x4198): undefined reference to `find_next_zero_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(exec.c.o): in function `stl_le_phys_armeb':
exec.c:(.text+0x43b2): undefined reference to `find_next_zero_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(exec.c.o): in function `stl_be_phys_armeb':
exec.c:(.text+0x45c8): undefined reference to `find_next_zero_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(exec.c.o): in function `stw_phys_armeb':
exec.c:(.text+0x47fa): undefined reference to `find_next_zero_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(exec.c.o): in function `stw_le_phys_armeb':
exec.c:(.text+0x4a0d): undefined reference to `find_next_zero_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(exec.c.o):exec.c:(.text+0x4c1a): more undefined references to `find_next_zero_bit' follow
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(exec.c.o): in function `notdirty_mem_write':
exec.c:(.text+0x58a7): undefined reference to `find_next_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: exec.c:(.text+0x597b): undefined reference to `find_next_bit'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(exec.c.o):(.data+0x0): undefined reference to `qemu_anon_ram_alloc'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(crypto_helper.c.o):(.data.rel.ro+0x0): undefined reference to `AES_sbox'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(crypto_helper.c.o):(.data.rel.ro+0x8): undefined reference to `AES_isbox'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(crypto_helper.c.o):(.data.rel.ro+0x10): undefined reference to `AES_shifts'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(crypto_helper.c.o):(.data.rel.ro+0x18): undefined reference to `AES_ishifts'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(helper.c.o): in function `pmccntr_sync_armeb':
helper.c:(.text+0x5cd): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(helper.c.o): in function `arm_gt_ptimer_cb_armeb':
helper.c:(.text+0x68b): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(helper.c.o): in function `arm_gt_vtimer_cb_armeb':
helper.c:(.text+0x6eb): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(helper.c.o): in function `pmcr_write_armeb':
helper.c:(.text+0x36b4): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: helper.c:(.text+0x3776): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(helper.c.o): in function `helper_crc32c_armeb':
helper.c:(.text+0x946b): undefined reference to `crc32c'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(helper.c.o): in function `pmccntr_read_armeb':
helper.c:(.text+0x96cc): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(helper.c.o): in function `pmccntr_write32_armeb':
helper.c:(.text+0x979d): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: helper.c:(.text+0x9848): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(helper.c.o): in function `pmccntr_write_armeb':
helper.c:(.text+0x98fd): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(helper.c.o): in function `pmccfiltr_write_armeb':
helper.c:(.text+0x99b4): undefined reference to `qemu_clock_get_ns'
/usr/bin/x86_64-unknown-linux-musl-ld: libarmeb-softmmu.a(helper.c.o):helper.c:(.text+0x9a62): more undefined references to `qemu_clock_get_ns' follow
clang-10: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```
</details>