### PR TITLE
Fix Incorrect memory view after running self-modifying code #820

### DIFF
--- a/bindings/python/unicorn/unicorn.py
+++ b/bindings/python/unicorn/unicorn.py
@@ -122,6 +122,7 @@ _setup_prototype(_uc, "uc_open", ucerr, ctypes.c_uint, ctypes.c_uint, ctypes.POI
 _setup_prototype(_uc, "uc_close", ucerr, uc_engine)
 _setup_prototype(_uc, "uc_strerror", ctypes.c_char_p, ucerr)
 _setup_prototype(_uc, "uc_errno", ucerr, uc_engine)
+_setup_prototype(_uc, "uc_set_slow_self_unpack", None, uc_engine, ctypes.c_bool)
 _setup_prototype(_uc, "uc_reg_read", ucerr, uc_engine, ctypes.c_int, ctypes.c_void_p)
 _setup_prototype(_uc, "uc_reg_write", ucerr, uc_engine, ctypes.c_int, ctypes.c_void_p)
 _setup_prototype(_uc, "uc_mem_read", ucerr, uc_engine, ctypes.c_uint64, ctypes.POINTER(ctypes.c_char), ctypes.c_size_t)
@@ -321,7 +322,9 @@ class Uc(object):
         status = _uc.uc_emu_stop(self._uch)
         if status != uc.UC_ERR_OK:
             raise UcError(status)
-
+    def set_slow_self_unpack(self, state):
+        _uc.uc_set_slow_self_unpack(self._uch, state)
+        
     # return the value of a register
     def reg_read(self, reg_id, opt=None):
         if self._arch == uc.UC_ARCH_X86:

--- a/include/uc_priv.h
+++ b/include/uc_priv.h
@@ -250,6 +250,7 @@ struct uc_struct {
     uint32_t target_page_align;
     uint64_t next_pc;   // save next PC for some special cases
     bool hook_insert;	// insert new hook at begin of the hook list (append by default)
+    bool slow_self_unpack;
 };
 
 // Metadata stub for the variable-size cpu context used with uc_context_*()

--- a/qemu/cpus.c
+++ b/qemu/cpus.c
@@ -72,6 +72,7 @@ int resume_all_vcpus(struct uc_struct *uc)
     }
 
     cpu->exit_request = 0;
+    cpu_set_slow_self_unpack(cpu, uc->slow_self_unpack);
 
     //qemu_clock_enable(QEMU_CLOCK_VIRTUAL, true);
     cpu_resume(cpu);

--- a/qemu/include/qom/cpu.h
+++ b/qemu/include/qom/cpu.h
@@ -210,6 +210,7 @@ struct CPUState {
     int nr_cores;
     int nr_threads;
     int numa_node;
+    bool slow_self_unpack;
 
     struct QemuThread *thread;
 #ifdef _WIN32
@@ -414,6 +415,34 @@ ObjectClass *cpu_class_by_name(struct uc_struct *uc, const char *typename_, cons
  * Returns: A #CPUState or %NULL if an error occurred.
  */
 CPUState *cpu_generic_init(struct uc_struct *uc, const char *typename_, const char *cpu_model);
+
+	/**
+ * cpu_slow_self_unpack_enabled
+ * @cpu: The vCPU to check.
+ *
+ * Checks where the codegen for CPU should injects EOB after each instruction.
+ * Useful to emulate self-modifying shellcode.
+ *
+ * Returns: %true if the mode is enabled for the CPU, %false otherwise.
+ */
+static inline bool cpu_slow_self_unpack_enabled(CPUState *cpu)
+{
+    return cpu->slow_self_unpack;
+}
+
+/**
+ * cpu_slow_self_unpack_enabled
+ * @cpu: The vCPU to set.
+ * @state: %true to enable mode, %false to disable.
+ *
+ * Set where the codegen for CPU should injects EOB after each instruction.
+ * Useful to emulate self-modifying shellcode.
+ */
+static inline void cpu_set_slow_self_unpack(CPUState *cpu, bool state)
+{
+    cpu->slow_self_unpack = state;
+}
+
 
 /**
  * cpu_has_work:

--- a/qemu/qom/cpu.c
+++ b/qemu/qom/cpu.c
@@ -156,7 +156,8 @@ static void cpu_common_reset(CPUState *cpu)
         qemu_log("CPU Reset (CPU %d)\n", cpu->cpu_index);
         log_cpu_state(cpu, cc->reset_dump_flags);
     }
-
+    cpu->slow_self_unpack = false;
+        
     cpu->interrupt_request = 0;
     cpu->current_tb = NULL;
     cpu->halted = 0;

--- a/uc.c
+++ b/uc.c
@@ -355,6 +355,14 @@ uc_err uc_close(uc_engine *uc)
     return UC_ERR_OK;
 }
 
+UNICORN_EXPORT
+void uc_set_slow_self_unpack(uc_engine *uc, bool state)
+{
+    uc->slow_self_unpack = state;
+    if (uc->current_cpu) {
+        cpu_set_slow_self_unpack(uc, state);
+    }
+}
 
 UNICORN_EXPORT
 uc_err uc_reg_read_batch(uc_engine *uc, int *ids, void **vals, int count)
@@ -639,6 +647,7 @@ uc_err uc_emu_start(uc_engine* uc, uint64_t begin, uint64_t until, uint64_t time
         if (err != UC_ERR_OK) {
             return err;
         }
+        uc_set_slow_self_unpack(uc, true);
     }
 
     uc->addr_end = until;


### PR DESCRIPTION
When I test qiling, I find issue https://github.com/unicorn-engine/unicorn/issues/820.
I also post a issue to qiling  https://github.com/qilingframework/qiling/issues/561.

So far, this fix work will.

```python
import unicorn
import unicorn.x86_const as x86

sc = bytes.fromhex(
    "dbd0d97424f45fb8e67741bc31c9b15831471a03471a83c704e2138ba93edb742"
    "a5f52911b5f00d10c6f43b7a004012c32688d43f3c7eb6a047bcfed868603ceb7"
    "48560fffb59a5da8b20872dd8f90f9ad1e901e6520b1b0fd7b1132d1f7182c363"
    "dd3c78cc9e201dd32486cd1c091a8d63ae4c024c6fe16561c8b8cf0d72b69003b"
    "adfa0ef0baa512076fde2f8c8e31a6d6b495e28dd58c4e63eacf30dc4e9bdd09e"
    "3c689a39e8c4954170424cd83bef47a0d38fa50609d5708d1720bc6ef22d2b1f0"
    "1e77ed64a22b4210ffda64e0175064e0e7460ca6d7ad862648a641aff7f0917a8"
    "e3b3eec91f12168c2a6f227b61e9d2c6db1664d5b5bf2bb3b0c8388c3cc0a0ea9"
    "c85ca43187344d08b94352419618ff394ff7d2bb777cd31102425e90423679cca"
    "c0ddb5bb2bb7124244495a4b42c95a4f4acc6ccac08bbe9b284a8a11fae2912c8"
    "b0959d08e283f51a92a2e4e44f31286ebdb2ae8efe4170e5e511b2590ed4cb993"
    "1614311fda3c8b573d46323595f0c85c5fe98bc05"
)

def main():
    uc = unicorn.Uc(unicorn.UC_ARCH_X86, unicorn.UC_MODE_32)
    uc.mem_map(0x1000, 0x2000)
    uc.mem_write(0x1000, sc)
    uc.reg_write(x86.UC_X86_REG_ESP, 0x2000)
    uc.emu_start(0x1000, 0, count=0x166)
    out = uc.mem_read(0x1000, 0x2000)

    for x in range(len(sc)):
        print("0x%08x: 0x%02x => 0x%02x" % (x, sc[x],out[x]))
    print(str(out))

if __name__ == "__main__":
    main()

```

```
0x0000000f: 0x58 => 0x58
0x00000010: 0x31 => 0x31
0x00000011: 0x47 => 0x47
0x00000012: 0x1a => 0x1a
0x00000013: 0x03 => 0x03
0x00000014: 0x47 => 0x47
0x00000015: 0x1a => 0x1a
0x00000016: 0x83 => 0x83
0x00000017: 0xc7 => 0xc7
0x00000018: 0x04 => 0x04
0x00000019: 0xe2 => 0xe2
0x0000001a: 0x13 => 0xf5
0x0000001b: 0x8b => 0xfc
0x0000001c: 0xa9 => 0xe8
0x0000001d: 0x3e => 0x82
0x0000001e: 0xdb => 0x00
0x0000001f: 0x74 => 0x00
0x00000020: 0x2a => 0x00
0x00000021: 0x5f => 0x60
0x00000022: 0x52 => 0x89
0x00000023: 0x91 => 0xe5
0x00000024: 0x1b => 0x31
0x00000025: 0x5f => 0xc0
0x00000026: 0x00 => 0x64
0x00000027: 0xd1 => 0x8b
0x00000028: 0x0c => 0x50
0x00000029: 0x6f => 0x30
0x0000002a: 0x43 => 0x8b
0x0000002b: 0xb7 => 0x52
0x0000002c: 0xa0 => 0x0c
0x0000002d: 0x04 => 0x8b
0x0000002e: 0x01 => 0x52
0x0000002f: 0x2c => 0x14
0x00000030: 0x32 => 0x8b
0x00000031: 0x68 => 0x72
0x00000032: 0x8d => 0x28
0x00000033: 0x43 => 0x0f
0x00000034: 0xf3 => 0xb7
0x00000035: 0xc7 => 0x4a
0x00000036: 0xeb => 0x26
0x00000037: 0x6a => 0x31
0x00000038: 0x04 => 0xff
0x00000039: 0x7b => 0xac
0x0000003a: 0xcf => 0x3c
0x0000003b: 0xed => 0x61
0x0000003c: 0x86 => 0x7c
0x0000003d: 0x86 => 0x02
0x0000003e: 0x03 => 0x2c
0x0000003f: 0xce => 0x20
0x00000040: 0xb7 => 0xc1
0x00000041: 0x48 => 0xcf
0x00000042: 0x56 => 0x0d
0x00000043: 0x0f => 0x01
0x00000044: 0xff => 0xc7
```

 

