### PR TITLE
Fix Python bindings build

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -137,7 +137,7 @@ def build_libraries():
         subprocess.check_call(cmake_args)
         os.chdir(BUILD_DIR)
         threads = os.getenv("THREADS", "4")
-        subprocess.check_call(["cmake", "--build", ".", "-j" + threads])
+        subprocess.check_call(["cmake", "--build", ".", "--", "-j" + threads])
     
         shutil.copy(LIBRARY_FILE, LIBS_DIR)
         try:


### PR DESCRIPTION
While trying to compile the bindings for Python, I ran into this error
```
luke@DESKTOP-AR7LCLA:~/unicorn-pub/bindings/python$ sudo python3 ./setup.py install
[truncated]
Unknown argument -j4
Usage: cmake --build <dir> [options] [-- [native-options]]
Options:
  <dir>          = Project binary directory to be built.
  -j [<jobs>] --parallel [<jobs>] = Build in parallel using
                   the given number of jobs. If <jobs> is omitted
                   the native build tool's default number is used.
                   The CMAKE_BUILD_PARALLEL_LEVEL environment variable
                   specifies a default parallel level when this option
                   is not given.
  --target <tgt> = Build <tgt> instead of default targets.
                   May only be specified once.
  --config <cfg> = For multi-configuration tools, choose <cfg>.
  --clean-first  = Build target 'clean' first, then build.
                   (To clean only, use --target 'clean'.)
  --use-stderr   = Ignored.  Behavior is default in CMake >= 3.0.
  --             = Pass remaining options to the native tool.
[truncated]
  File "./setup.py", line 141, in build_libraries
    subprocess.check_call(["cmake", "--build", ".", "-j" + threads])
  File "/usr/lib/python3.7/subprocess.py", line 347, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['cmake', '--build', '.', '-j4']' returned non-zero exit status 1.
```

The pull request is fairly trivial. It adds, what I am assuming is, the missing argument intended to pass the `-j4` argument to the compiler used by CMake. 
