### PR TITLE
check pkg-config for unicorn libraries

### DIFF
--- a/bindings/ruby/unicorn_gem/ext/extconf.rb
+++ b/bindings/ruby/unicorn_gem/ext/extconf.rb
@@ -3,6 +3,7 @@ require 'mkmf'
 extension_name = 'unicorn_engine'
 
 dir_config(extension_name)
+pkg_config('unicorn')
 have_library('unicorn')
 
 create_makefile(extension_name)


### PR DESCRIPTION
allow for non-standard install locations of unicorn engine

this is required for when i am trying to package unicorn for other package managers.