### PR TITLE
Clear Python pending hook exception before we enter the emulation.

### DIFF
--- a/bindings/python/unicorn/unicorn.py
+++ b/bindings/python/unicorn/unicorn.py
@@ -460,6 +460,7 @@ class Uc(object):
 
     # emulate from @begin, and stop when reaching address @until
     def emu_start(self, begin, until, timeout=0, count=0):
+        self._hook_exception = None
         status = _uc.uc_emu_start(self._uch, begin, until, timeout, count)
         if status != uc.UC_ERR_OK:
             raise UcError(status)


### PR DESCRIPTION
The pending exception hook is set when the hook raised an exception
and wants to report it outside the emulation loop. However, it is
never cleared back to None. This means that after an exception is
raised in a hook, all subsequent execution (even if successful) will
raise the exception.

This change clears the exception before we start another emulation,
which should ensure that if we have _hook_exception set, it really
is from hooks in this emulation run.