### PR TITLE
Fix fpip

### DIFF
--- a/qemu/target-i386/translate.c
+++ b/qemu/target-i386/translate.c
@@ -6875,6 +6875,8 @@ static target_ulong disas_insn(CPUX86State *env, DisasContext *s,
                 goto illegal_op;
             }
         }
+        tcg_gen_movi_tl(tcg_ctx, *(TCGv *)tcg_ctx->cpu_tmp0, pc_start - s->cs_base);
+        tcg_gen_st_tl(tcg_ctx, *(TCGv *)tcg_ctx->cpu_tmp0, cpu_env, offsetof(CPUX86State, fpip));
         break;
         /************************/
         /* string ops */

--- a/qemu/target-i386/translate.c
+++ b/qemu/target-i386/translate.c
@@ -314,11 +314,6 @@ static void gen_update_cc_op(DisasContext *s)
     }
 }
 
-static void fpu_update_ip(CPUX86State *env, target_ulong pc)
-{
-    env->fpip = pc;
-}
-
 #ifdef TARGET_X86_64
 
 #define NB_OP_SIZES 4
@@ -6401,7 +6396,6 @@ static target_ulong disas_insn(CPUX86State *env, DisasContext *s,
                         /* fcomp needs pop */
                         gen_helper_fpop(tcg_ctx, cpu_env);
                     }
-                    fpu_update_ip(env, pc_start);
             }
             else if((op == 0x08) || /* flds */
                     (op == 0x0a) || /* fsts */
@@ -6486,7 +6480,6 @@ static target_ulong disas_insn(CPUX86State *env, DisasContext *s,
                         gen_helper_fpop(tcg_ctx, cpu_env);
                     break;
                 }
-                fpu_update_ip(env, pc_start);
             }
             else if(op == 0x0c) /* fldenv mem */
             {
@@ -6517,7 +6510,6 @@ static target_ulong disas_insn(CPUX86State *env, DisasContext *s,
                 gen_update_cc_op(s);
                 gen_jmp_im(s, pc_start - s->cs_base);
                 gen_helper_fldt_ST0(tcg_ctx, cpu_env, cpu_A0);
-                fpu_update_ip(env, pc_start);
             }
             else if(op == 0x1f) /* fstpt mem */
             {
@@ -6525,7 +6517,6 @@ static target_ulong disas_insn(CPUX86State *env, DisasContext *s,
                 gen_jmp_im(s, pc_start - s->cs_base);
                 gen_helper_fstt_ST0(tcg_ctx, cpu_env, cpu_A0);
                 gen_helper_fpop(tcg_ctx, cpu_env);
-                fpu_update_ip(env, pc_start);
             }
             else if(op == 0x2c) /* frstor mem */
             {
@@ -6550,7 +6541,6 @@ static target_ulong disas_insn(CPUX86State *env, DisasContext *s,
                 gen_update_cc_op(s);
                 gen_jmp_im(s, pc_start - s->cs_base);
                 gen_helper_fbld_ST0(tcg_ctx, cpu_env, cpu_A0);
-                fpu_update_ip(env, pc_start);
             }
             else if(op == 0x3e) /* fbstp */
             {
@@ -6558,20 +6548,17 @@ static target_ulong disas_insn(CPUX86State *env, DisasContext *s,
                 gen_jmp_im(s, pc_start - s->cs_base);
                 gen_helper_fbst_ST0(tcg_ctx, cpu_env, cpu_A0);
                 gen_helper_fpop(tcg_ctx, cpu_env);
-                fpu_update_ip(env, pc_start);
             }
             else if(op == 0x3d) /* fildll */
             {
                 tcg_gen_qemu_ld_i64(s->uc, cpu_tmp1_i64, cpu_A0, s->mem_index, MO_LEQ);
                 gen_helper_fildll_ST0(tcg_ctx, cpu_env, cpu_tmp1_i64);
-                fpu_update_ip(env, pc_start);
             }
             else if(op == 0x3f) /* fistpll */
             {
                 gen_helper_fistll_ST0(tcg_ctx, cpu_tmp1_i64, cpu_env);
                 tcg_gen_qemu_st_i64(s->uc, cpu_tmp1_i64, cpu_A0, s->mem_index, MO_LEQ);
                 gen_helper_fpop(tcg_ctx, cpu_env);
-                fpu_update_ip(env, pc_start);
             }
             else
             {
@@ -6887,7 +6874,6 @@ static target_ulong disas_insn(CPUX86State *env, DisasContext *s,
             default:
                 goto illegal_op;
             }
-            fpu_update_ip(env, pc_start);
         }
         break;
         /************************/
@@ -8766,6 +8752,12 @@ static inline void gen_intermediate_code_internal(uint8_t *gen_opc_cc_op,
             block_full = true;
             break;
         }
+        /*
+        gen_jmp_im(dc, pc_ptr - dc->cs_base);
+        gen_eob(dc);
+        block_full = true;
+        break;
+        */
     }
     //if (tb->cflags & CF_LAST_IO)
     //    gen_io_end();

--- a/tests/regress/fpu_ip.py
+++ b/tests/regress/fpu_ip.py
@@ -28,7 +28,7 @@ disasm = SimpleEngine()
 def hook_code(uc, addr, size, user_data):
 	mem = uc.mem_read(addr, size)
 	print("  0x%X:" % (addr)),
-	disasm.disas_single(str(mem))
+	disasm.disas_single(bytes(mem))
 
 class FpuIP(regress.RegressTest):
 


### PR DESCRIPTION
See my review here for details.

https://github.com/unicorn-engine/unicorn/pull/74/files#r614950124

The patch is submitted to qemu at https://lists.nongnu.org/archive/html/qemu-devel/2021-04/msg02868.html.

No idea the time it is merged in the upstream but I would like to merge it into Unicorn early since many users may emulate MSF generated shellcode which requires correct fpip implementation.