### PR TITLE
Fix leak in test_mem_protect_map_ptr. (#1682)

### DIFF
--- a/tests/unit/test_mem.c
+++ b/tests/unit/test_mem.c
@@ -142,6 +142,9 @@ static void test_mem_protect_map_ptr(void)
     TEST_CHECK(val == mem);
 
     OK(uc_close(uc));
+
+    free(data2);
+    free(data1);
 }
 
 static void test_map_at_the_end(void)


### PR DESCRIPTION
This fixes a memory leak in test_mem reported by leak sanitizer. See #1682 for details.