### PR TITLE
fix issue 1663:tricore pc don't move

### DIFF
--- a/qemu/target/tricore/helper.h
+++ b/qemu/target/tricore/helper.h
@@ -22,6 +22,7 @@
 
 DEF_HELPER_4(uc_tracecode, void, i32, i32, ptr, i64)
 DEF_HELPER_6(uc_traceopcode, void, ptr, i64, i64, i32, ptr, i64)
+DEF_HELPER_1(uc_tricore_exit,void, env)
 
 /* Arithmetic */
 DEF_HELPER_3(add_ssov, i32, env, i32, i32)

--- a/qemu/target/tricore/op_helper.c
+++ b/qemu/target/tricore/op_helper.c
@@ -2793,3 +2793,12 @@ uint32_t helper_psw_read(CPUTriCoreState *env)
 {
     return psw_read(env);
 }
+
+void helper_uc_tricore_exit(CPUTriCoreState *env)
+{
+    CPUState *cs = env_cpu(env);
+
+    cs->exception_index = EXCP_HLT;
+    cs->halted = 1;
+    cpu_loop_exit(cs);
+}

--- a/qemu/tricore.h
+++ b/qemu/tricore.h
@@ -1286,4 +1286,5 @@
 #define helper_pack helper_pack_tricore
 #define gen_intermediate_code gen_intermediate_code_tricore
 #define restore_state_to_opc restore_state_to_opc_tricore
+#define helper_uc_tricore_exit helper_uc_tricore_exit_tricore
 #endif

--- a/symbols.sh
+++ b/symbols.sh
@@ -6284,6 +6284,7 @@ helper_fmsub \
 helper_pack \
 gen_intermediate_code \
 restore_state_to_opc \
+helper_uc_tricore_exit \
 "
 
 ARCHS="x86_64 arm aarch64 riscv32 riscv64 mips mipsel mips64 mips64el sparc sparc64 m68k ppc ppc64 s390x tricore"


### PR DESCRIPTION
Issue is described in #1663 
```
from unicorn import *
from unicorn.tricore_const import *
tricore_code = b"\x91\x10\x01\xf8\xd9\xff\xa0\x2f" #movh.a a15,#0x8011;lea a15,[a15]-0x760
ADDRESS = 0x4000
mu = Uc(UC_ARCH_TRICORE,UC_MODE_LITTLE_ENDIAN)
mu.mem_map(ADDRESS, 0x4000,7)
mu.mem_write(ADDRESS,tricore_code)
mu.emu_start(ADDRESS,0,count=2) # pc don't move
r_pc = mu.reg_read(UC_TRICORE_REG_PC)
print(f"after pc {hex(r_pc)}") # pc 0x4000
```
After mu.emu_start, pc is 0x4000 but should be 0x4008.

To solve this problem, use ```gen_save_pc``` to sync pc in function ```tricore_tr_translate_insn```.