### PR TITLE
Issues and tests for jump hook address

### DIFF
--- a/qemu/accel/tcg/translate-all.c
+++ b/qemu/accel/tcg/translate-all.c
@@ -1090,6 +1090,7 @@ void tcg_exec_init(struct uc_struct *uc, unsigned long tb_size)
     code_gen_alloc(uc, tb_size);
     tb_exec_unlock(uc->tcg_ctx);
     tcg_prologue_init(uc->tcg_ctx);
+    tb_exec_lock(uc->tcg_ctx);
     /* cpu_interrupt_handler is not used in uc1 */
     uc->l1_map = g_malloc0(sizeof(void *) * V_L1_MAX_SIZE);
     /* Invalidate / Cache TBs */

--- a/qemu/exec.c
+++ b/qemu/exec.c
@@ -1087,8 +1087,8 @@ RAMBlock *qemu_ram_alloc_from_ptr(struct uc_struct *uc, ram_addr_t size, void *h
     RAMBlock *new_block;
     ram_addr_t max_size = size;
 
-    size = HOST_PAGE_ALIGN(uc, size);
-    max_size = HOST_PAGE_ALIGN(uc, max_size);
+    // size = HOST_PAGE_ALIGN(uc, size);
+    // max_size = HOST_PAGE_ALIGN(uc, max_size);
     new_block = g_malloc0(sizeof(*new_block));
     if (new_block == NULL)
         return NULL;

--- a/qemu/softmmu/cpus.c
+++ b/qemu/softmmu/cpus.c
@@ -220,6 +220,9 @@ void resume_all_vcpus(struct uc_struct* uc)
         uc_exit_invalidate_iter((gpointer)&uc->exits[uc->nested_level - 1], NULL, (gpointer)uc);
     }
 
+    // Why?
+    tb_exec_lock(uc->tcg_ctx);
+
     cpu->created = false;
 }
 

--- a/tests/unit/test_arm64.c
+++ b/tests/unit/test_arm64.c
@@ -195,10 +195,98 @@ static void test_arm64_mrs_hook(void)
     OK(uc_close(uc));
 }
 
+
+static void test_arm64_correct_address_in_small_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
+{
+  // Check registers
+  uint64_t r_x0 = 0x0;
+  uint64_t r_pc = 0x0;
+  OK(uc_reg_read(uc, UC_ARM64_REG_X0, &r_x0));
+  OK(uc_reg_read(uc, UC_ARM64_REG_PC, &r_pc));
+  TEST_CHECK(r_x0 == 0x7F00);
+  TEST_CHECK(r_pc == 0x7F00);
+
+  // Check address
+  // printf("%lx\n", address);
+  TEST_CHECK(address == 0x7F00);
+}
+
+static void test_arm64_correct_address_in_small_jump_hook(void)
+{
+    uc_engine *uc;
+    // mov x0, 0x7F00;
+    // br x0
+    char code[] = "\x00\xe0\x8f\xd2\x00\x00\x1f\xd6";
+
+    uint64_t r_x0 = 0x0;
+    uint64_t r_pc = 0x0;
+    uc_hook hook;
+
+    uc_common_setup(&uc, UC_ARCH_ARM64, UC_MODE_ARM, code, sizeof(code) - 1, UC_CPU_ARM64_A72);
+    OK(uc_hook_add(uc, &hook, UC_HOOK_MEM_UNMAPPED, test_arm64_correct_address_in_small_jump_hook_callback, NULL, 1, 0));
+
+    uc_assert_err(
+        UC_ERR_FETCH_UNMAPPED,
+        uc_emu_start(uc, code_start, code_start + sizeof(code) - 1, 0, 0));
+
+    OK(uc_reg_read(uc, UC_ARM64_REG_X0, &r_x0));
+    OK(uc_reg_read(uc, UC_ARM64_REG_PC, &r_pc));
+    TEST_CHECK(r_x0 == 0x7F00);
+    TEST_CHECK(r_pc == 0x7F00);
+
+    OK(uc_close(uc));
+}
+
+static void test_arm64_correct_address_in_long_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
+{
+  // Check registers
+  uint64_t r_x0 = 0x0;
+  uint64_t r_pc = 0x0;
+  OK(uc_reg_read(uc, UC_ARM64_REG_X0, &r_x0));
+  OK(uc_reg_read(uc, UC_ARM64_REG_PC, &r_pc));
+  TEST_CHECK(r_x0 == 0x7FFFFFFFFFFFFF00);
+  TEST_CHECK(r_pc == 0x7FFFFFFFFFFFFF00);
+
+  // Check address
+  // printf("%lx\n", address);
+  TEST_CHECK(address == 0x7FFFFFFFFFFFFF00);
+}
+
+static void test_arm64_correct_address_in_long_jump_hook(void)
+{
+    uc_engine *uc;
+    // mov x0, 0x7FFFFFFFFFFFFF00;
+    // br x0
+    char code[] = "\xe0\xdb\x78\xb2\x00\x00\x1f\xd6";
+
+    uint64_t r_x0 = 0x0;
+    uint64_t r_pc = 0x0;
+    uc_hook hook;
+
+    uc_common_setup(&uc, UC_ARCH_ARM64, UC_MODE_ARM, code, sizeof(code) - 1, UC_CPU_ARM64_A72);
+    OK(uc_hook_add(uc, &hook, UC_HOOK_MEM_UNMAPPED, test_arm64_correct_address_in_long_jump_hook_callback, NULL, 1, 0));
+
+    uc_assert_err(
+        UC_ERR_FETCH_UNMAPPED,
+        uc_emu_start(uc, code_start, code_start + sizeof(code) - 1, 0, 0));
+
+    OK(uc_reg_read(uc, UC_ARM64_REG_X0, &r_x0));
+    OK(uc_reg_read(uc, UC_ARM64_REG_PC, &r_pc));
+    TEST_CHECK(r_x0 == 0x7FFFFFFFFFFFFF00);
+    TEST_CHECK(r_pc == 0x7FFFFFFFFFFFFF00);
+
+    OK(uc_close(uc));
+}
+
+
+
+
 TEST_LIST = {{"test_arm64_until", test_arm64_until},
              {"test_arm64_code_patching", test_arm64_code_patching},
              {"test_arm64_code_patching_count", test_arm64_code_patching_count},
              {"test_arm64_v8_pac", test_arm64_v8_pac},
              {"test_arm64_read_sctlr", test_arm64_read_sctlr},
              {"test_arm64_mrs_hook", test_arm64_mrs_hook},
+             {"test_arm64_correct_address_in_small_jump_hook", test_arm64_correct_address_in_small_jump_hook},
+             {"test_arm64_correct_address_in_long_jump_hook", test_arm64_correct_address_in_long_jump_hook},
              {NULL, NULL}};

--- a/tests/unit/test_arm64.c
+++ b/tests/unit/test_arm64.c
@@ -196,7 +196,7 @@ static void test_arm64_mrs_hook(void)
 }
 
 
-static void test_arm64_correct_address_in_small_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
+static bool test_arm64_correct_address_in_small_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
 {
   // Check registers
   uint64_t r_x0 = 0x0;
@@ -209,6 +209,8 @@ static void test_arm64_correct_address_in_small_jump_hook_callback(uc_engine *uc
   // Check address
   // printf("%lx\n", address);
   TEST_CHECK(address == 0x7F00);
+
+  return false;
 }
 
 static void test_arm64_correct_address_in_small_jump_hook(void)
@@ -237,7 +239,7 @@ static void test_arm64_correct_address_in_small_jump_hook(void)
     OK(uc_close(uc));
 }
 
-static void test_arm64_correct_address_in_long_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
+static bool test_arm64_correct_address_in_long_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
 {
   // Check registers
   uint64_t r_x0 = 0x0;
@@ -250,6 +252,8 @@ static void test_arm64_correct_address_in_long_jump_hook_callback(uc_engine *uc,
   // Check address
   // printf("%lx\n", address);
   TEST_CHECK(address == 0x7FFFFFFFFFFFFF00);
+
+  return false;
 }
 
 static void test_arm64_correct_address_in_long_jump_hook(void)

--- a/tests/unit/test_riscv.c
+++ b/tests/unit/test_riscv.c
@@ -537,6 +537,91 @@ static void test_riscv64_mmio_map(void)
     OK(uc_close(uc));
 }
 
+
+static void test_riscv_correct_address_in_small_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
+{
+  // Check registers
+  uint64_t r_x5 = 0x0;
+  uint64_t r_pc = 0x0;
+  OK(uc_reg_read(uc, UC_RISCV_REG_X5, &r_x5));
+  OK(uc_reg_read(uc, UC_RISCV_REG_PC, &r_pc));
+  TEST_CHECK(r_x5 == 0x7F00);
+  TEST_CHECK(r_pc == 0x7F00);
+
+  // Check address
+  // printf("%lx\n", address);
+  TEST_CHECK(address == 0x7F00);
+}
+
+static void test_riscv_correct_address_in_small_jump_hook(void)
+{
+    uc_engine *uc;
+    // li 0x7F00, x5  >  lui t0, 8; addiw t0, t0, -256;
+    // jr x5
+    char code[] = "\xb7\x82\x00\x00\x9b\x82\x02\xf0\x67\x80\x02\x00";
+
+    uint64_t r_x5 = 0x0;
+    uint64_t r_pc = 0x0;
+    uc_hook hook;
+
+    uc_common_setup(&uc, UC_ARCH_RISCV, UC_MODE_RISCV64, code, sizeof(code) - 1);
+    OK(uc_hook_add(uc, &hook, UC_HOOK_MEM_UNMAPPED, test_riscv_correct_address_in_small_jump_hook_callback, NULL, 1, 0));
+
+    uc_assert_err(
+        UC_ERR_FETCH_UNMAPPED,
+        uc_emu_start(uc, code_start, code_start + sizeof(code) - 1, 0, 0));
+
+    OK(uc_reg_read(uc, UC_RISCV_REG_X5, &r_x5));
+    OK(uc_reg_read(uc, UC_RISCV_REG_PC, &r_pc));
+    TEST_CHECK(r_x5 == 0x7F00);
+    TEST_CHECK(r_pc == 0x7F00);
+
+    OK(uc_close(uc));
+}
+
+static void test_riscv_correct_address_in_long_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
+{
+  // Check registers
+  uint64_t r_x5 = 0x0;
+  uint64_t r_pc = 0x0;
+  OK(uc_reg_read(uc, UC_RISCV_REG_X5, &r_x5));
+  OK(uc_reg_read(uc, UC_RISCV_REG_PC, &r_pc));
+  TEST_CHECK(r_x5 == 0x7FFFFFFFFFFFFF00);
+  TEST_CHECK(r_pc == 0x7FFFFFFFFFFFFF00);
+
+  // Check address
+  // printf("%lx\n", address);
+  TEST_CHECK(address == 0x7FFFFFFFFFFFFF00);
+}
+
+static void test_riscv_correct_address_in_long_jump_hook(void)
+{
+    uc_engine *uc;
+    // li 0x7FFFFFFFFFFFFF00, x5  >  addi t0, zero, -1; slli t0, t0, 63; addi t0, t0, -256;
+    // jr x5
+    char code[] = "\x93\x02\xf0\xff\x93\x92\xf2\x03\x93\x82\x02\xf0\x67\x80\x02\x00";
+
+    uint64_t r_x5 = 0x0;
+    uint64_t r_pc = 0x0;
+    uc_hook hook;
+
+    uc_common_setup(&uc, UC_ARCH_RISCV, UC_MODE_RISCV64, code, sizeof(code) - 1);
+    OK(uc_hook_add(uc, &hook, UC_HOOK_MEM_UNMAPPED, test_riscv_correct_address_in_long_jump_hook_callback, NULL, 1, 0));
+
+    uc_assert_err(
+        UC_ERR_FETCH_UNMAPPED,
+        uc_emu_start(uc, code_start, code_start + sizeof(code) - 1, 0, 0));
+
+    OK(uc_reg_read(uc, UC_RISCV_REG_X5, &r_x5));
+    OK(uc_reg_read(uc, UC_RISCV_REG_PC, &r_pc));
+    TEST_CHECK(r_x5 == 0x7FFFFFFFFFFFFF00);
+    TEST_CHECK(r_pc == 0x7FFFFFFFFFFFFF00);
+
+    OK(uc_close(uc));
+}
+
+
+
 TEST_LIST = {
     {"test_riscv32_nop", test_riscv32_nop},
     {"test_riscv64_nop", test_riscv64_nop},
@@ -556,4 +641,6 @@ TEST_LIST = {
     {"test_riscv32_map", test_riscv32_map},
     {"test_riscv64_code_patching", test_riscv64_code_patching},
     {"test_riscv64_code_patching_count", test_riscv64_code_patching_count},
+    {"test_riscv_correct_address_in_small_jump_hook", test_riscv_correct_address_in_small_jump_hook},
+    {"test_riscv_correct_address_in_long_jump_hook", test_riscv_correct_address_in_long_jump_hook},
     {NULL, NULL}};

--- a/tests/unit/test_riscv.c
+++ b/tests/unit/test_riscv.c
@@ -538,7 +538,7 @@ static void test_riscv64_mmio_map(void)
 }
 
 
-static void test_riscv_correct_address_in_small_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
+static bool test_riscv_correct_address_in_small_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
 {
   // Check registers
   uint64_t r_x5 = 0x0;
@@ -551,6 +551,7 @@ static void test_riscv_correct_address_in_small_jump_hook_callback(uc_engine *uc
   // Check address
   // printf("%lx\n", address);
   TEST_CHECK(address == 0x7F00);
+  return false;
 }
 
 static void test_riscv_correct_address_in_small_jump_hook(void)
@@ -579,7 +580,7 @@ static void test_riscv_correct_address_in_small_jump_hook(void)
     OK(uc_close(uc));
 }
 
-static void test_riscv_correct_address_in_long_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
+static bool test_riscv_correct_address_in_long_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
 {
   // Check registers
   uint64_t r_x5 = 0x0;
@@ -592,6 +593,7 @@ static void test_riscv_correct_address_in_long_jump_hook_callback(uc_engine *uc,
   // Check address
   // printf("%lx\n", address);
   TEST_CHECK(address == 0x7FFFFFFFFFFFFF00);
+  return false;
 }
 
 static void test_riscv_correct_address_in_long_jump_hook(void)

--- a/tests/unit/test_x86.c
+++ b/tests/unit/test_x86.c
@@ -981,7 +981,7 @@ static void test_x86_nested_uc_emu_start_exits(void)
     OK(uc_close(uc));
 }
 
-static void test_x86_correct_address_in_small_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
+static bool test_x86_correct_address_in_small_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
 {
   // Check registers
   uint64_t r_rax = 0x0;
@@ -992,8 +992,9 @@ static void test_x86_correct_address_in_small_jump_hook_callback(uc_engine *uc, 
   TEST_CHECK(r_rip == 0x7F00);
 
   // Check address
-  // printf("%lx\n", address);
   TEST_CHECK(address == 0x7F00);
+
+  return false;
 }
 
 static void test_x86_correct_address_in_small_jump_hook(void)
@@ -1023,7 +1024,24 @@ static void test_x86_correct_address_in_small_jump_hook(void)
     OK(uc_close(uc));
 }
 
-static void test_x86_correct_address_in_long_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
+static void test_x86_cpuid_1()
+{
+    uc_engine *uc;
+    char code[] = "\xB8\x01\x00\x00\x00\x0F\xA2"; // MOV EAX,1; CPUID
+    int reg;
+
+    uc_common_setup(&uc, UC_ARCH_X86, UC_MODE_32, code, sizeof(code) - 1);
+
+    OK(uc_emu_start(uc, code_start, code_start + sizeof(code) - 1, 0, 0));
+
+    OK(uc_reg_read(uc, UC_X86_REG_EDX, &reg));
+
+    TEST_CHECK(reg == 0x7088100);
+
+    OK(uc_close(uc));
+}
+
+static bool test_x86_correct_address_in_long_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
 {
   // Check registers
   uint64_t r_rax = 0x0;
@@ -1034,8 +1052,9 @@ static void test_x86_correct_address_in_long_jump_hook_callback(uc_engine *uc, i
   TEST_CHECK(r_rip == 0x7FFFFFFFFFFFFF00);
 
   // Check address
-  // printf("%lx\n", address);
   TEST_CHECK(address == 0x7FFFFFFFFFFFFF00);
+
+  return false;
 }
 
 static void test_x86_correct_address_in_long_jump_hook(void)
@@ -1100,4 +1119,5 @@ TEST_LIST = {
     {"test_x86_nested_uc_emu_start_exits", test_x86_nested_uc_emu_start_exits},
     {"test_x86_correct_address_in_small_jump_hook", test_x86_correct_address_in_small_jump_hook},
     {"test_x86_correct_address_in_long_jump_hook", test_x86_correct_address_in_long_jump_hook},
+    {"test_x86_cpuid_1", test_x86_cpuid_1},
     {NULL, NULL}};

--- a/tests/unit/test_x86.c
+++ b/tests/unit/test_x86.c
@@ -981,6 +981,91 @@ static void test_x86_nested_uc_emu_start_exits(void)
     OK(uc_close(uc));
 }
 
+static void test_x86_correct_address_in_small_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
+{
+  // Check registers
+  uint64_t r_rax = 0x0;
+  uint64_t r_rip = 0x0;
+  OK(uc_reg_read(uc, UC_X86_REG_RAX, &r_rax));
+  OK(uc_reg_read(uc, UC_X86_REG_RIP, &r_rip));
+  TEST_CHECK(r_rax == 0x7F00);
+  TEST_CHECK(r_rip == 0x7F00);
+
+  // Check address
+  // printf("%lx\n", address);
+  TEST_CHECK(address == 0x7F00);
+}
+
+static void test_x86_correct_address_in_small_jump_hook(void)
+{
+    uc_engine *uc;
+    // movabs $0x7FFFFFFFFEFBEC9C, %rax
+    // jmp  *%rax
+    char code[] = "\x48\xb8\x00\x7F\x00\x00\x00\x00\x00\x00\xff\xe0";
+
+    uint64_t r_rax = 0x0;
+    uint64_t r_rip = 0x0;
+    uc_hook hook;
+
+    uc_common_setup(&uc, UC_ARCH_X86, UC_MODE_64, code, sizeof(code) - 1);
+    OK(uc_hook_add(uc, &hook, UC_HOOK_MEM_UNMAPPED, test_x86_correct_address_in_small_jump_hook_callback, NULL, 1, 0));
+
+
+    uc_assert_err(
+        UC_ERR_FETCH_UNMAPPED,
+        uc_emu_start(uc, code_start, code_start + sizeof(code) - 1, 0, 0));
+
+    OK(uc_reg_read(uc, UC_X86_REG_RAX, &r_rax));
+    OK(uc_reg_read(uc, UC_X86_REG_RIP, &r_rip));
+    TEST_CHECK(r_rax == 0x7F00);
+    TEST_CHECK(r_rip == 0x7F00);
+
+    OK(uc_close(uc));
+}
+
+static void test_x86_correct_address_in_long_jump_hook_callback(uc_engine *uc, int type, uint64_t address, int size, int64_t value, void *user_data)
+{
+  // Check registers
+  uint64_t r_rax = 0x0;
+  uint64_t r_rip = 0x0;
+  OK(uc_reg_read(uc, UC_X86_REG_RAX, &r_rax));
+  OK(uc_reg_read(uc, UC_X86_REG_RIP, &r_rip));
+  TEST_CHECK(r_rax == 0x7FFFFFFFFFFFFF00);
+  TEST_CHECK(r_rip == 0x7FFFFFFFFFFFFF00);
+
+  // Check address
+  // printf("%lx\n", address);
+  TEST_CHECK(address == 0x7FFFFFFFFFFFFF00);
+}
+
+static void test_x86_correct_address_in_long_jump_hook(void)
+{
+    uc_engine *uc;
+    // movabs $0x7FFFFFFFFEFBEC9C, %rax
+    // jmp  *%rax
+    char code[] = "\x48\xb8\x00\xff\xff\xff\xff\xff\xff\x7f\xff\xe0";
+
+    uint64_t r_rax = 0x0;
+    uint64_t r_rip = 0x0;
+    uc_hook hook;
+
+    uc_common_setup(&uc, UC_ARCH_X86, UC_MODE_64, code, sizeof(code) - 1);
+    OK(uc_hook_add(uc, &hook, UC_HOOK_MEM_UNMAPPED, test_x86_correct_address_in_long_jump_hook_callback, NULL, 1, 0));
+
+
+    uc_assert_err(
+        UC_ERR_FETCH_UNMAPPED,
+        uc_emu_start(uc, code_start, code_start + sizeof(code) - 1, 0, 0));
+
+    OK(uc_reg_read(uc, UC_X86_REG_RAX, &r_rax));
+    OK(uc_reg_read(uc, UC_X86_REG_RIP, &r_rip));
+    TEST_CHECK(r_rax == 0x7FFFFFFFFFFFFF00);
+    TEST_CHECK(r_rip == 0x7FFFFFFFFFFFFF00);
+
+    OK(uc_close(uc));
+}
+
+
 TEST_LIST = {
     {"test_x86_in", test_x86_in},
     {"test_x86_out", test_x86_out},
@@ -1013,4 +1098,6 @@ TEST_LIST = {
     {"test_x86_64_nested_emu_start_error", test_x86_64_nested_emu_start_error},
     {"test_x86_eflags_reserved_bit", test_x86_eflags_reserved_bit},
     {"test_x86_nested_uc_emu_start_exits", test_x86_nested_uc_emu_start_exits},
+    {"test_x86_correct_address_in_small_jump_hook", test_x86_correct_address_in_small_jump_hook},
+    {"test_x86_correct_address_in_long_jump_hook", test_x86_correct_address_in_long_jump_hook},
     {NULL, NULL}};

--- a/tests/unit/test_x86.c
+++ b/tests/unit/test_x86.c
@@ -999,7 +999,7 @@ static void test_x86_correct_address_in_small_jump_hook_callback(uc_engine *uc, 
 static void test_x86_correct_address_in_small_jump_hook(void)
 {
     uc_engine *uc;
-    // movabs $0x7FFFFFFFFEFBEC9C, %rax
+    // movabs $0x7F00, %rax
     // jmp  *%rax
     char code[] = "\x48\xb8\x00\x7F\x00\x00\x00\x00\x00\x00\xff\xe0";
 
@@ -1041,7 +1041,7 @@ static void test_x86_correct_address_in_long_jump_hook_callback(uc_engine *uc, i
 static void test_x86_correct_address_in_long_jump_hook(void)
 {
     uc_engine *uc;
-    // movabs $0x7FFFFFFFFEFBEC9C, %rax
+    // movabs $0x7FFFFFFFFFFFFF00, %rax
     // jmp  *%rax
     char code[] = "\x48\xb8\x00\xff\xff\xff\xff\xff\xff\x7f\xff\xe0";
 


### PR DESCRIPTION
Hello, in x86 hooks for unmapped memory get an address with a 1-bit offset. 
The two tests added show that:
- The `movabs` instruction gets executed correctly as the value is set in `rax`
- The `jmp` instruction gets executed correctly as the value is set in `rip`
- The address obtained in the hook is incorrect (uncommenting the `printf` shows the address with a 1-bit offset)
- The same behavior is correct in ARM64 and RISC-V

Edit from merge with @PalumboN:

Fix patch https://github.com/unicorn-engine/unicorn/issues/1615 and https://github.com/unicorn-engine/unicorn/pull/1608
- Adding tb_exec_locks needed for Mac M1
- Ignore second hooks calls after memory mapping error (bug)
- Comment page align macro because is not working properly

Maybe we need to iterate this solutions, but now I have all tests green and it's working with PharoVM