### PR TITLE
Issues with count for code patching 

### DIFF
--- a/tests/unit/test_arm64.c
+++ b/tests/unit/test_arm64.c
@@ -78,6 +78,7 @@ static void test_arm64_code_patching() {
     OK(uc_close(uc));
 }
 
+// Need to flush the cache before running the emulation after patching
 static void test_arm64_code_patching_count() {
     uc_engine *uc;
     char code[] = "\x00\x04\x00\x11"; // add w0, w0, 0x1
@@ -93,6 +94,7 @@ static void test_arm64_code_patching_count() {
     // patch instruction
     char patch_code[] = "\x00\xfc\x1f\x11"; // add w0, w0, 0x7FF
     OK(uc_mem_write(uc, code_start, patch_code, sizeof(patch_code) - 1));
+    OK(uc_ctl_remove_cache(uc, code_start, code_start + sizeof(patch_code) - 1));
     // zero out x0
     r_x0 = 0x0;
     OK(uc_reg_write(uc, UC_ARM64_REG_X0, &r_x0));

--- a/tests/unit/test_riscv.c
+++ b/tests/unit/test_riscv.c
@@ -399,6 +399,7 @@ static void test_riscv64_code_patching() {
     OK(uc_close(uc));
 }
 
+// Need to flush the cache before running the emulation after patching
 static void test_riscv64_code_patching_count() {
     uc_engine *uc;
     char code[] = "\x93\x82\x12\x00"; // addi t0, t0, 0x1
@@ -414,6 +415,7 @@ static void test_riscv64_code_patching_count() {
     // patch instruction
     char patch_code[] = "\x93\x82\xf2\x7f"; // addi t0, t0, 0x7FF
     OK(uc_mem_write(uc, code_start, patch_code, sizeof(patch_code) - 1));
+    OK(uc_ctl_remove_cache(uc, code_start, code_start + sizeof(patch_code) - 1));
     // zero out t0
     r_t0 = 0x0;
     OK(uc_reg_write(uc, UC_RISCV_REG_T0, &r_t0));


### PR DESCRIPTION
Hello, when rewriting (what I called code patching) the code memory to change an instruction, the previous instruction will be executed instead. 
In the tests, I wrote an `add 1` to a register, emulated to see the result, then overwrote the instruction with `add 7ff` to the same register and re-emulated. When using the `start_address`/`end_address` method, the execution of the new instruction proceeds however when using a count, the previous instruction is executed instead.
