### PR TITLE
Fix rust binding for insn_in hook callback

### DIFF
--- a/bindings/rust/src/ffi.rs
+++ b/bindings/rust/src/ffi.rs
@@ -181,7 +181,7 @@ pub extern "C" fn insn_in_hook_proxy<D, F>(
     size: usize,
     user_data: *mut UcHook<D, F>,
 ) where
-    F: FnMut(&mut crate::Unicorn<D>, u32, usize),
+    F: FnMut(&mut crate::Unicorn<D>, u32, usize) -> u32,
 {
     let user_data = unsafe { &mut *user_data };
     debug_assert_eq!(uc, user_data.uc.get_handle());

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -758,7 +758,7 @@ impl<'a, D> Unicorn<'a, D> {
     /// Add hook for x86 IN instruction.
     pub fn add_insn_in_hook<F: 'a>(&mut self, callback: F) -> Result<ffi::uc_hook, uc_error>
     where
-        F: FnMut(&mut Unicorn<D>, u32, usize),
+        F: FnMut(&mut Unicorn<D>, u32, usize) -> u32,
     {
         let mut hook_ptr = core::ptr::null_mut();
         let mut user_data = Box::new(ffi::UcHook {

--- a/bindings/rust/tests/unicorn.rs
+++ b/bindings/rust/tests/unicorn.rs
@@ -309,6 +309,7 @@ fn x86_insn_in_callback() {
     let callback_insn = insn_cell.clone();
     let callback = move |_: &mut Unicorn<()>, port: u32, size: usize| {
         *callback_insn.borrow_mut() = InsnInExpectation(port, size);
+        42
     };
 
     let x86_code32: Vec<u8> = vec![0xe5, 0x10]; // IN eax, 0x10;
@@ -332,6 +333,7 @@ fn x86_insn_in_callback() {
         Ok(())
     );
     assert_eq!(expect, *insn_cell.borrow());
+    assert_eq!(emu.reg_read(RegisterX86::EAX), Ok(42));
     assert_eq!(emu.remove_hook(hook), Ok(()));
 }
 


### PR DESCRIPTION
The x86 IN callback [uc_cb_insn_in_t](https://github.com/n1tram1/unicorn/blob/c10639fd4658a852049546162d116b123e2b1ec2/include/unicorn/unicorn.h#L231) is supposed to return a u32 (the value from the i/o port).

This fixes that by making the callback return a u32.