### PR TITLE
Fix clang-cl compile with CONFIG_INT128 option in QEMU

### DIFF
--- a/qemu/include/qemu/host-utils.h
+++ b/qemu/include/qemu/host-utils.h
@@ -49,7 +49,29 @@ static inline void muls64(uint64_t *plow, uint64_t *phigh,
 /* compute with 96 bit intermediate result: (a*b)/c */
 static inline uint64_t muldiv64(uint64_t a, uint32_t b, uint32_t c)
 {
-    return (__int128_t)a * b / c;
+    #if defined(_MSC_VER) && defined(__clang__)
+        union {
+            uint64_t ll;
+            struct {
+    #ifdef HOST_WORDS_BIGENDIAN
+                uint32_t high, low;
+    #else
+                uint32_t low, high;
+    #endif
+            } l;
+        } u, res;
+        uint64_t rl, rh;
+
+        u.ll = a;
+        rl = (uint64_t)u.l.low * (uint64_t)b;
+        rh = (uint64_t)u.l.high * (uint64_t)b;
+        rh += (rl >> 32);
+        res.l.high = rh / c;
+        res.l.low = (((rh % c) << 32) + (rl & 0xffffffff)) / c;
+        return res.ll;
+    #else
+        return (__int128_t)a * b / c;
+    #endif
 }
 
 static inline int divu128(uint64_t *plow, uint64_t *phigh, uint64_t divisor)


### PR DESCRIPTION
This fixes the linker error:
`lld-link: error: undefined symbol: __udivti3`
when compiling with clang-cl on windows.