### PR TITLE
Adjust big memory test for host pagesize

### DIFF
--- a/tests/unit/test_mem.c
+++ b/tests/unit/test_mem.c
@@ -181,8 +181,15 @@ static void test_map_big_memory(void)
 
     OK(uc_open(UC_ARCH_X86, UC_MODE_64, &uc));
 
+#if defined(_WIN32) || defined(__WIN32__) || defined(__WINDOWS__)
+    uint64_t requested_size = 0xfffffffffffff000;  // assume 4K page size
+#else
+    long ps = sysconf(_SC_PAGESIZE);
+    uint64_t requested_size = (uint64_t)(-ps);
+#endif
+
     uc_assert_err(UC_ERR_NOMEM,
-                  uc_mem_map(uc, 0x0, 0xfffffffffffff000, UC_PROT_ALL));
+                  uc_mem_map(uc, 0x0, requested_size, UC_PROT_ALL));
 
     OK(uc_close(uc));
 }


### PR DESCRIPTION
On machines with a page size larger than 4K, the requested memory size in `test_map_big_memory` gets rounded up and overflows to zero.

This PR adds some code to query the page size and adjust the requested memory size accordingly. See also the discussion in #1678 and thanks to @relapids for the initial debugging, which helped me resolve this issue for Debian on mipsel and s390x much more quickly.
