### PR TITLE
cmake: fix build if workdir is outside of CMAKE_BINARY_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,7 @@ else()
     execute_process(COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/qemu/configure
         ${EXTRA_CFLAGS}
         ${TARGET_LIST}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
     execute_process(COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/qemu/scripts/create_config
         INPUT_FILE ${CMAKE_BINARY_DIR}/config-host.mak


### PR DESCRIPTION
this e.g. happens if you would try to compile this like this:

cmake -B build
cmake --build build --config Release

@scribam Should fix the remaining CI failures of https://github.com/Vita3K/Vita3K/pull/727