### PR TITLE
Disable ARM-specific tests when ARM is unavailable. (#1689)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1403,6 +1403,9 @@ if(UNICORN_BUILD_TESTS)
         add_executable(${TEST_FILE}
             ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/${TEST_FILE}.c
         )
+        target_compile_options(${TEST_FILE} PRIVATE
+            ${UNICORN_COMPILE_OPTIONS}
+        )
         target_link_libraries(${TEST_FILE} PRIVATE
             ${SAMPLES_LIB}
         )

--- a/tests/unit/test_ctl.c
+++ b/tests/unit/test_ctl.c
@@ -175,6 +175,8 @@ static void test_uc_ctl_tb_cache(void)
     OK(uc_close(uc));
 }
 
+// Test requires UC_ARCH_ARM.
+#ifdef UNICORN_HAS_ARM
 static void test_uc_ctl_change_page_size(void)
 {
     uc_engine *uc;
@@ -191,7 +193,10 @@ static void test_uc_ctl_change_page_size(void)
     OK(uc_close(uc));
     OK(uc_close(uc2));
 }
+#endif
 
+// Test requires UC_ARCH_ARM.
+#ifdef UNICORN_HAS_ARM
 // Copy from test_arm.c but with new API.
 static void test_uc_ctl_arm_cpu(void)
 {
@@ -226,6 +231,7 @@ static void test_uc_ctl_arm_cpu(void)
 
     OK(uc_close(uc));
 }
+#endif
 
 static void test_uc_hook_cached_cb(uc_engine *uc, uint64_t addr, size_t size,
                                    void *user_data)
@@ -289,7 +295,9 @@ TEST_LIST = {{"test_uc_ctl_mode", test_uc_ctl_mode},
              {"test_uc_ctl_time_out", test_uc_ctl_time_out},
              {"test_uc_ctl_exits", test_uc_ctl_exits},
              {"test_uc_ctl_tb_cache", test_uc_ctl_tb_cache},
+#ifdef UNICORN_HAS_ARM
              {"test_uc_ctl_change_page_size", test_uc_ctl_change_page_size},
              {"test_uc_ctl_arm_cpu", test_uc_ctl_arm_cpu},
+#endif
              {"test_uc_hook_cached_uaf", test_uc_hook_cached_uaf},
              {NULL, NULL}};


### PR DESCRIPTION
When ARM target is not enabled, disable the ARM-specific tests in the test suites which are included unconditionally. See #1689 for details.