### PR TITLE
Allow Rust memory hooks to return a bool

### DIFF
--- a/bindings/rust/src/ffi.rs
+++ b/bindings/rust/src/ffi.rs
@@ -155,7 +155,7 @@ pub extern "C" fn mem_hook_proxy<D>(
     size: u32,
     value: i64,
     user_data: *mut MemHook<D>,
-) {
+) -> bool {
     let unicorn = unsafe { &mut *(*user_data).unicorn };
     let callback = &mut unsafe { &mut *(*user_data).callback };
     assert_eq!(uc, unicorn.uc);
@@ -167,7 +167,7 @@ pub extern "C" fn mem_hook_proxy<D>(
         address,
         size as usize,
         value,
-    );
+    )
 }
 
 pub extern "C" fn intr_hook_proxy<D>(uc: uc_handle, value: u32, user_data: *mut InterruptHook<D>) {

--- a/bindings/rust/src/ffi.rs
+++ b/bindings/rust/src/ffi.rs
@@ -89,7 +89,7 @@ pub struct BlockHook<D> {
 
 pub struct MemHook<D> {
     pub unicorn: *mut crate::UnicornInner<D>,
-    pub callback: Box<dyn FnMut(crate::UnicornHandle<D>, MemType, u64, usize, i64)>,
+    pub callback: Box<dyn FnMut(crate::UnicornHandle<D>, MemType, u64, usize, i64) -> bool>,
 }
 
 pub struct InterruptHook<D> {

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -468,7 +468,7 @@ impl<'a, D> UnicornHandle<'a, D> {
         callback: F,
     ) -> Result<ffi::uc_hook, uc_error>
     where
-        F: FnMut(UnicornHandle<D>, MemType, u64, usize, i64),
+        F: FnMut(UnicornHandle<D>, MemType, u64, usize, i64) -> bool,
     {
         if !(HookType::MEM_ALL | HookType::MEM_READ_AFTER).contains(hook_type) {
             return Err(uc_error::ARG);

--- a/bindings/rust/src/utils.rs
+++ b/bindings/rust/src/utils.rs
@@ -324,7 +324,7 @@ fn heap_unalloc(
     addr: u64,
     _size: usize,
     _val: i64,
-) {
+) -> bool {
     let arch = uc.get_arch();
     let reg = match arch {
         Arch::X86 => RegisterX86::RIP as i32,
@@ -346,7 +346,7 @@ fn heap_oob(
     addr: u64,
     _size: usize,
     _val: i64,
-) {
+) -> bool {
     let arch = uc.get_arch();
     let reg = match arch {
         Arch::X86 => RegisterX86::RIP as i32,
@@ -370,7 +370,7 @@ fn heap_bo(
     addr: u64,
     _size: usize,
     _val: i64,
-) {
+) -> bool {
     let arch = uc.get_arch();
     let reg = match arch {
         Arch::X86 => RegisterX86::RIP as i32,
@@ -394,7 +394,7 @@ fn heap_uaf(
     addr: u64,
     _size: usize,
     _val: i64,
-) {
+) -> bool {
     let arch = uc.get_arch();
     let reg = match arch {
         Arch::X86 => RegisterX86::RIP as i32,

--- a/bindings/rust/tests/unicorn.rs
+++ b/bindings/rust/tests/unicorn.rs
@@ -278,9 +278,10 @@ fn x86_mem_callback() {
 
     let callback_mems = mems_cell.clone();
     let callback =
-        move |_: Unicorn<'_>, mem_type: MemType, address: u64, size: usize, value: i64| {
+        move |_: Unicorn<'_>, mem_type: MemType, address: u64, size: usize, value: i64| -> bool {
             let mut mems = callback_mems.borrow_mut();
             mems.push(MemExpectation(mem_type, address, size, value));
+            true
         };
 
     // mov eax, 0xdeadbeef;


### PR DESCRIPTION
Unicorn memory hooks return a boolean to indicate if the exception was handled and emulation should continue, or if emulation should halt.

This adds this functionality to the Rust bindings, allowing memory hooks to return a bool.