### PR TITLE
fix HI/LO register read/write issue in MIPS

### DIFF
--- a/qemu/target-mips/unicorn.c
+++ b/qemu/target-mips/unicorn.c
@@ -100,6 +100,10 @@ int mips_reg_read(struct uc_struct *uc, unsigned int *regs, void **vals, int cou
                 case UC_MIPS_REG_CP0_USERLOCAL:
                          *(mipsreg_t *)value = MIPS_CPU(uc, mycpu)->env.active_tc.CP0_UserLocal;
                          break;                              
+                case UC_MIPS_REG_HI:
+                         *(mipsreg_t *)value = MIPS_CPU(uc, mycpu)->env.active_tc.HI[0];
+                case UC_MIPS_REG_LO:
+                         *(mipsreg_t *)value = MIPS_CPU(uc, mycpu)->env.active_tc.LO[0];
             }
         }
     }
@@ -132,6 +136,12 @@ int mips_reg_write(struct uc_struct *uc, unsigned int *regs, void *const *vals, 
                 case UC_MIPS_REG_CP0_USERLOCAL:
                          MIPS_CPU(uc, mycpu)->env.active_tc.CP0_UserLocal = *(mipsreg_t *)value;
                          break;                         
+                case UC_MIPS_REG_HI:
+                         MIPS_CPU(uc, mycpu)->env.HI[0] = *(mipsreg_t *)value;
+                         break;
+                case UC_MIPS_REG_LO:
+                         MIPS_CPU(uc, mycpu)->env.LO[0] = *(mipsreg_t *)value;
+                         break;
             }
         }
     }

--- a/qemu/target-mips/unicorn.c
+++ b/qemu/target-mips/unicorn.c
@@ -137,10 +137,10 @@ int mips_reg_write(struct uc_struct *uc, unsigned int *regs, void *const *vals, 
                          MIPS_CPU(uc, mycpu)->env.active_tc.CP0_UserLocal = *(mipsreg_t *)value;
                          break;                         
                 case UC_MIPS_REG_HI:
-                         MIPS_CPU(uc, mycpu)->env.HI[0] = *(mipsreg_t *)value;
+                         MIPS_CPU(uc, mycpu)->env.active_tc.HI[0] = *(mipsreg_t *)value;
                          break;
                 case UC_MIPS_REG_LO:
-                         MIPS_CPU(uc, mycpu)->env.LO[0] = *(mipsreg_t *)value;
+                         MIPS_CPU(uc, mycpu)->env.active_tc.LO[0] = *(mipsreg_t *)value;
                          break;
             }
         }


### PR DESCRIPTION
```python
from unicorn import *
from unicorn.mips_const import *

# code to be emulated
MIPS_CODE_EL = b"".join([
    b"\xad\xde\x02\x3c", # lui   $v0, 0xdead
    b"\xef\xbe\x42\x34", # ori   $v0, $v0, 0xbeef
    b"\xad\xde\x03\x3c", # lui   $v1, 0xdead
    b"\xef\xbe\x63\x34", # ori   $v1, $v1, 0xbeef
    b"\x19\x00\x43\x00", # multu $v0, $v1
    ])

# memory address where emulation starts
ADDRESS = 0x10000

# Initialize emulator in MIPS32 + EL mode
mu = Uc(UC_ARCH_MIPS, UC_MODE_MIPS32 + UC_MODE_LITTLE_ENDIAN)

# map 2MB memory for this emulation
mu.mem_map(ADDRESS, 2 * 1024 * 1024)

# write machine code to be emulated to memory
mu.mem_write(ADDRESS, MIPS_CODE_EL)

# emulate machine code in infinite time
mu.emu_start(ADDRESS, ADDRESS + len(MIPS_CODE_EL))

# now print out some registers
print(">>> Emulation done. Below is the CPU context")

lo = mu.reg_read(UC_MIPS_REG_LO)
print(">>> LO = 0x%x" % lo) # should be 0x216da321
hi = mu.reg_read(UC_MIPS_REG_HI)
print(">>> HI = 0x%x" % hi) # should be 0xc1b1cd12
```

considering the code above, LO and HI will be always zero due to the `reg_read` and `reg_write` didn't handle this.

I tested it locally and its working as I expect, but i'm not sure I am doing it right. any hints will be quite appreciated 