### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/docs/COMPILE.md
+++ b/docs/COMPILE.md
@@ -128,3 +128,17 @@ mkdir build; cd build
 cmake .. -DCMAKE_C_COMPILER=gcc-arm-linux-gnueabihf
 make
 ```
+
+## Building from vcpkg
+
+The Unicorn port in vcpkg is kept up to date by Microsoft team members and community contributors. The url of vcpkg is: https://github.com/Microsoft/vcpkg . You can download and install unicorn using the vcpkg dependency manager:
+
+```bash
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+./vcpkg integrate install
+./vcpkg install unicorn
+```
+
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.


### PR DESCRIPTION
Unicorn is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for unicorn and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build unicorn, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here](https://github.com/microsoft/vcpkg/blob/master/ports/unicorn/portfile.cmake) is what the port script looks like. We try to keep the library maintained as close as possible to the original library.