### PR TITLE
Remove deprecated javah and build with javac

### DIFF
--- a/bindings/java/Makefile.build
+++ b/bindings/java/Makefile.build
@@ -46,7 +46,7 @@ all: lib jar samples
 	$(CC) -c $(CFLAGS) $(INCS) $< -o $@
 
 unicorn_Unicorn.h: unicorn/Unicorn.java
-	javah unicorn.Unicorn
+	javac -h unicorn/ unicorn/*.java
 
 unicorn_Unicorn.o: unicorn_Unicorn.c unicorn_Unicorn.h
 	$(CC) -c $(CFLAGS) $(INCS) $< -o $@


### PR DESCRIPTION
Hi, I was having trouble building java bindings on latest ubuntu. I installed jdk8 which has javah but somehow was failing during install (missing compiled classes even if they were in place in unicorn/). I guess mixing with jdk11 pop the issue. 
Using javac from most recent jdk works very fine.