### PR TITLE
Problem: Could not allocate dynamic translator buffer

### DIFF
--- a/qemu/include/qemu/osdep.h
+++ b/qemu/include/qemu/osdep.h
@@ -124,7 +124,7 @@ struct uc_struct;
  * 
  * Issue: https://github.com/desktop/desktop/issues/12978
  */
-#if defined(__APPLE__) && defined(HAVE_PTHREAD_JIT_PROTECT) && defined(__arm__)
+#if defined(__APPLE__) && defined(HAVE_PTHREAD_JIT_PROTECT) && (defined(__arm__) || defined(__aarch64__))
 #define USE_MAP_JIT
 #endif
 


### PR DESCRIPTION
`Could not allocate dynamic translator buffer` error while
trying to perform any memory-related operation.

This happens on aarch64 (MacBook Pro M1)

Solution: ensure aarch64 architecture is properly checked against

Fixes #1556