### PR TITLE
 Rust binding: call cmake in build script (for master branch)

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -24,4 +24,4 @@ libc = "0.2"
 capstone="0.6.0"
 
 [build-dependencies]
-build-helper = "0.1"
+cmake = "0.1"


### PR DESCRIPTION
porting of #1444

I found the option of CMakeLists.txt is different between master and next branch.