### PR TITLE
wrapping cpu_exit call with mutex to prevent race condition

### DIFF
--- a/uc.c
+++ b/uc.c
@@ -9,6 +9,8 @@
 #include <stdlib.h>
 #endif
 
+#include <sys/types.h>
+
 #include <time.h>   // nanosleep
 
 #include <string.h>


### PR DESCRIPTION
While using Unicorn in series of genetic programming experiments, my research group would occasionally run into segmentation faults. These seemed to occur only when the Unicorn emulation called the `uc_emu_stop()` function, from a watchdog thread separate from the main emulation thread. This function checks to ensure that `uc->current_cpu` is not null, and _then_ calls `cpu_exit(uc->current_cpu)`. This led us to suspect a race condition, whereby, after the check but before the call, `uc->current_cpu` was made null by events unfolding on another thread. Wrapping this critical section in a mutex lock, as done here, appears to have fixed this issue, and we're no longer seeing any segfaults. 
