### PR TITLE
Add test case for #1497

### DIFF
--- a/tests/unit/test_mem.c
+++ b/tests/unit/test_mem.c
@@ -74,8 +74,22 @@ static void test_splitting_mem_unmap()
     OK(uc_close(uc));
 }
 
+static void test_splitting_mmio_unmap()
+{
+    uc_engine *uc;
+
+    OK(uc_open(UC_ARCH_X86, UC_MODE_32, &uc));
+
+    OK(uc_mmio_map(uc, 0x3000, 0x2000, NULL, NULL, NULL, NULL));
+
+    OK(uc_mem_unmap(uc, 0x3000, 0x1000));
+
+    OK(uc_close(uc));
+}
+
 TEST_LIST = {{"test_map_correct", test_map_correct},
              {"test_map_wrapping", test_map_wrapping},
              {"test_mem_protect", test_mem_protect},
              {"test_splitting_mem_unmap", test_splitting_mem_unmap},
+             {"test_x86_splitting_mmio_unmap", test_splitting_mmio_unmap},
              {NULL, NULL}};


### PR DESCRIPTION
This adds the test case mentioned in #1497 as a unit test.

Feel free to close this, if unmapping parts of MMIO regions is intentionally not supported.