### PR TITLE
Fix git URL in Rust build script

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -19,7 +19,7 @@ fn main() {
 
         Command::new("git")
             .arg("clone")
-            .arg("git@github.com:unicorn-engine/unicorn.git")
+            .arg("https://github.com/unicorn-engine/unicorn.git")
             .arg("-b")
             .arg(version)
             .arg(&unicorn_dir)


### PR DESCRIPTION
Build script failed with `thread 'main' panicked at 'Fail to create build directory on *nix.: Os { code: 2, kind: NotFound, message: "No such file or directory" }'`. This is caused by a permission denied error:
```
git clone git@github.com:unicorn-engine/unicorn.git -b dev unicorn                                            
Clonando en 'unicorn'...
git@github.com: Permission denied (publickey).
fatal: No se pudo leer del repositorio remoto.
```