### PR TITLE
Fail when VEX.L is set in SSE instructions (AVX is not supported)

### DIFF
--- a/qemu/target/i386/translate.c
+++ b/qemu/target/i386/translate.c
@@ -3378,6 +3378,10 @@ static void gen_sse(CPUX86State *env, DisasContext *s, int b,
     if (is_xmm)
         reg |= rex_r;
     mod = (modrm >> 6) & 3;
+    /* VEX.L (256 bit) encodings are not supported */
+    if (s->vex_l != 0) {
+        goto illegal_op; // perhaps it should be unknown_op?
+    }
     if (sse_fn_epp == SSE_SPECIAL) {
         b |= (b1 << 8);
         switch(b) {

--- a/tests/regress/x86_vex.c
+++ b/tests/regress/x86_vex.c
@@ -47,12 +47,37 @@ static void test_vmovdqu(void)
     OK(uc_close(uc));
 }
 
+/* https://github.com/unicorn-engine/unicorn/issues/1656 */
+static void test_vex_l(void)
+{
+    uc_engine *uc;
+    uc_err err;
+
+    /* vmovdqu ymm1, [rcx] */
+    char code[] = { '\xC5', '\xFE', '\x6F', '\x09' };
+
+    /* initialize memory and run emulation  */
+    OK(uc_open(UC_ARCH_X86, UC_MODE_64, &uc));
+    OK(uc_mem_map(uc, 0, 2 * 1024 * 1024, UC_PROT_ALL));
+
+    OK(uc_mem_write(uc, 0, code, sizeof(code) / sizeof(code[0])));
+
+    err = uc_emu_start(uc, 0, sizeof(code) / sizeof(code[0]), 0, 0);
+    if(err != UC_ERR_INSN_INVALID) {
+        fprintf(stderr, "%s", uc_strerror(err));
+        assert(false);
+    }
+
+    OK(uc_close(uc));
+}
+
 
 /* TODO: Add more vex prefixed instructions
          Suggestions: vxorpd, vxorps, vandpd, ... */
 int main(int argc, char **argv, char **envp)
 {
         test_vmovdqu();
+        test_vex_l();
         return 0;
 }
 


### PR DESCRIPTION
Closes #1656

According to https://gitlab.com/qemu-project/qemu/-/issues/132 YMM isn't supported in qemu upstream at all. I still have to test on a real CPU what exception is thrown, but other checks on `vex_l` seem to indicate it is `illegal_op`. An alternative would be to add the check to `vex_l` to every opcode, but since YMM isn't supported at all I think this is reasonable.