### PR TITLE
SetCPUModel go binding for setting the CPU model

### DIFF
--- a/bindings/go/unicorn/uc.c
+++ b/bindings/go/unicorn/uc.c
@@ -23,3 +23,7 @@ uc_err uc_reg_write_batch_helper(uc_engine *handle, int *regs, uint64_t *val_in,
     free(val_ref);
     return ret;
 }
+
+uc_err uc_ctl_set_cpu_model_helper(uc_engine *handle, int model) {
+    return uc_ctl_set_cpu_model(handle, model);
+}

--- a/bindings/go/unicorn/uc.h
+++ b/bindings/go/unicorn/uc.h
@@ -1,2 +1,3 @@
 uc_err uc_reg_read_batch_helper(uc_engine *handle, int *regs, uint64_t *val_out, int count);
 uc_err uc_reg_write_batch_helper(uc_engine *handle, int *regs, uint64_t *val_in, int count);
+uc_err uc_ctl_set_cpu_model_helper(uc_engine *handle, int model);

--- a/bindings/go/unicorn/unicorn.go
+++ b/bindings/go/unicorn/unicorn.go
@@ -62,6 +62,7 @@ type Unicorn interface {
 	Handle() *C.uc_engine
 	RegWriteX86Msr(reg uint64, val uint64) error
 	RegReadX86Msr(reg uint64) (uint64, error)
+	SetCPUModel(model int) error
 }
 
 type uc struct {
@@ -232,4 +233,9 @@ func (u *uc) Query(queryType int) (uint64, error) {
 
 func (u *uc) Handle() *C.uc_engine {
 	return u.handle
+}
+
+func (u *uc) SetCPUModel(model int) error {
+	ucerr := C.uc_ctl_set_cpu_model_helper(u.handle, C.int(model))
+	return errReturn(ucerr)
 }


### PR DESCRIPTION
I added a `SetCPUModel` method to the unicorn interface in the go bindings to address #1502. CGO does not support calling C functions with varargs so I also added a `uc_ctl_set_cpu_model_helper` function to `uc.c` to call `uc_ctl`

Usage:

`
emu, _ := uc.NewUnicorn(uc.ARCH_M68K, uc.MODE_BIG_ENDIAN)
emu.SetCPUModel(uc.CPU_M68000_CPU)
`