### PR TITLE
fix 64-bit fstenv

### DIFF
--- a/qemu/target-i386/fpu_helper.c
+++ b/qemu/target-i386/fpu_helper.c
@@ -1008,9 +1008,8 @@ void helper_fstenv(CPUX86State *env, target_ulong ptr, int data32)
         }
     }
 
-    // DFLAG enum: tcg.h, case here to int
-    if ((env->hflags & HF_CS64_MASK) || data32) {
-        /* 32 or 64 bit */
+    if (data32) {
+        /* 32 bit */
         cpu_stl_data(env, ptr, env->fpuc);
         cpu_stl_data(env, ptr + 4, fpus);
         cpu_stl_data(env, ptr + 8, fptag);

--- a/qemu/target-i386/fpu_helper.c
+++ b/qemu/target-i386/fpu_helper.c
@@ -1009,16 +1009,8 @@ void helper_fstenv(CPUX86State *env, target_ulong ptr, int data32)
     }
 
     // DFLAG enum: tcg.h, case here to int
-    if (env->hflags & HF_CS64_MASK) {
-        cpu_stl_data(env, ptr, env->fpuc);
-        cpu_stl_data(env, ptr + 4, fpus);
-        cpu_stl_data(env, ptr + 8, fptag);
-        cpu_stl_data(env, ptr + 12, (uint32_t)env->fpip); /* fpip */
-        cpu_stl_data(env, ptr + 20, 0); /* fpcs */
-        cpu_stl_data(env, ptr + 24, 0); /* fpoo */
-        cpu_stl_data(env, ptr + 28, 0); /* fpos */
-    } else if (data32) {
-        /* 32 bit */
+    if ((env->hflags & HF_CS64_MASK) || data32) {
+        /* 32 or 64 bit */
         cpu_stl_data(env, ptr, env->fpuc);
         cpu_stl_data(env, ptr + 4, fpus);
         cpu_stl_data(env, ptr + 8, fptag);


### PR DESCRIPTION
FSTENV and FNSTENV instruction in 64-bit and 32-bit mode should be handled in the same way.

https://stackoverflow.com/a/50460464/11790783