### PR TITLE
Allow building with clang-cl (using MSVC config) on Windows.

### DIFF
--- a/qemu/include/qemu/atomic.h
+++ b/qemu/include/qemu/atomic.h
@@ -65,7 +65,7 @@
         (unsigned short)1,                                                             \
       (expr)+0))))))
 
-#ifdef __ATOMIC_RELAXED
+#if defined(__ATOMIC_RELAXED) && !(defined(_MSC_VER) && defined(__clang__))
 /* For C11 atomic ops */
 
 /* Sanity check that the size of an atomic operation isn't "overly large".

--- a/qemu/include/qemu/atomic.h
+++ b/qemu/include/qemu/atomic.h
@@ -31,38 +31,38 @@
  * implicit promotion.  int and larger types, as well as pointers, can be
  * converted to a non-qualified type just by applying a binary operator.
  */
-#define typeof_strip_qual(expr)                                                    \
-  typeof(                                                                          \
-    __builtin_choose_expr(                                                         \
-      __builtin_types_compatible_p(typeof(expr), bool) ||                          \
-        __builtin_types_compatible_p(typeof(expr), const bool) ||                  \
-        __builtin_types_compatible_p(typeof(expr), volatile bool) ||               \
-        __builtin_types_compatible_p(typeof(expr), const volatile bool),           \
-        (bool)1,                                                                   \
-    __builtin_choose_expr(                                                         \
-      __builtin_types_compatible_p(typeof(expr), signed char) ||                   \
-        __builtin_types_compatible_p(typeof(expr), const signed char) ||           \
-        __builtin_types_compatible_p(typeof(expr), volatile signed char) ||        \
-        __builtin_types_compatible_p(typeof(expr), const volatile signed char),    \
-        (signed char)1,                                                            \
-    __builtin_choose_expr(                                                         \
-      __builtin_types_compatible_p(typeof(expr), unsigned char) ||                 \
-        __builtin_types_compatible_p(typeof(expr), const unsigned char) ||         \
-        __builtin_types_compatible_p(typeof(expr), volatile unsigned char) ||      \
-        __builtin_types_compatible_p(typeof(expr), const volatile unsigned char),  \
-        (unsigned char)1,                                                          \
-    __builtin_choose_expr(                                                         \
-      __builtin_types_compatible_p(typeof(expr), signed short) ||                  \
-        __builtin_types_compatible_p(typeof(expr), const signed short) ||          \
-        __builtin_types_compatible_p(typeof(expr), volatile signed short) ||       \
-        __builtin_types_compatible_p(typeof(expr), const volatile signed short),   \
-        (signed short)1,                                                           \
-    __builtin_choose_expr(                                                         \
-      __builtin_types_compatible_p(typeof(expr), unsigned short) ||                \
-        __builtin_types_compatible_p(typeof(expr), const unsigned short) ||        \
-        __builtin_types_compatible_p(typeof(expr), volatile unsigned short) ||     \
-        __builtin_types_compatible_p(typeof(expr), const volatile unsigned short), \
-        (unsigned short)1,                                                         \
+#define typeof_strip_qual(expr)                                                        \
+  __typeof__(                                                                          \
+    __builtin_choose_expr(                                                             \
+      __builtin_types_compatible_p(__typeof__(expr), bool) ||                          \
+        __builtin_types_compatible_p(__typeof__(expr), const bool) ||                  \
+        __builtin_types_compatible_p(__typeof__(expr), volatile bool) ||               \
+        __builtin_types_compatible_p(__typeof__(expr), const volatile bool),           \
+        (bool)1,                                                                       \
+    __builtin_choose_expr(                                                             \
+      __builtin_types_compatible_p(__typeof__(expr), signed char) ||                   \
+        __builtin_types_compatible_p(__typeof__(expr), const signed char) ||           \
+        __builtin_types_compatible_p(__typeof__(expr), volatile signed char) ||        \
+        __builtin_types_compatible_p(__typeof__(expr), const volatile signed char),    \
+        (signed char)1,                                                                \
+    __builtin_choose_expr(                                                             \
+      __builtin_types_compatible_p(__typeof__(expr), unsigned char) ||                 \
+        __builtin_types_compatible_p(__typeof__(expr), const unsigned char) ||         \
+        __builtin_types_compatible_p(__typeof__(expr), volatile unsigned char) ||      \
+        __builtin_types_compatible_p(__typeof__(expr), const volatile unsigned char),  \
+        (unsigned char)1,                                                              \
+    __builtin_choose_expr(                                                             \
+      __builtin_types_compatible_p(__typeof__(expr), signed short) ||                  \
+        __builtin_types_compatible_p(__typeof__(expr), const signed short) ||          \
+        __builtin_types_compatible_p(__typeof__(expr), volatile signed short) ||       \
+        __builtin_types_compatible_p(__typeof__(expr), const volatile signed short),   \
+        (signed short)1,                                                               \
+    __builtin_choose_expr(                                                             \
+      __builtin_types_compatible_p(__typeof__(expr), unsigned short) ||                \
+        __builtin_types_compatible_p(__typeof__(expr), const unsigned short) ||        \
+        __builtin_types_compatible_p(__typeof__(expr), volatile unsigned short) ||     \
+        __builtin_types_compatible_p(__typeof__(expr), const volatile unsigned short), \
+        (unsigned short)1,                                                             \
       (expr)+0))))))
 
 #ifdef __ATOMIC_RELAXED

--- a/qemu/include/qemu/int128.h
+++ b/qemu/include/qemu/int128.h
@@ -146,7 +146,9 @@ static inline Int128 bswap128(Int128 a)
 #else /* !CONFIG_INT128 */
 
 typedef struct Int128 Int128;
+#if !(defined(_MSC_VER) && defined(__clang__))
 typedef Int128 __int128_t;
+#endif
 
 struct Int128 {
     uint64_t lo;

--- a/qemu/target/ppc/excp_helper.c
+++ b/qemu/target/ppc/excp_helper.c
@@ -1061,7 +1061,11 @@ void helper_store_msr(CPUPPCState *env, target_ulong val)
 }
 
 #if defined(TARGET_PPC64)
+#if defined(_MSC_VER) && defined(__clang__)
+void helper_pminsn(CPUPPCState *env, uint32_t insn)
+#else
 void helper_pminsn(CPUPPCState *env, powerpc_pm_insn_t insn)
+#endif
 {
     CPUState *cs;
 


### PR DESCRIPTION
Not sure if this is a change you're interested in or not, but figured I'd send it and let you decide. If you don't want this it's fine, it's easy enough for me to maintain my own patchset (though of course I'd prefer not to).

Build example (using latest LLVM + VS2022 targeting x64):
```
PS E:\Dev\unicorn\build> cmake -S ..\repo\ -B . -G Ninja -D CMAKE_C_COMPILER=clang-cl -D CMAKE_BUILD_TYPE=Debug
PS E:\Dev\unicorn\build> cmake --build .
PS E:\Dev\unicorn\build> cmake --build . --target test
```

There are 4 changes here.

1. The `typeof` extension is only available in GNU mode, whereas `__typeof__` is always available in all modes.

2. __int128_t is already defined with Clang, and since it shares the MSVC headers (hence doesn't define CONFIG_INT128) we need to ifdef it out. Alternatively it looks like it would be possible to drop the __int128_t altogether in that code, but I wasn't sure which would be preferable. Dropping it altogether seems potentially 'safer' to me in terms of not accidentally using the 'real' __int128_t when you meant to be using Int128, but I'm not sure if the typedef was there for some reason I wasn't aware of, since it seems to have been added intentionally. However it appears unused to me (all uses of __int128_t I see are guarded by CONFIG_INT128 - e.g. the MSVC build passed locally for me with that typedef removed).

3. For helper_pminsn the DEF_HELPER_2 macro declares the function to take uint32_t as the second arg, but it's defined to take powerpc_pm_insn_t. Not sure why it's only clang-cl which really doesn't like this. Probably it could also be done without the special-casing by just changing it unconditionally to use uint32_t in the definition (I'd need to test that works everywhere of course), but again this seemed like the less invasive change. Happy to test changing it unconditionally if you think that's better (I can test on Linux, FreeBSD, MacOS and Windows - a quick test with Clang and GCC on Linux showed that it seemed to work so if that's the preferred route I'd expect it to work elsewhere too).

4. The change around __ATOMIC_RELAXED to exclude clang-cl was due to a segfault in tb_remove_from_jmp_list as a result of the atomic_or_fetch operation only returning a 32-bit value, and truncating the high half of the 64-bit pointer. Forcing clang-cl to use the same code-path as MSVC for atomic operations resolved the issue.