### PR TITLE
python: look for libunicorn.so.1 rather than libunicorn.so

### DIFF
--- a/bindings/python/unicorn/unicorn.py
+++ b/bindings/python/unicorn/unicorn.py
@@ -23,7 +23,7 @@ if _python2:
 _lib = { 'darwin': 'libunicorn.dylib',
          'win32': 'unicorn.dll',
          'cygwin': 'cygunicorn.dll',
-         'linux': 'libunicorn.so',
+         'linux': 'libunicorn.so.1',
          'linux2': 'libunicorn.so' }
 
 


### PR DESCRIPTION
Many linux distributions place the ".so" form of their shared libraries
in an optional development package, preferring the ".so.N" form. Modify
the Python package to look for the latter rather than the former.

Signed-off-by: W. Michael Petullo <mike@flyn.org>

I maintain the Fedora unicorn package. I am not sure how this fits into the larger Unicorn project, but it seemed to make sense for Fedora.