### PR TITLE
s390x/tcg: Fix BRASL and BRCL with large negative offsets

### DIFF
--- a/qemu/target/s390x/translate.c
+++ b/qemu/target/s390x/translate.c
@@ -1268,7 +1268,7 @@ static DisasJumpType help_branch(DisasContext *s, DisasCompare *c,
                                  bool is_imm, int imm, TCGv_i64 cdest)
 {
     DisasJumpType ret;
-    uint64_t dest = s->base.pc_next + 2 * imm;
+    uint64_t dest = s->base.pc_next + (int64_t)imm * 2;
     TCGLabel *lab;
     TCGContext *tcg_ctx = s->uc->tcg_ctx;
 
@@ -1606,7 +1606,7 @@ static DisasJumpType op_basi(DisasContext *s, DisasOps *o)
 {
     TCGContext *tcg_ctx = s->uc->tcg_ctx;
     pc_to_link_info(tcg_ctx, o->out, s, s->pc_tmp);
-    return help_goto_direct(s, s->base.pc_next + 2 * get_field(s, i2));
+    return help_goto_direct(s, s->base.pc_next + (int64_t)get_field(s, i2) * 2);
 }
 
 static DisasJumpType op_bc(DisasContext *s, DisasOps *o)


### PR DESCRIPTION
This is a backport of the following upstream commits:
- commit fc3dd86a290a ("s390x/tcg: Fix BRASL with a large negative offset")
- commit 16ed5f14215b ("s390x/tcg: Fix BRCL with a large negative offset")