### PR TITLE
Fix failing test caused by removal of UC_ERR_TIMEOUT

### DIFF
--- a/bindings/python/sample_x86.py
+++ b/bindings/python/sample_x86.py
@@ -384,15 +384,8 @@ def test_i386_loop():
         print(">>> EDX = 0x%x" %r_edx)
 
     except UcError as e:
-        # timeout is acceptable in this case
-        if e.errno == UC_ERR_TIMEOUT:
-            print(">>> Emulation done. Below is the CPU context")
-            r_ecx = mu.reg_read(UC_X86_REG_ECX)
-            r_edx = mu.reg_read(UC_X86_REG_EDX)
-            print(">>> ECX = 0x%x" %r_ecx)
-            print(">>> EDX = 0x%x" %r_edx)
-        else:
-            print("ERROR: %s" % e)
+        print("ERROR: %s" % e)
+
 
 # Test X86 32 bit with IN/OUT instruction
 def test_i386_inout():


### PR DESCRIPTION
Caused by fbef45b18f2f59d9699af54c6ad6ac73eaba3b29.
Now the code assumes if it completes without an error, it was successful.