### PR TITLE
Fixed endianness when writing PPC32 CR register.

### DIFF
--- a/qemu/target/ppc/unicorn.c
+++ b/qemu/target/ppc/unicorn.c
@@ -292,7 +292,7 @@ static void reg_write(CPUPPCState *env, unsigned int regid, const void *value)
             break;
         case UC_PPC_REG_CR:
             val = *(uint32_t *)value;
-            for (i = 0; i < 8; i++) {
+            for (i = 7; i >= 0; i--) {
                 env->crf[i] = val & 0b1111;
                 val >>= 4;
             }

--- a/tests/unit/test_ppc.c
+++ b/tests/unit/test_ppc.c
@@ -89,7 +89,24 @@ static void test_ppc32_sc(void)
     OK(uc_close(uc));
 }
 
+static void test_ppc32_cr(void)
+{
+    uc_engine *uc;
+    uint32_t r_cr = 0x12345678;
+
+    uc_common_setup(&uc, UC_ARCH_PPC, UC_MODE_32 | UC_MODE_BIG_ENDIAN, NULL, 0);
+
+    OK(uc_reg_write(uc, UC_PPC_REG_CR, &r_cr));
+    r_cr = 0;
+    OK(uc_reg_read(uc, UC_PPC_REG_CR, &r_cr));
+
+    TEST_CHECK(r_cr == 0x12345678);
+
+    OK(uc_close(uc));
+}
+
 TEST_LIST = {{"test_ppc32_add", test_ppc32_add},
              {"test_ppc32_fadd", test_ppc32_fadd},
              {"test_ppc32_sc", test_ppc32_sc},
+             {"test_ppc32_cr", test_ppc32_cr},
              {NULL, NULL}};


### PR DESCRIPTION
When writing a value to the CR (conditional register) the order of the nibbles was reversed. I believe the nibble ordering in the `reg_read` is correct, so I correct `reg_write` to maintain the same endianness. Also included a unit test to make sure that the value we write is the value we read out.