### PR TITLE
Fix crashes on M1

### DIFF
--- a/qemu/accel/tcg/cputlb.c
+++ b/qemu/accel/tcg/cputlb.c
@@ -1419,6 +1419,9 @@ load_helper(CPUArchState *env, target_ulong addr, TCGMemOpIdx oi,
             uintptr_t retaddr, MemOp op, bool code_read,
             FullLoadHelper *full_load)
 {
+    // Hack for double load on error
+    if (env->uc->cpu->exit_request) return 0;
+
     uintptr_t mmu_idx = get_mmuidx(oi);
     uintptr_t index = tlb_index(env, mmu_idx, addr);
     CPUTLBEntry *entry = tlb_entry(env, mmu_idx, addr);
@@ -1451,7 +1454,12 @@ load_helper(CPUArchState *env, target_ulong addr, TCGMemOpIdx oi,
                         continue;
                     if (!HOOK_BOUND_CHECK(hook, addr))
                         continue;
-                    if ((handled = ((uc_cb_eventmem_t)hook->callback)(uc, UC_MEM_FETCH_UNMAPPED, addr, size, 0, hook->user_data)))
+
+                    // Lock here to fix a crash on M1
+                    tb_exec_lock(uc->tcg_ctx);
+                    handled = ((uc_cb_eventmem_t)hook->callback)(uc, UC_MEM_FETCH_UNMAPPED, addr, size - uc->size_recur_mem, 0, hook->user_data);
+                    tb_exec_unlock(uc->tcg_ctx);
+                    if (handled)
                         break;
 
                     // the last callback may already asked to stop emulation
@@ -1466,7 +1474,12 @@ load_helper(CPUArchState *env, target_ulong addr, TCGMemOpIdx oi,
                         continue;
                     if (!HOOK_BOUND_CHECK(hook, addr))
                         continue;
-                    if ((handled = ((uc_cb_eventmem_t)hook->callback)(uc, UC_MEM_READ_UNMAPPED, addr, size, 0, hook->user_data)))
+
+                    // Lock here to fix a crash on M1
+                    tb_exec_lock(uc->tcg_ctx);
+                    handled = ((uc_cb_eventmem_t)hook->callback)(uc, UC_MEM_READ_UNMAPPED, addr, size, 0, hook->user_data);
+                    tb_exec_unlock(uc->tcg_ctx);
+                    if (handled)
                         break;
 
                     // the last callback may already asked to stop emulation

--- a/qemu/accel/tcg/translate-all.c
+++ b/qemu/accel/tcg/translate-all.c
@@ -1094,6 +1094,7 @@ void tcg_exec_init(struct uc_struct *uc, unsigned long tb_size)
     code_gen_alloc(uc, tb_size);
     tb_exec_unlock(uc->tcg_ctx);
     tcg_prologue_init(uc->tcg_ctx);
+    tb_exec_lock(uc->tcg_ctx);
     /* cpu_interrupt_handler is not used in uc1 */
     uc->l1_map = g_malloc0(sizeof(void *) * V_L1_MAX_SIZE);
     /* Invalidate / Cache TBs */

--- a/qemu/softmmu/cpus.c
+++ b/qemu/softmmu/cpus.c
@@ -226,6 +226,9 @@ void resume_all_vcpus(struct uc_struct* uc)
         uc_exit_invalidate_iter((gpointer)&uc->exits[uc->nested_level - 1], NULL, (gpointer)uc);
     }
 
+    // Why?
+    tb_exec_lock(uc->tcg_ctx);
+
     cpu->created = false;
 }
 

--- a/tests/unit/test_x86.c
+++ b/tests/unit/test_x86.c
@@ -1227,6 +1227,23 @@ static void test_x86_lazy_mapping(void)
     OK(uc_close(uc));
 }
 
+static void test_x86_cpuid_1()
+{
+    uc_engine *uc;
+    char code[] = "\xB8\x01\x00\x00\x00\x0F\xA2"; // MOV EAX,1; CPUID
+    int reg;
+
+    uc_common_setup(&uc, UC_ARCH_X86, UC_MODE_32, code, sizeof(code) - 1);
+
+    OK(uc_emu_start(uc, code_start, code_start + sizeof(code) - 1, 0, 0));
+
+    OK(uc_reg_read(uc, UC_X86_REG_EDX, &reg));
+
+    TEST_CHECK(reg == 0x7088100);
+
+    OK(uc_close(uc));
+}
+
 TEST_LIST = {
     {"test_x86_in", test_x86_in},
     {"test_x86_out", test_x86_out},
@@ -1269,4 +1286,5 @@ TEST_LIST = {
     {"test_x86_unaligned_access", test_x86_unaligned_access},
 #endif
     {"test_x86_lazy_mapping", test_x86_lazy_mapping},
+    {"test_x86_cpuid_1", test_x86_cpuid_1},
     {NULL, NULL}};


### PR DESCRIPTION
See #1615 

I just merged the changes from https://github.com/QDucasse/unicorn/pull/2. Unfortunately this doesn't seem to fix everything. The new state of the tests on the M1:

```
./build/test_x86
Test test_x86_in...                             [ OK ]
Test test_x86_out...                            [ OK ]
Test test_x86_mem_hook_all...                     Test interrupted by signal 10.
Test test_x86_inc_dec_pxor...                   [ OK ]
Test test_x86_relative_jump...                  [ OK ]
Test test_x86_loop...                           [ OK ]
Test test_x86_invalid_mem_read...               [ OK ]
Test test_x86_invalid_mem_write...              [ OK ]
Test test_x86_invalid_jump...                   [ OK ]
Test test_x86_64_syscall...                     [ OK ]
Test test_x86_16_add...                         [ OK ]
Test test_x86_reg_save...                       [ OK ]
Test test_x86_invalid_mem_read_stop_in_cb...    [ OK ]
Test test_x86_x87_fnstenv...                    [ OK ]
Test test_x86_mmio...                           [ OK ]
Test test_x86_missing_code...                   [ OK ]
Test test_x86_smc_xor...                        [ OK ]
Test test_x86_mmio_uc_mem_rw...                 [ OK ]
Test test_x86_sysenter...                       [ OK ]
Test test_x86_hook_cpuid...                     [ OK ]
Test test_x86_486_cpuid...                      [ OK ]
Test test_x86_clear_tb_cache...                 [ OK ]
Test test_x86_clear_empty_tb...                 [ OK ]
Test test_x86_hook_tcg_op...                    [ OK ]
Test test_x86_cmpxchg...                        [ OK ]
Test test_x86_nested_emu_start...               [ OK ]
Test test_x86_nested_emu_stop...                [ OK ]
Test test_x86_64_nested_emu_start_error...      [ OK ]
Test test_x86_eflags_reserved_bit...            [ OK ]
Test test_x86_nested_uc_emu_start_exits...      [ OK ]
Test test_x86_clear_count_cache...                Test interrupted by signal 10.
Test test_x86_correct_address_in_small_jump_hook... [ OK ]
Test test_x86_correct_address_in_long_jump_hook... [ OK ]
Test test_x86_invalid_vex_l...                  [ OK ]
Test test_x86_lazy_mapping...                   [ OK ]
Test test_x86_cpuid_1...                        [ OK ]
FAILED: 2 of 36 unit tests have failed.
```