### PR TITLE
compile on VS2008/VS2010

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -827,7 +827,15 @@ if (WIN32)
         ${CMAKE_CURRENT_SOURCE_DIR}/msvc/unicorn/qapi-visit.c
     )
     if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-        enable_language(ASM_MASM)
+        if(MSVC_VERSION LESS 1600 AND MSVC_IDE)
+            add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/build/setjmp-wrapper-win32.dir/setjmp-wrapper-win32.obj"
+                COMMAND ml64 /c /nologo /Fo"${CMAKE_CURRENT_SOURCE_DIR}/build/setjmp-wrapper-win32.dir/setjmp-wrapper-win32.obj" /W3 /errorReport:prompt /Ta"${CMAKE_CURRENT_SOURCE_DIR}/qemu/util/setjmp-wrapper-win32.asm"
+                DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/qemu/util/setjmp-wrapper-win32.asm"
+            )
+            set(UNICORN_SRCS ${UNICORN_SRCS} "${CMAKE_CURRENT_SOURCE_DIR}/build/setjmp-wrapper-win32.dir/setjmp-wrapper-win32.obj")
+        else()
+            enable_language(ASM_MASM)
+        endif()
         set(UNICORN_SRCS ${UNICORN_SRCS} qemu/util/setjmp-wrapper-win32.asm)
     endif()
 else()

--- a/include/unicorn/platform.h
+++ b/include/unicorn/platform.h
@@ -64,6 +64,23 @@ typedef unsigned int   uint32_t;
 typedef signed long long   int64_t;
 typedef unsigned long long uint64_t;
 
+typedef signed char        int_fast8_t;
+typedef int                int_fast16_t;
+typedef int                int_fast32_t;
+typedef long long          int_fast64_t;
+typedef unsigned char      uint_fast8_t;
+typedef unsigned int       uint_fast16_t;
+typedef unsigned int       uint_fast32_t;
+typedef unsigned long long uint_fast64_t;
+
+#if !defined(_W64)
+#if !defined(__midl) && (defined(_X86_) || defined(_M_IX86)) && _MSC_VER >= 1300
+#define _W64 __w64
+#else
+#define _W64
+#endif
+#endif
+
 #ifndef _INTPTR_T_DEFINED
  #define _INTPTR_T_DEFINED
  #ifdef _WIN64
@@ -94,7 +111,36 @@ typedef _W64 unsigned int  uintptr_t;
 #define UINT16_MAX       0xffffui16
 #define UINT32_MAX       0xffffffffui32
 #define UINT64_MAX       0xffffffffffffffffui64
+
+#define INT_FAST8_MIN    INT8_MIN
+#define INT_FAST16_MIN   INT32_MIN
+#define INT_FAST32_MIN   INT32_MIN
+#define INT_FAST64_MIN   INT64_MIN
+#define INT_FAST8_MAX    INT8_MAX
+#define INT_FAST16_MAX   INT32_MAX
+#define INT_FAST32_MAX   INT32_MAX
+#define INT_FAST64_MAX   INT64_MAX
+#define UINT_FAST8_MAX   UINT8_MAX
+#define UINT_FAST16_MAX  UINT32_MAX
+#define UINT_FAST32_MAX  UINT32_MAX
+#define UINT_FAST64_MAX  UINT64_MAX
+
+#ifdef _WIN64
+#define INTPTR_MIN      INT64_MIN
+#define INTPTR_MAX      INT64_MAX
+#define UINTPTR_MAX     UINT64_MAX
+#else /* _WIN64 */
+#define INTPTR_MIN      INT32_MIN
+#define INTPTR_MAX      INT32_MAX
+#define UINTPTR_MAX     UINT32_MAX
+#endif /* _WIN64 */
+
 #else // this system has stdint.h
+
+#if defined(_MSC_VER) && (_MSC_VER == MSC_VER_VS2010)
+#define _INTPTR 2
+#endif
+
 #include <stdint.h>
 #endif  // (defined(_MSC_VER) && (_MSC_VER < MSC_VER_VS2010)) || defined(_KERNEL_MODE)
 


### PR DESCRIPTION
Compiling with Win32 Release/MinSizeRel/RelWithDebInfo in VS2008 will cause "fatal error C1063: compiler limit: compiler stack overflow" problem.
Compiling with Win32 Debug or x64 does not have this problem.
You can easily bypass this problem by changing the optimization options /O1 and /O2 to /Od.
In VS2010, when _INTPTR is 0 or 1, UINTPTR_MAX is 0xFFFFFFFF.