### PR TITLE
Optimize memory_mapping

### DIFF
--- a/uc.c
+++ b/uc.c
@@ -697,25 +697,52 @@ uc_err uc_emu_stop(uc_engine *uc)
     return UC_ERR_OK;
 }
 
+// return target index where a memory region at the address exists, or could be inserted
+//
+// address either is inside the mapping at the returned index, or is in free space before
+// the next mapping.
+//
+// if there is overlap, between regions, ending address will be higher than the starting
+// address of the mapping at returned index
+static int bsearch_mapped_blocks(const uc_engine *uc, uint64_t address) {
+    int left, right, mid;
+    MemoryRegion *mapping;
+
+    left = 0;
+    right = uc->mapped_block_count;
+
+    while (left < right) {
+        mid = left + (right - left) / 2;
+
+        mapping = uc->mapped_blocks[mid];
+
+        if (mapping->end - 1 < address) {
+            left = mid + 1;
+        } else if (mapping->addr > address) {
+            right = mid;
+        } else {
+            return mid;
+        }
+    }
+
+    return left;
+}
+
 // find if a memory range overlaps with existing mapped regions
 static bool memory_overlap(struct uc_struct *uc, uint64_t begin, size_t size)
 {
     unsigned int i;
     uint64_t end = begin + size - 1;
 
-    for(i = 0; i < uc->mapped_block_count; i++) {
-        // begin address falls inside this region?
-        if (begin >= uc->mapped_blocks[i]->addr && begin <= uc->mapped_blocks[i]->end - 1)
-            return true;
+    i = bsearch_mapped_blocks(uc, begin);
 
-        // end address falls inside this region?
-        if (end >= uc->mapped_blocks[i]->addr && end <= uc->mapped_blocks[i]->end - 1)
-            return true;
+    // is this the highest region with no possible overlap?
+    if (i >= uc->mapped_block_count)
+        return false;
 
-        // this region falls totally inside this range?
-        if (begin < uc->mapped_blocks[i]->addr && end > uc->mapped_blocks[i]->end - 1)
-            return true;
-    }
+    // end address overlaps this region?
+    if (end >= uc->mapped_blocks[i]->addr)
+        return true;
 
     // not found
     return false;
@@ -725,6 +752,7 @@ static bool memory_overlap(struct uc_struct *uc, uint64_t begin, size_t size)
 static uc_err mem_map(uc_engine *uc, uint64_t address, size_t size, uint32_t perms, MemoryRegion *block)
 {
     MemoryRegion **regions;
+    int pos;
 
     if (block == NULL)
         return UC_ERR_NOMEM;
@@ -738,7 +766,12 @@ static uc_err mem_map(uc_engine *uc, uint64_t address, size_t size, uint32_t per
         uc->mapped_blocks = regions;
     }
 
-    uc->mapped_blocks[uc->mapped_block_count] = block;
+    pos = bsearch_mapped_blocks(uc, block->addr);
+
+    // shift the array right to give space for the new pointer
+    memmove(&uc->mapped_blocks[pos + 1], &uc->mapped_blocks[pos], sizeof(MemoryRegion*) * (uc->mapped_block_count - pos));
+
+    uc->mapped_blocks[pos] = block;
     uc->mapped_block_count++;
 
     return UC_ERR_OK;
@@ -876,7 +909,7 @@ static bool split_region(struct uc_struct *uc, MemoryRegion *mr, uint64_t addres
 
     // RAM_PREALLOC is not defined outside exec.c and I didn't feel like
     // moving it
-	prealloc = !!(block->flags & 1);
+    prealloc = !!(block->flags & 1);
 
     if (block->flags & 1) {
         backup = block->host;
@@ -1092,13 +1125,10 @@ MemoryRegion *memory_mapping(struct uc_struct* uc, uint64_t address)
     if (i < uc->mapped_block_count && address >= uc->mapped_blocks[i]->addr && address < uc->mapped_blocks[i]->end)
         return uc->mapped_blocks[i];
 
-    for(i = 0; i < uc->mapped_block_count; i++) {
-        if (address >= uc->mapped_blocks[i]->addr && address <= uc->mapped_blocks[i]->end - 1) {
-            // cache this index for the next query
-            uc->mapped_block_cache_index = i;
-            return uc->mapped_blocks[i];
-        }
-    }
+    i = bsearch_mapped_blocks(uc, address);
+
+    if (i < uc->mapped_block_count && address >= uc->mapped_blocks[i]->addr && address <= uc->mapped_blocks[i]->end - 1)
+        return uc->mapped_blocks[i];
 
     // not found
     return NULL;


### PR DESCRIPTION
Optimized `memory_mapping` function by ensuring the regions are sorted, which allows to use binary search. This makes insertion in `mem_map` `O(n)`, however, `memory_mapping` function seems to be invoked far more often than the former, and improving it from `O(n)` to `O(log n)` makes it scale much better with lots of single page mappings.

I tested it against Linux kernel's `kallsyms_lookup_name` function and total runtime went down from 1.6 seconds to 1.2.