### PR TITLE
Fix enabled hooks even after deleting them

### DIFF
--- a/include/uc_priv.h
+++ b/include/uc_priv.h
@@ -127,7 +127,7 @@ enum uc_hook_idx {
 // if statement to check hook bounds
 #define HOOK_BOUND_CHECK(hh, addr)                  \
     ((((addr) >= (hh)->begin && (addr) <= (hh)->end) \
-         || (hh)->begin > (hh)->end))
+        || (hh)->begin > (hh)->end) && !((hh)->to_delete))
 
 #define HOOK_EXISTS(uc, idx) ((uc)->hook[idx##_IDX].head != NULL)
 #define HOOK_EXISTS_BOUNDED(uc, idx, addr) _hook_exists_bounded((uc)->hook[idx##_IDX].head, addr)


### PR DESCRIPTION
When you uc_emu_start with count more than 0 and then uc_emu_start with count = 0, to be deleted hooks are not processed yet (because it's processed at the end of uc_emu_start) still have effects. 

Because of this issue, code hook internally inserted by unicorn to count the instructions are not really deleted when we uc_emu_start with count = 0. This "leftover" hook inserted monitoring tcg between every instruction and resulted in the hang described in https://github.com/unicorn-engine/unicorn/issues/1313, even if we didn't add any code hook.

This PR fixes this issue by checking to_delete field in HOOK_BOUND_CHECK, so that unicorn can ignore to be deleted hooks.