### PR TITLE
Add qemu_ prefix to bitmap_set and bitmap_clear to avoid conflicts.

### DIFF
--- a/qemu/include/exec/ram_addr.h
+++ b/qemu/include/exec/ram_addr.h
@@ -93,7 +93,7 @@ static inline void cpu_physical_memory_set_dirty_range(struct uc_struct *uc, ram
 
     end = TARGET_PAGE_ALIGN(start + length) >> TARGET_PAGE_BITS;
     page = start >> TARGET_PAGE_BITS;
-    bitmap_set(uc->ram_list.dirty_memory[DIRTY_MEMORY_CODE], page, end - page);
+    qemu_bitmap_set(uc->ram_list.dirty_memory[DIRTY_MEMORY_CODE], page, end - page);
 }
 
 #if !defined(_WIN32)
@@ -153,7 +153,7 @@ static inline void cpu_physical_memory_clear_dirty_range(struct uc_struct *uc, r
     assert(client < DIRTY_MEMORY_NUM);
     end = TARGET_PAGE_ALIGN(start + length) >> TARGET_PAGE_BITS;
     page = start >> TARGET_PAGE_BITS;
-    bitmap_clear(uc->ram_list.dirty_memory[client], page, end - page);
+    qemu_bitmap_clear(uc->ram_list.dirty_memory[client], page, end - page);
 }
 
 void cpu_physical_memory_reset_dirty(struct uc_struct *uc,

--- a/qemu/include/qemu/bitmap.h
+++ b/qemu/include/qemu/bitmap.h
@@ -26,8 +26,8 @@
  * Note that nbits should be always a compile time evaluable constant.
  * Otherwise many inlines will generate horrible code.
  *
- * bitmap_set(dst, pos, nbits)			Set specified bit area
- * bitmap_clear(dst, pos, nbits)		Clear specified bit area
+ * qemu_bitmap_set(dst, pos, nbits)			Set specified bit area
+ * qemu_bitmap_clear(dst, pos, nbits)		Clear specified bit area
  */
 
 /*
@@ -46,15 +46,15 @@
 #define DECLARE_BITMAP(name,bits)                  \
         unsigned long name[BITS_TO_LONGS(bits)]
 
-void bitmap_set(unsigned long *map, long i, long len);
-void bitmap_clear(unsigned long *map, long start, long nr);
+void qemu_bitmap_set(unsigned long *map, long i, long len);
+void qemu_bitmap_clear(unsigned long *map, long start, long nr);
 
 static inline unsigned long *bitmap_zero_extend(unsigned long *old,
                                                 long old_nbits, long new_nbits)
 {
     long new_len = BITS_TO_LONGS(new_nbits) * sizeof(unsigned long);
     unsigned long *new = g_realloc(old, new_len);
-    bitmap_clear(new, old_nbits, new_nbits - old_nbits);
+    qemu_bitmap_clear(new, old_nbits, new_nbits - old_nbits);
     return new;
 }
 

--- a/qemu/util/bitmap.c
+++ b/qemu/util/bitmap.c
@@ -14,7 +14,7 @@
 
 #define BITMAP_FIRST_WORD_MASK(start) (~0UL << ((start) % BITS_PER_LONG))
 
-void bitmap_set(unsigned long *map, long start, long nr)
+void qemu_bitmap_set(unsigned long *map, long start, long nr)
 {
     unsigned long *p = map + BIT_WORD(start);
     const long size = start + nr;
@@ -34,7 +34,7 @@ void bitmap_set(unsigned long *map, long start, long nr)
     }
 }
 
-void bitmap_clear(unsigned long *map, long start, long nr)
+void qemu_bitmap_clear(unsigned long *map, long start, long nr)
 {
     unsigned long *p = map + BIT_WORD(start);
     const long size = start + nr;


### PR DESCRIPTION
When unicorn and systemd are combined into a single binary the 2
libraries conflict on bitmap_set and bitmap_clear functions which breaks
unicorn.