### PR TITLE
rust: Allow to remove self inside a hook

### DIFF
--- a/bindings/rust/src/ffi.rs
+++ b/bindings/rust/src/ffi.rs
@@ -96,12 +96,13 @@ pub trait IsUcHook<'a> {}
 
 impl<'a, D, F> IsUcHook<'a> for UcHook<'a, D, F> {}
 
-pub extern "C" fn mmio_read_callback_proxy<D, F> (
+pub extern "C" fn mmio_read_callback_proxy<D, F>(
     uc: uc_handle,
     offset: u64,
     size: usize,
     user_data: *mut UcHook<D, F>,
-) -> u64 where
+) -> u64
+where
     F: FnMut(&mut crate::Unicorn<D>, u64, usize) -> u64,
 {
     let user_data = unsafe { &mut *user_data };
@@ -109,7 +110,7 @@ pub extern "C" fn mmio_read_callback_proxy<D, F> (
     (user_data.callback)(&mut user_data.uc, offset, size)
 }
 
-pub extern "C" fn mmio_write_callback_proxy<D, F> (
+pub extern "C" fn mmio_write_callback_proxy<D, F>(
     uc: uc_handle,
     offset: u64,
     size: usize,

--- a/bindings/rust/tests/unicorn.rs
+++ b/bindings/rust/tests/unicorn.rs
@@ -427,7 +427,10 @@ fn x86_mmio() {
 
     {
         // MOV eax, [0x2004]; MOV [0x2008], ax;
-        let x86_code: Vec<u8> = vec![0x8B, 0x04, 0x25, 0x04, 0x20, 0x00, 0x00, 0x66, 0x89, 0x04, 0x25, 0x08, 0x20, 0x00, 0x00];
+        let x86_code: Vec<u8> = vec![
+            0x8B, 0x04, 0x25, 0x04, 0x20, 0x00, 0x00, 0x66, 0x89, 0x04, 0x25, 0x08, 0x20, 0x00,
+            0x00,
+        ];
 
         let read_cell = Rc::new(RefCell::new(MmioReadExpectation(0, 0)));
         let cb_read_cell = read_cell.clone();
@@ -436,7 +439,7 @@ fn x86_mmio() {
             42
         };
 
-        let write_cell = Rc::new(RefCell::new(MmioWriteExpectation(0,0,0)));
+        let write_cell = Rc::new(RefCell::new(MmioWriteExpectation(0, 0, 0)));
         let cb_write_cell = write_cell.clone();
         let write_callback = move |_: &mut Unicorn<'_, ()>, offset, size, value| {
             *cb_write_cell.borrow_mut() = MmioWriteExpectation(offset, size, value);
@@ -444,7 +447,10 @@ fn x86_mmio() {
 
         assert_eq!(emu.mem_write(0x1000, &x86_code), Ok(()));
 
-        assert_eq!(emu.mmio_map(0x2000, 0x1000, Some(read_callback), Some(write_callback)), Ok(()));
+        assert_eq!(
+            emu.mmio_map(0x2000, 0x1000, Some(read_callback), Some(write_callback)),
+            Ok(())
+        );
 
         assert_eq!(
             emu.emu_start(
@@ -494,9 +500,11 @@ fn x86_mmio() {
 
     {
         // MOV ax, 42; MOV [0x2008], ax;
-        let x86_code: Vec<u8> = vec![0x66, 0xB8, 0x2A, 0x00, 0x66, 0x89, 0x04, 0x25, 0x08, 0x20, 0x00, 0x00];
+        let x86_code: Vec<u8> = vec![
+            0x66, 0xB8, 0x2A, 0x00, 0x66, 0x89, 0x04, 0x25, 0x08, 0x20, 0x00, 0x00,
+        ];
 
-        let write_cell = Rc::new(RefCell::new(MmioWriteExpectation(0,0,0)));
+        let write_cell = Rc::new(RefCell::new(MmioWriteExpectation(0, 0, 0)));
         let cb_write_cell = write_cell.clone();
         let write_callback = move |_: &mut Unicorn<'_, ()>, offset, size, value| {
             *cb_write_cell.borrow_mut() = MmioWriteExpectation(offset, size, value);


### PR DESCRIPTION
And I do a `cargo fmt` and `cargo clippy` on the code.

* * *
After #1480, remove self inside a hook leads to a segmentation fault. This is the PoC:
```rust
use std::ffi::c_void;
use unicorn_engine::unicorn_const::{Arch, Mode, Permission, SECOND_SCALE};
use unicorn_engine::Unicorn;

static mut STEP_HOOK: Option<*mut c_void> = None;

fn step_hook(uc: &mut Unicorn<()>, _addr: u64, _size: u32) {
    unsafe {
        if let Some(step_hook) = STEP_HOOK {
            uc.remove_hook(step_hook)
                .expect("Failed to remove step hook");
            STEP_HOOK = None
        }
    }
}

fn main() {
    let x86_code = [
        0x48, 0xB8, 0xEF, 0xBE, 0xAD, 0xDE, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x05,
    ];
    let mut uc = unicorn_engine::Unicorn::new(Arch::X86, Mode::MODE_32)
        .expect("failed to initialize unicorn instance");
    assert_eq!(uc.mem_map(0x1000, 0x4000, Permission::ALL), Ok(()));
    assert_eq!(uc.mem_write(0x1000, &x86_code), Ok(()));
    unsafe {
        STEP_HOOK = Some(
            uc.add_code_hook(1, 0, step_hook)
                .expect("Failed to add code hook"),
        )
    }
    let _ = uc.emu_start(
        0x1000,
        (0x1000 + x86_code.len()) as u64,
        10 * SECOND_SCALE,
        1000,
    );
}

```

* * *
Related issue: #1406
