### PR TITLE
adding pypi workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,41 @@
+name: Build and publish pypi package
+
+on: [push]
+
+jobs:
+  deploy:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        platform: [x32, x64]
+        exclude:
+          - { platform: x32, os: macos-latest }
+          - { platform: x32, os: ubuntu-latest }  
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Set up MSVC
+      if: matrix.os == 'windows-latest'
+      uses: microsoft/setup-msbuild@v1 
+    - name: Install dependencies
+      run: |
+        pip install setuptools wheel
+    - name: Build distribution 📦
+      shell: bash
+      run: |
+         if [ ${{ matrix.platform }} == 'x32' ] && [ ${{ matrix.os }} == 'windows-latest' ]; then
+             cd bindings/python && python setup.py build -p win32 sdist bdist_wheel -p win32
+         else
+             cd bindings/python && python setup.py bdist_wheel
+         fi
+    - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.event.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.pypi_pass }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,41 +1,60 @@
-name: Build and publish pypi package
+name: PyPI 📦 Distribution
 
 on: [push]
 
 jobs:
   deploy:
-
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
         platform: [x32, x64]
-        exclude:
-          - { platform: x32, os: macos-latest }
-          - { platform: x32, os: ubuntu-latest }  
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
+
     - name: Set up MSVC
       if: matrix.os == 'windows-latest'
-      uses: microsoft/setup-msbuild@v1 
+      uses: microsoft/setup-msbuild@v1
+
     - name: Install dependencies
       run: |
         pip install setuptools wheel
+
     - name: Build distribution 📦
-      shell: bash
+      shell: bash 
       run: |
-         if [ ${{ matrix.platform }} == 'x32' ] && [ ${{ matrix.os }} == 'windows-latest' ]; then
+        if [ ${{ matrix.platform }} == 'x32' ] && [ ${{ matrix.os }} == 'windows-latest' ]; then
              cd bindings/python && python setup.py build -p win32 sdist bdist_wheel -p win32
-         else
+             rm dist/*.tar.gz
+        elif [ ${{ matrix.platform }} == 'x32' ] && [ ${{ matrix.os }} == 'ubuntu-latest' ]; then
+             docker run --rm -v `pwd`/:/work dockcross/manylinux1-x86 > ./dockcross
+             chmod +x ./dockcross
+             ./dockcross bindings/python/build_wheel.sh
+        elif [ ${{ matrix.platform }} == 'x64' ] && [ ${{ matrix.os }} == 'ubuntu-latest' ]; then
+             docker run --rm -v `pwd`/:/work dockcross/manylinux1-x64 > ./dockcross
+             chmod +x ./dockcross
+             ./dockcross bindings/python/build_wheel.sh
+        elif [ ${{ matrix.platform }} == 'x32' ] && [ ${{ matrix.os }} == 'macos-latest' ]; then
+             cd bindings/python && python setup.py sdist
+        else
              cd bindings/python && python setup.py bdist_wheel
-         fi
+        fi
+
+    - uses: actions/upload-artifact@v2
+      with:
+         name: unicorn-packages-${{ matrix.os }}-${{ matrix.platform }}
+         path: ${{ github.workspace }}/bindings/python/dist/*
+
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.event.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master
       with:
+        username: __token__
         password: ${{ secrets.pypi_pass }}
+        packages_dir: ${{ github.workspace }}/bindings/python/dist/

--- a/bindings/python/build_wheel.sh
+++ b/bindings/python/build_wheel.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e -x
+
+cd bindings/python
+
+# Compile wheels
+if [ -f /opt/python/cp36-cp36m/bin/python ];then
+  /opt/python/cp36-cp36m/bin/python setup.py bdist_wheel
+else
+  python3 setup.py bdist_wheel
+fi
+cd dist
+auditwheel repair *.whl
+mv -f wheelhouse/*.whl .

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -23,7 +23,7 @@ SYSTEM = sys.platform
 IS_64BITS = platform.architecture()[0] == '64bit'
 
 # are we building from the repository or from a source distribution?
-ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 LIBS_DIR = os.path.join(ROOT_DIR, 'unicorn', 'lib')
 HEADERS_DIR = os.path.join(ROOT_DIR, 'unicorn', 'include')
 SRC_DIR = os.path.join(ROOT_DIR, 'src')
@@ -226,6 +226,7 @@ class custom_bdist_egg(bdist_egg):
 
 def dummy_src():
     return []
+
 
 if 'bdist_wheel' in sys.argv and '--plat-name' not in sys.argv:
     idx = sys.argv.index('bdist_wheel') + 1


### PR DESCRIPTION
**Purpose:**
Utilizing github action to build and publish python distribution packages including source package to pypi.org  on repo [tag]. Build will still be triggered on [push].

Binary distribution packages:
sdist, win32, win-amd64, manylinux1_x86_64, manylinux_i686, macos_x86_64

**Preparation:**
1. Go to https://pypi.org/manage/account/#api-tokens and create a new API token for the Unicorn project on PyPI, limit the token scope to just this project. You can call it something like GitHub Actions CI/CD or anything that can be easily distinguishable in the token list. Don’t close the page just yet — you won’t see that token again.

2. In a separate browser tab or window, go to the Github Settings tab of unicorn-engine/unicorn repository and then click on Secrets in the left sidebar.

3. Create a new secret called pypi_pass and copy-paste the token generated from the first step.

**Build tools/Dockers**
Using dockcross's manylinux1 images for Linux build. pypa manylinux version can be found [here](https://github.com/chfl4gs/unicorn/actions/runs/126324927/workflow).

**Artifacts**
Workflow will produce zipped artifacts on each builds for download/inspection/testing. Note: unicorn-packages-macos-latest-x32 artifact is just a source package.