### PR TITLE
Fixes #1661 - Hook block infinite loop when changing PC

### DIFF
--- a/qemu/accel/tcg/cpu-exec.c
+++ b/qemu/accel/tcg/cpu-exec.c
@@ -72,7 +72,7 @@ static inline tcg_target_ulong cpu_tb_exec(CPUState *cpu, TranslationBlock *itb)
          * of the start of the TB.
          */
         CPUClass *cc = CPU_GET_CLASS(cpu);
-        if (!HOOK_EXISTS(env->uc, UC_HOOK_CODE)) {
+        if (!HOOK_EXISTS(env->uc, UC_HOOK_CODE) && !env->uc->timeout) {
             // We should sync pc for R/W error.
             switch (env->uc->invalid_error) {
                 case UC_ERR_WRITE_PROT:
@@ -87,6 +87,9 @@ static inline tcg_target_ulong cpu_tb_exec(CPUState *cpu, TranslationBlock *itb)
                     break;
                 default:
                     if (cc->synchronize_from_tb) {
+                        // avoid sync twice when helper_uc_tracecode() already did this.
+                        if (env->uc->emu_counter <= env->uc->emu_count &&
+                                !env->uc->stop_request && !env->uc->quit_request)
                         cc->synchronize_from_tb(cpu, last_tb);
                     } else {
                         assert(cc->set_pc);

--- a/tests/regress/hook_block_infinite_loop.py
+++ b/tests/regress/hook_block_infinite_loop.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python
+
+'''https://github.com/unicorn-engine/unicorn/issues/1661'''
+
+from __future__ import print_function
+import regress
+
+from unicorn import *
+from unicorn.arm64_const import *
+
+# MOV x0, #1234
+# MOV x1, #2345
+# MOV x2, #4331
+# LDR x9, =0x2000
+# BLR x9
+# MOV x8, x2
+code_1 = '409A80D2212581D2621D82D2090084D220013FD6E80302AA'
+addr_1 = 0x1000
+
+# MOV x2, #9999
+# RET
+code_2 = 'E2E184D2C0035FD6'
+addr_2 = 0x2000
+
+
+def hook_code(uc_, address, size, user_data):
+    print('Called hook_code')
+    pass
+
+
+def hook_block(uc_, address, size, user_data):
+    print('Called hook_block')
+    uc_.reg_write(UC_ARM64_REG_X2, 1337)
+    uc_.reg_write(UC_ARM64_REG_PC, uc_.reg_read(UC_ARM64_REG_LR))
+
+
+class HookBlockInfiniteLoop(regress.RegressTest):
+    def runTest(self):
+        uc = Uc(UC_ARCH_ARM64, UC_MODE_ARM)
+        uc.mem_map(addr_1, 0x1000)
+        uc.mem_map(addr_2, 0x2000)
+        uc.mem_write(addr_1, bytes.fromhex(code_1))
+        uc.mem_write(addr_2, bytes.fromhex(code_2))
+        # Uncommenting line below would also fix it on Unicorn 2.0.0
+        # uc.hook_del(uc.hook_add(UC_HOOK_CODE, hook_code))
+        uc.hook_add(UC_HOOK_BLOCK, hook_block, user_data=None, begin=addr_2, end=addr_2 + 4)
+        uc.emu_start(addr_1, until=addr_1 + len(code_1) // 2)
+
+        print('x2 = 1337 (EXPECTED)')
+        print('x2 = %d (ACTUAL)' % uc.reg_read(UC_ARM64_REG_X2))
+
+        self.assertEqual(1337, uc.reg_read(UC_ARM64_REG_X2), "Unexpected X2")
+
+
+if __name__ == '__main__':
+    regress.main()


### PR DESCRIPTION
Issue is described in #1661.

> I have the exact same issue. My arm64 code is jumping to a block that is hooked with HOOK_BLOCK, I then handle it in my own code and set the X0 and PC so the arm64 code resumes. This used to work fine with Unicorn 1. Now, when I run the same code it fails to work properly and keeps calling the block, creating an infinite loop.
> 
> Then, I added a HOOK_CODE block in an attempt to debug it. To my confusion it started working after I added the debug hook.

Reverting commit https://github.com/unicorn-engine/unicorn/commit/b7bc13650c56ebaad47264c7c7cf5a5a72e25fd4 fixes the issue. 

I can't tell you why because I don't understand the internals well, it is the first commit I tried when @paulkermann mentioned it was a regression in RC7.

If there is a better fix please feel free to commit to the PR.