### PR TITLE
Rust MMIO

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -81,6 +81,8 @@ pub struct UnicornInner<'a, D> {
     pub arch: Arch,
     /// to keep ownership over the hook for this uc instance's lifetime
     pub hooks: Vec<(ffi::uc_hook, Box<dyn ffi::IsUcHook<'a> + 'a>)>,
+    /// To keep ownership over the mmio callbacks for this uc instance's lifetime
+    pub mmio_callbacks: Vec<(Option<Box<dyn ffi::IsUcHook<'a> + 'a>>, Option<Box<dyn ffi::IsUcHook<'a> + 'a>>)>,
     pub data: D,
 }
 
@@ -123,6 +125,7 @@ where
                     arch,
                     data,
                     hooks: vec![],
+                    mmio_callbacks: vec![],
                 })),
             })
         } else {
@@ -260,6 +263,99 @@ impl<'a, D> Unicorn<'a, D> {
         } else {
             Err(err)
         }
+    }
+
+    /// Map in am MMIO region backed by callbacks.
+    ///
+    /// `address` must be aligned to 4kb or this will return `Error::ARG`.
+    /// `size` must be a multiple of 4kb or this will return `Error::ARG`.
+    pub fn mmio_map<R: 'a, W: 'a>(
+        &mut self,
+        address: u64, 
+        size: libc::size_t,
+        read_callback: Option<R>,
+        write_callback: Option<W>,
+    ) -> Result<(), uc_error>
+    where
+        R: FnMut(&mut Unicorn<D>, u64, usize) -> u64,
+        W: FnMut(&mut Unicorn<D>, u64, usize, u64),
+    {
+        let mut read_data = read_callback.map( |c| {
+            Box::new(ffi::UcHook {
+                callback: c,
+                uc: Unicorn {
+                    inner: self.inner.clone(),
+                },
+            })
+        });
+        let mut write_data = write_callback.map( |c| {
+            Box::new(ffi::UcHook {
+                callback: c,
+                uc: Unicorn {
+                    inner: self.inner.clone(),
+                },
+            })
+        });
+
+        let err = unsafe {
+            ffi::uc_mmio_map(
+                self.inner().uc,
+                address,
+                size,
+                ffi::mmio_read_callback_proxy::<D, R> as _,
+                match read_data {
+                    Some(ref mut d) => d.as_mut() as *mut _ as _,
+                    None => ptr::null_mut(),
+                },
+                ffi::mmio_write_callback_proxy::<D, W> as _,
+                match write_data {
+                    Some(ref mut d) => d.as_mut() as *mut _ as _,
+                    None => ptr::null_mut(),
+                },
+            )
+        };
+
+        if err == uc_error::OK {
+            let rd = read_data.map( |c| c as Box<dyn ffi::IsUcHook> );
+            let wd = write_data.map( |c| c as Box<dyn ffi::IsUcHook> );
+            self.inner_mut().mmio_callbacks.push((rd, wd));
+
+            Ok(())
+        } else {
+            Err(err)
+        }
+    }
+
+    /// Map in a read-only MMIO region backed by a callback.
+    ///
+    /// `address` must be aligned to 4kb or this will return `Error::ARG`.
+    /// `size` must be a multiple of 4kb or this will return `Error::ARG`.
+    pub fn mmio_map_ro<F: 'a>(
+        &mut self,
+        address: u64,
+        size: libc::size_t,
+        callback: F,
+    ) -> Result<(), uc_error>
+    where
+        F: FnMut(&mut Unicorn<D>, u64, usize) -> u64,
+    {
+        self.mmio_map(address, size, Some(callback), None::<fn(&mut Unicorn<D>, u64, usize, u64)>)
+    }
+
+    /// Map in a write-only MMIO region backed by a callback.
+    ///
+    /// `address` must be aligned to 4kb or this will return `Error::ARG`.
+    /// `size` must be a multiple of 4kb or this will return `Error::ARG`.
+    pub fn mmio_map_wo<F: 'a>(
+        &mut self,
+        address: u64,
+        size: libc::size_t,
+        callback: F,
+    ) -> Result<(), uc_error>
+    where
+        F: FnMut(&mut Unicorn<D>, u64, usize, u64),
+    {
+        self.mmio_map(address, size, None::<fn(&mut Unicorn<D>, u64, usize) -> u64>, Some(callback))
     }
 
     /// Unmap a memory region.


### PR DESCRIPTION
I noticed that the rust bindings apparently don't have a way to map MMIO regions at the moment. This PR adds `map_mmio` to provide this functionality.

Some things that I'm unhappy with, but don't see a way to make them better at the moment (feedback very welcome):

* The logic in `mmio_map` to take a pointer to the user data and then move the `Box`es of the user data into `self.inner_mut().mmio_callbacks` only works, because the pointer isn't checked by regular borrowing rules. This is basically the same method as used for hook callbacks and AIUI the `Box` guarantees that the contents of the box will always stay in the same location, so this should be safe. But I would be slightly more satisfied with a solution that would also work under normal borrowing rules.
* The logic in `MmioCallbackScope.unmap` is kinda complicated and easy to get wrong. I'm not really confident that I didn't make any off-by-one errors. Unfortunately I'm also not really sure how to properly write automated tests for this, because the test suite doesn't have access to `Unicorn.inner()` to check that deallocation is actually working as intended.

`Unicorn<D>.mmio_unmap` could probably be made more efficient by keeping the `MmioCallbackScope`s sorted and using some sort of binary search to find regions to unmap. However, I wanted to keep this implementation simple for the moment. The introduced logic is already complicated as-is and I would imagine that `mem_unmap` isn't very performance critical for most use cases. But if you think a more performant implementation is needed, I can take a look at it again.