### PR TITLE
Handle pathological cases more consistently

### DIFF
--- a/qemu/accel/tcg/cpu-exec.c
+++ b/qemu/accel/tcg/cpu-exec.c
@@ -595,6 +595,9 @@ int cpu_exec(struct uc_struct *uc, CPUState *cpu)
             }
 
             tb = tb_find(cpu, last_tb, tb_exit, cflags);
+            if (unlikely(cpu->exit_request)) {
+                continue;
+            }
             cpu_loop_exec_tb(cpu, tb, &last_tb, &tb_exit);
             /* Try to align the host and virtual clocks
                if the guest is in advance */

--- a/qemu/accel/tcg/cputlb.c
+++ b/qemu/accel/tcg/cputlb.c
@@ -1635,11 +1635,15 @@ load_helper(CPUArchState *env, target_ulong addr, TCGMemOpIdx oi,
         target_ulong addr1, addr2;
         uint64_t r1, r2;
         unsigned shift;
+        int old_size;
     do_unaligned_access:
         addr1 = addr & ~((target_ulong)size - 1);
         addr2 = addr1 + size;
+        old_size = uc->size_recur_mem;
+        uc->size_recur_mem = size;
         r1 = full_load(env, addr1, oi, retaddr);
         r2 = full_load(env, addr2, oi, retaddr);
+        uc->size_recur_mem = old_size;
         shift = (addr & (size - 1)) * 8;
 
         if (memop_big_endian(op)) {

--- a/qemu/accel/tcg/translate-all.c
+++ b/qemu/accel/tcg/translate-all.c
@@ -1584,9 +1584,8 @@ TranslationBlock *tb_gen_code(CPUState *cpu,
     phys_pc = get_page_addr_code(env, pc);
 
     if (phys_pc == -1) {
-        /* Generate a temporary TB with 1 insn in it */
-        cflags &= ~CF_COUNT_MASK;
-        cflags |= CF_NOCACHE | 1;
+        /* Generate a temporary TB; do not cache */
+        cflags |= CF_NOCACHE;
     }
 
     cflags &= ~CF_CLUSTER_MASK;


### PR DESCRIPTION
These are two changes I've needed to make to make angr work with unicorn 2.

First commit: presently, if we try to execute a non-executable region, the lifting code never checks to see if reads succeed, it just blindly trusts the result. As a consequence, we may execute some non-executable guest code or hooks before checking cpu->exit_request and breaking out of the loop. This fixes that.

Second commit: If you respond to an unmapped memory fault during instruction fetch by mapping the related memory in a callback, qemu will only attempt to lift a single instruction for the current block. This is incredibly annoying (and breaks angr's tests, which are sensitive to block counts and boundaries), so I fixed it.