### PR TITLE
Fix https://github.com/unicorn-engine/unicorn/issues/1590

### DIFF
--- a/uc.c
+++ b/uc.c
@@ -975,6 +975,10 @@ static uc_err mem_map_check(uc_engine *uc, uint64_t address, size_t size,
     }
 
     // address cannot wrapp around
+    if (address + size < address || address + size < size) {
+        return UC_ERR_ARG;
+    }
+    
     if (address + size - 1 < address) {
         return UC_ERR_ARG;
     }


### PR DESCRIPTION
We only need to add simple judgment to prevent integer overflow.

If we apply `0xfffffffffffff000 ~ 0xfffffffffffff000 + 0x1000` like #1590, we will not be able to bypass the memory check!
```shell
Failed on uc_mem_map() with error returned: 15 Invalid argument (UC_ERR_ARG)
```
