### PR TITLE
Drop trait attempts to free uc_context structs with uc_free instead of uc_context_free

### DIFF
--- a/bindings/rust/src/ffi.rs
+++ b/bindings/rust/src/ffi.rs
@@ -15,7 +15,7 @@ extern "C" {
     pub fn uc_arch_supported(arch: Arch) -> bool;
     pub fn uc_open(arch: Arch, mode: Mode, engine: *mut uc_handle) -> uc_error;
     pub fn uc_close(engine: uc_handle) -> uc_error;
-    pub fn uc_free(mem: uc_context) -> uc_error;
+    pub fn uc_context_free(mem: uc_context) -> uc_error;
     pub fn uc_errno(engine: uc_handle) -> uc_error;
     pub fn uc_strerror(error_code: uc_error) -> *const c_char;
     pub fn uc_reg_write(engine: uc_handle, regid: c_int, value: *const c_void) -> uc_error;

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -63,7 +63,7 @@ impl Context {
 
 impl Drop for Context {
     fn drop(&mut self) {
-        unsafe { ffi::uc_free(self.context) };
+        unsafe { ffi::uc_context_free(self.context) };
     }
 }
 
@@ -736,7 +736,7 @@ impl<'a, D> UnicornHandle<'a, D> {
                 context: new_context,
             })
         } else {
-            unsafe { ffi::uc_free(new_context) };
+            unsafe { ffi::uc_context_free(new_context) };
             Err(err)
         }
     }


### PR DESCRIPTION
The Rust bindings wrongfully attempt to free `uc_context` structures using `uc_free` instead of `uc_context_free`. Thus, freed objects are still referenced in the `saved_contexts` list of `uc_engine` objects.

```Rust
impl Drop for Context {
    fn drop(&mut self) {
        unsafe { ffi::uc_free(self.context) };
    }
}
```

Whenever a `Context` object goes out of scope this leads to a UAF in `uc_close` when the `saved_contexts` list is freed.

```C
cur = uc->saved_contexts.head;
while (cur != NULL) {
    struct list_item *next = cur->next;
    struct uc_context *context = (struct uc_context*)cur->data;
    context->uc = NULL;
    cur = next;
}
list_clear(&uc->saved_contexts)
```

`struct uc_context *context` will point to the data that was already freed by the trait implementation. The same bug also occurs in `context_init`.

```Rust
pub fn context_init(&self) -> Result<Context, uc_error> {
    let mut new_context: ffi::uc_context = Default::default();
    let err = unsafe { ffi::uc_context_alloc(self.inner.uc, &mut new_context) };
    if err != uc_error::OK {
        return Err(err);
    }
    let err = unsafe { ffi::uc_context_save(self.inner.uc, new_context) };
    if err == uc_error::OK {
        Ok(Context {
            context: new_context,
        })
    } else {
        unsafe { ffi::uc_free(new_context) };
        Err(err)
    }
}
```

This pull request ensures that `uc_context` objects are now freed using `uc_context_free` which also takes care of the list cleanup.
