### PR TITLE
Proposed fix for #1579: adjusting stop_request and quit_request

### DIFF
--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -828,6 +828,20 @@ UNICORN_EXPORT
 uc_err uc_emu_start(uc_engine *uc, uint64_t begin, uint64_t until,
                     uint64_t timeout, size_t count);
 
+
+/*
+ "Soft" stop emulation: perform all the logic of stopping emulation
+ without setting the uc.stop_request. Most callers will use this when
+ setting quit_request to flush TB and continue execution. The function
+ uc_emu_stop() calls this function and then sets uc.stop_request.
+
+ @uc: handle returned by uc_open()
+
+ @return UC_ERR_OK on success, or other value on failure (refer to uc_err enum
+   for detailed error).
+*/
+uc_err uc_emu_soft_stop(uc_engine *uc);
+
 /*
  Stop emulation (which was started by uc_emu_start() API.
  This is typically called from callback functions registered via tracing APIs.

--- a/qemu/softmmu/cpus.c
+++ b/qemu/softmmu/cpus.c
@@ -95,12 +95,7 @@ static int tcg_cpu_exec(struct uc_struct *uc)
             uc->quit_request = false;
             r = cpu_exec(uc, cpu);
 
-            // quit current TB but continue emulating?
-            if (uc->quit_request) {
-                // reset stop_request
-                uc->stop_request = false;
-            } else if (uc->stop_request) {
-                //printf(">>> got STOP request!!!\n");
+            if (uc->stop_request) {
                 finish = true;
                 break;
             }

--- a/qemu/target/arm/unicorn_aarch64.c
+++ b/qemu/target/arm/unicorn_aarch64.c
@@ -355,7 +355,7 @@ int arm64_reg_write(struct uc_struct *uc, unsigned int *regs, void *const *vals,
         if (regid == UC_ARM64_REG_PC) {
             // force to quit execution and flush TB
             uc->quit_request = true;
-            uc_emu_stop(uc);
+            uc_emu_soft_stop(uc);
         }
     }
 

--- a/qemu/target/arm/unicorn_arm.c
+++ b/qemu/target/arm/unicorn_arm.c
@@ -479,7 +479,7 @@ int arm_reg_write(struct uc_struct *uc, unsigned int *regs, void *const *vals,
         if (regid == UC_ARM_REG_R15) {
             // force to quit execution and flush TB
             uc->quit_request = true;
-            uc_emu_stop(uc);
+            uc_emu_soft_stop(uc);
         }
     }
 

--- a/qemu/target/i386/unicorn.c
+++ b/qemu/target/i386/unicorn.c
@@ -1520,7 +1520,7 @@ int x86_reg_write(struct uc_struct *uc, unsigned int *regs, void *const *vals,
             case UC_X86_REG_IP:
                 // force to quit execution and flush TB
                 uc->quit_request = true;
-                uc_emu_stop(uc);
+                uc_emu_soft_stop(uc);
                 break;
             }
 
@@ -1534,7 +1534,7 @@ int x86_reg_write(struct uc_struct *uc, unsigned int *regs, void *const *vals,
             case UC_X86_REG_IP:
                 // force to quit execution and flush TB
                 uc->quit_request = true;
-                uc_emu_stop(uc);
+                uc_emu_soft_stop(uc);
                 break;
             }
 #endif

--- a/qemu/target/m68k/unicorn.c
+++ b/qemu/target/m68k/unicorn.c
@@ -112,7 +112,7 @@ int m68k_reg_write(struct uc_struct *uc, unsigned int *regs, void *const *vals,
         if (regid == UC_M68K_REG_PC) {
             // force to quit execution and flush TB
             uc->quit_request = true;
-            uc_emu_stop(uc);
+            uc_emu_soft_stop(uc);
         }
     }
 

--- a/qemu/target/mips/unicorn.c
+++ b/qemu/target/mips/unicorn.c
@@ -165,7 +165,7 @@ int mips_reg_write(struct uc_struct *uc, unsigned int *regs, void *const *vals,
         if (regid == UC_MIPS_REG_PC) {
             // force to quit execution and flush TB
             uc->quit_request = true;
-            uc_emu_stop(uc);
+            uc_emu_soft_stop(uc);
         }
     }
 

--- a/qemu/target/ppc/unicorn.c
+++ b/qemu/target/ppc/unicorn.c
@@ -321,7 +321,7 @@ int ppc_reg_write(struct uc_struct *uc, unsigned int *regs, void *const *vals,
         if (regid == UC_PPC_REG_PC) {
             // force to quit execution and flush TB
             uc->quit_request = true;
-            uc_emu_stop(uc);
+            uc_emu_soft_stop(uc);
         }
     }
 

--- a/qemu/target/riscv/unicorn.c
+++ b/qemu/target/riscv/unicorn.c
@@ -555,7 +555,7 @@ int riscv_reg_write(struct uc_struct *uc, unsigned int *regs, void *const *vals,
         if (regid == UC_RISCV_REG_PC) {
             // force to quit execution and flush TB
             uc->quit_request = true;
-            uc_emu_stop(uc);
+            uc_emu_soft_stop(uc);
         }
     }
 

--- a/qemu/target/s390x/unicorn.c
+++ b/qemu/target/s390x/unicorn.c
@@ -125,7 +125,7 @@ static int s390_reg_write(struct uc_struct *uc, unsigned int *regs,
         if (regid == UC_S390X_REG_PC) {
             // force to quit execution and flush TB
             uc->quit_request = true;
-            uc_emu_stop(uc);
+            uc_emu_soft_stop(uc);
         }
     }
 

--- a/qemu/target/sparc/unicorn.c
+++ b/qemu/target/sparc/unicorn.c
@@ -131,7 +131,7 @@ int sparc_reg_write(struct uc_struct *uc, unsigned int *regs, void *const *vals,
         if (regid == UC_SPARC_REG_PC) {
             // force to quit execution and flush TB
             uc->quit_request = true;
-            uc_emu_stop(uc);
+            uc_emu_soft_stop(uc);
             break;
         }
     }

--- a/uc.c
+++ b/uc.c
@@ -855,8 +855,7 @@ uc_err uc_emu_start(uc_engine *uc, uint64_t begin, uint64_t until,
     return uc->invalid_error;
 }
 
-UNICORN_EXPORT
-uc_err uc_emu_stop(uc_engine *uc)
+uc_err uc_emu_soft_stop(uc_engine *uc)
 {
     UC_INIT(uc);
 
@@ -872,6 +871,16 @@ uc_err uc_emu_stop(uc_engine *uc)
     }
 
     return UC_ERR_OK;
+}
+
+UNICORN_EXPORT
+uc_err uc_emu_stop(uc_engine *uc)
+{
+    uc_err err;
+
+    err = uc_emu_soft_stop(uc);
+    uc->stop_request = true;
+    return err;
 }
 
 // return target index where a memory region at the address exists, or could be
@@ -1391,7 +1400,7 @@ uc_err uc_mem_protect(struct uc_struct *uc, uint64_t address, size_t size,
     // place
     if (remove_exec) {
         uc->quit_request = true;
-        uc_emu_stop(uc);
+        uc_emu_soft_stop(uc);
     }
 
     return UC_ERR_OK;


### PR DESCRIPTION
Slightly changed how stop_request and quit_request are set and 
checked. First, this adds uc_emu_soft_stop(), which now has all
the same logic that was previously in uc_emu_stop(), except it
does not set uc->stop_request.  The uc_emu_stop() function now
calls uc_emu_soft_stop() and then sets uc->stop_request. The
point of making uc_emu_soft_stop its own function was to split
out the logic of using stop_request vs quit_request: places
that just "quit" (as in flush but then continue emulating) still
set the uc->quit_request flag, but now call uc_emu_soft_stop()
instead of uc_emu_stop(). The logic in softmmu/cpus.c now only
checks if uc->stop_request is set to determine if it should
break out of the loop.

The target architectures have been updated to call the new
uc_emu_soft_stop instead of uc_emu_stop for their "quits".

TL;DR stop_request and quit_request are now one-or-the-other
instead of one-and-maybe-the-other.

This is to address #1579 

NOTE: This is my first time looking at the inner workings of
Unicorn, and a grown-up should review this carefully because
I probably did this wrong ;). I wanted to attempt a fix instead 
of simply filing a bug with a repro. I will not be offended if my
fix is partially or completely rejected! 
