### PR TITLE
X86 instruction FTST was incorrectly overwriting ST0 instead of FT0

### DIFF
--- a/CREDITS.TXT
+++ b/CREDITS.TXT
@@ -73,3 +73,4 @@ Huitao Chen (chenhuitao) & KaiJern Lau (xwings): Cmake support
 Huitao Chen (chenhuitao) & KaiJern Lau (xwings): Python3 support for building
 Kevin Foo (chfl4gs): Travis-CI migration
 Ziqiao Kong (lazymio): uc_context_free() API and various bug fix & improvement.
+Sven Almgren (blindmatrix)

--- a/CREDITS.TXT
+++ b/CREDITS.TXT
@@ -73,4 +73,4 @@ Huitao Chen (chenhuitao) & KaiJern Lau (xwings): Cmake support
 Huitao Chen (chenhuitao) & KaiJern Lau (xwings): Python3 support for building
 Kevin Foo (chfl4gs): Travis-CI migration
 Ziqiao Kong (lazymio): uc_context_free() API and various bug fix & improvement.
-Sven Almgren (blindmatrix)
+Sven Almgren (blindmatrix): bug fix

--- a/qemu/target-i386/fpu_helper.c
+++ b/qemu/target-i386/fpu_helper.c
@@ -540,7 +540,7 @@ void helper_fldz_FT0(CPUX86State *env)
 {
     //FT0 = floatx80_zero;
     floatx80 zero = { 0x0000000000000000LL, 0x0000 };
-    ST0 = zero;
+    FT0 = zero;
 }
 
 uint32_t helper_fnstsw(CPUX86State *env)


### PR DESCRIPTION
ST0 gets overwritten with 0.0 whenever FTST is executed.