### PR TITLE
Removed unused bitmap_set rename bitmap_clear to qemu_bitmap_clear.

### DIFF
--- a/qemu/include/qemu/bitmap.h
+++ b/qemu/include/qemu/bitmap.h
@@ -26,14 +26,12 @@
  * Note that nbits should be always a compile time evaluable constant.
  * Otherwise many inlines will generate horrible code.
  *
- * bitmap_set(dst, pos, nbits)			Set specified bit area
- * bitmap_clear(dst, pos, nbits)		Clear specified bit area
+ * qemu_bitmap_clear(dst, pos, nbits)		Clear specified bit area
  */
 
 /*
  * Also the following operations apply to bitmaps.
  *
- * set_bit(bit, addr)			*addr |= bit
  * clear_bit(bit, addr)			*addr &= ~bit
  */
 
@@ -46,15 +44,14 @@
 #define DECLARE_BITMAP(name,bits)                  \
         unsigned long name[BITS_TO_LONGS(bits)]
 
-void bitmap_set(unsigned long *map, long i, long len);
-void bitmap_clear(unsigned long *map, long start, long nr);
+void qemu_bitmap_clear(unsigned long *map, long start, long nr);
 
 static inline unsigned long *bitmap_zero_extend(unsigned long *old,
                                                 long old_nbits, long new_nbits)
 {
     long new_len = BITS_TO_LONGS(new_nbits) * sizeof(unsigned long);
     unsigned long *new = g_realloc(old, new_len);
-    bitmap_clear(new, old_nbits, new_nbits - old_nbits);
+    qemu_bitmap_clear(new, old_nbits, new_nbits - old_nbits);
     return new;
 }
 

--- a/qemu/util/bitmap.c
+++ b/qemu/util/bitmap.c
@@ -14,27 +14,7 @@
 
 #define BITMAP_FIRST_WORD_MASK(start) (~0UL << ((start) % BITS_PER_LONG))
 
-void bitmap_set(unsigned long *map, long start, long nr)
-{
-    unsigned long *p = map + BIT_WORD(start);
-    const long size = start + nr;
-    int bits_to_set = BITS_PER_LONG - (start % BITS_PER_LONG);
-    unsigned long mask_to_set = BITMAP_FIRST_WORD_MASK(start);
-
-    while (nr - bits_to_set >= 0) {
-        *p |= mask_to_set;
-        nr -= bits_to_set;
-        bits_to_set = BITS_PER_LONG;
-        mask_to_set = ~0UL;
-        p++;
-    }
-    if (nr) {
-        mask_to_set &= BITMAP_LAST_WORD_MASK(size);
-        *p |= mask_to_set;
-    }
-}
-
-void bitmap_clear(unsigned long *map, long start, long nr)
+void qemu_bitmap_clear(unsigned long *map, long start, long nr)
 {
     unsigned long *p = map + BIT_WORD(start);
     const long size = start + nr;


### PR DESCRIPTION
When unicorn and systemd are included into a single binary they conflict
on the bitmap_clear function which breaks unicorn. It seems that
long-term we can remove the qemu_bitmap_clear altogether and leave only
bitmap_zero_extend.