### PR TITLE
Bug fix for LUI instruction (MIPS)

### DIFF
--- a/qemu/target-mips/translate.c
+++ b/qemu/target-mips/translate.c
@@ -2551,7 +2551,7 @@ static void gen_logic_imm(DisasContext *ctx, uint32_t opc,
             tcg_gen_ext32s_tl(tcg_ctx, *cpu_gpr[rt], *cpu_gpr[rt]);
             MIPS_DEBUG("aui %s, %s, %04x", regnames[rt], regnames[rs], imm);
         } else {
-            tcg_gen_movi_tl(tcg_ctx, *cpu_gpr[rt], uimm << 16);
+            tcg_gen_movi_tl(tcg_ctx, *cpu_gpr[rt], imm << 16);
             MIPS_DEBUG("lui %s, " TARGET_FMT_lx, regnames[rt], uimm);
         }
         break;


### PR DESCRIPTION
This little patch fixes a bug in the QEMU of Unicorn - implementation of the LUI instruction (MIPS) is not correct: the instruction must perform signed extension of the immediate operand, but it is unsigned in the code (probably a misprint); I have fixed it. I also attach the corresponding fragment of the MIPS instruction set reference which describes this instruction.

![lui_mips](https://user-images.githubusercontent.com/76033185/144881837-33aeaffd-9c4d-4d62-b263-1fdf0149a0fe.png)
