### PR TITLE
Fix https://github.com/unicorn-engine/unicorn/issues/1586

### DIFF
--- a/uc.c
+++ b/uc.c
@@ -388,7 +388,7 @@ uc_err uc_open(uc_arch arch, uc_mode mode, uc_engine **result)
         }
 
         if (uc->init_arch == NULL) {
-            *result = uc;
+            free(uc);
             return UC_ERR_ARCH;
         }
 

--- a/uc.c
+++ b/uc.c
@@ -388,6 +388,7 @@ uc_err uc_open(uc_arch arch, uc_mode mode, uc_engine **result)
         }
 
         if (uc->init_arch == NULL) {
+            *result = uc;
             return UC_ERR_ARCH;
         }
 


### PR DESCRIPTION
If `uc->init_arch == NULL`, uc need to be retruned because it already points to heap space. Of course, we can also directly free the corresponding memory space.

```c
if (uc->init_arch == NULL) {
    free(uc);
    return UC_ERR_ARCH;
}
```
