### PR TITLE
Add github workflow to publish Nuget for .NET bindings

### DIFF
--- a/.github/workflows/Nuget-publishing.yml
+++ b/.github/workflows/Nuget-publishing.yml
@@ -105,7 +105,7 @@ jobs:
               fs.writeFileSync(`/home/runner/${artifact.name}.zip`, Buffer.from(download.data));
             
               console.log(`Unzipping: /home/runner/${artifact.name}.zip`);            
-              await exec.exec("unzip", [`/home/runner/${artifact.name}.zip`]);
+              await exec.exec("unzip", [`/home/runner/${artifact.name}.zip`, "-d", "/home/runner/"]);
               console.log(`Extracting library from 7z file to: ${destDir}/${sourceFile}`);
               await exec.exec("7z", ["e", `-o${destDir}/`, `/home/runner/${artifact.name}`, `${sourceDir}${sourceFile}`], options);
               if (sourceFile != destFile) {

--- a/.github/workflows/Nuget-publishing.yml
+++ b/.github/workflows/Nuget-publishing.yml
@@ -45,6 +45,7 @@ jobs:
             let sourceFile = "";
             let destDir = "";
             let destFile = "";
+            var output = {};
             for (const artifact of allArtifacts.data.artifacts) {
               switch(artifact.name) {
                 case 'ubuntu-cmake-aarch64.7z':
@@ -109,7 +110,9 @@ jobs:
               console.log(`Extracting library from 7z file to: ${destDir}/${sourceFile}`);
               await exec.exec("7z", ["e", `-o${destDir}/`, `/home/runner/${artifact.name}`, `${sourceDir}${sourceFile}`], options);
               if (sourceFile != destFile) {
-                console.log(`Renaming library to: ${destFile}`);
+                output = await exec.getExecOutput("ls", [destDir], options);
+                sourceFile = output.stdout.trim();
+                console.log(`Renaming ${sourceFile} to ${destFile}`);
                 await exec.exec("mv", [`${destDir}/${sourceFile}`, `${destDir}/${destFile}`], options);
               }
             }

--- a/.github/workflows/Nuget-publishing.yml
+++ b/.github/workflows/Nuget-publishing.yml
@@ -102,12 +102,12 @@ jobs:
                artifact_id: artifact.id,
                archive_format: 'zip',
               });
-              fs.writeFileSync(`/tmp/${artifact.name}.zip`, Buffer.from(download.data));
+              fs.writeFileSync(`/home/runner/${artifact.name}.zip`, Buffer.from(download.data));
             
-              console.log(`Unzipping: /tmp/${artifact.name}.zip`);            
-              await exec.exec("unzip", [`/tmp/${artifact.name}.zip`]);
-              console.log(`Extracting library from 7z file to: ${destDir}${sourceFile}`);
-              await exec.exec("7z", ["e", `-o${destDir}`, `/tmp/${artifact.name}`, `${sourceDir}${sourceFile}`], options);
+              console.log(`Unzipping: /home/runner/${artifact.name}.zip`);            
+              await exec.exec("unzip", [`/home/runner/${artifact.name}.zip`]);
+              console.log(`Extracting library from 7z file to: ${destDir}/${sourceFile}`);
+              await exec.exec("7z", ["e", `-o${destDir}/`, `/home/runner/${artifact.name}`, `${sourceDir}${sourceFile}`], options);
               if (sourceFile != destFile) {
                 console.log(`Renaming library to: ${destFile}`);
                 await exec.exec("mv", [`${destDir}/${sourceFile}`, `${destDir}/${destFile}`], options);

--- a/.github/workflows/Nuget-publishing.yml
+++ b/.github/workflows/Nuget-publishing.yml
@@ -1,11 +1,17 @@
 name: Nuget 📦 Distribution
 
 on:
-  workflow_run:
-    workflows:
-      - "Build UC2"
-    types:
-      - completed
+  push:
+    paths-ignore:
+      - ".gitignore"
+      - "docs/**"
+      - "README"
+      - "CREDITS.TXT"
+      - "COPYING_GLIB"
+      - "COPYING.LGPL2"
+      - "AUTHORS.TXT"
+      - "CHANGELOG"
+      - "COPYING"
     branches:
       - dev
       - master
@@ -14,128 +20,406 @@ permissions:
   packages: write
 
 jobs:
-  publish:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
+  Windows:
+    runs-on: ${{ matrix.config.os }}
+    name: ${{ matrix.config.name }}
+    strategy:
+      fail-fast: true
+      matrix:
+        config:
+          - {
+            os: windows-2019,
+            arch: x64,
+            python-arch: x64,
+            python-ver: '3.8',
+            name: 'windows-x64 MSVC 64bit shared',
+            msvc-arch: x64,
+            artifact: 'windows_msvc64_shared.7z',
+            shared: 'yes',
+            build_type: 'Release',
+            archiver: '7z a',
+            generators: 'Visual Studio 16 2019'
+          }
+          - {
+            os: windows-2019,
+            arch: x86,
+            python-arch: x86,
+            python-ver: '3.8',
+            name: 'windows-x86 MSVC 32bit shared',
+            msvc-arch: x86,
+            artifact: 'windows_msvc32_shared.7z',
+            shared: 'yes',
+            build_type: 'Release',
+            archiver: '7z a',
+            generators: 'Visual Studio 16 2019'
+          }
+        compiler: [ gcc ]
+    steps:
+      - uses: actions/checkout@v2
 
-    defaults:
-      run:
-        working-directory: bindings/dotnet/UnicornEngine
+      - name: '🛠️ Win MSVC 64 setup'
+        if: contains(matrix.config.name, 'MSVC 64')
+        uses: microsoft/setup-msbuild@v1
+
+      - name: '🛠️ Win MSVC 64 dev cmd setup'
+        if: contains(matrix.config.name, 'MSVC 64')
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: '🚧 Win MSVC 64 build'
+        if: contains(matrix.config.name, 'MSVC 64')
+        shell: bash
+        run: |
+          choco install ninja cmake
+          ninja --version
+          cmake --version
+          mkdir build
+          cmake \
+            -S . \
+            -B . \
+            -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
+            -G "${{ matrix.config.generators }}" \
+            -DCMAKE_INSTALL_PREFIX:PATH=instdir \
+            -DBUILD_SHARED_LIBS=${{ matrix.config.shared }}
+          cmake --build . --config ${{ matrix.config.build_type }}
+          cmake --install . --strip --config ${{ matrix.config.build_type }}
+          ctest -VV -C ${{ matrix.config.build_type }}
+          mv Release instdir
+
+      - name: '🛠️ Win MSVC 32 setup'
+        if: contains(matrix.config.name, 'MSVC 32')
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x86
+
+      - name: '🚧 Win MSVC 32 build'
+        if: contains(matrix.config.name, 'MSVC 32')
+        shell: bash
+        run: |
+          choco install ninja cmake
+          ninja --version
+          cmake --version
+          mkdir build
+          cmake \
+            -S . \
+            -B . \
+            -A "win32" \
+            -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
+            -G "${{ matrix.config.generators }}" \
+            -DCMAKE_INSTALL_PREFIX:PATH=instdir \
+            -DBUILD_SHARED_LIBS=${{ matrix.config.shared }}
+          cmake --build . --config ${{ matrix.config.build_type }}
+          cmake --install . --strip --config ${{ matrix.config.build_type }}
+          ctest -VV -C ${{ matrix.config.build_type }}
+          mv Release instdir
+
+      - name: '📦 Pack artifact'
+        if: always()
+        shell: bash
+        working-directory: instdir
+        run: |
+          ls -laR
+          ${{ matrix.config.archiver }} ../${{ matrix.config.artifact }} . ../test*
+
+      - name: '📤 Upload artifact'
+        if: always()
+        uses: actions/upload-artifact@v1
+        with:
+          path: ./${{ matrix.config.artifact }}
+          name: ${{ matrix.config.artifact }}
+
+  Macos:
+    runs-on: ${{ matrix.config.os }}
+    name: ${{ matrix.config.name }} - ${{ matrix.compiler }}
+    strategy:
+      fail-fast: true
+      matrix:
+        config:
+          - {
+            os: macos-latest,
+            arch: x64,
+            python-arch: x64,
+            python-ver: '3.8',
+            name: 'macos-x64 cmake shared',
+            shared: 'yes',
+            artifact: 'macos-cmake-shared-x64.7z',
+            build_type: 'Release',
+            archiver: '7za a',
+            generators: 'Ninja'
+          }
+        compiler: [ gcc ]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: '🚧 Mac build'
+        if: contains(matrix.config.name, 'macos-x64')
+        shell: bash
+        run: |
+          brew install p7zip cmake ninja
+          ninja --version
+          cmake --version
+          mkdir build
+          mkdir instdir
+          cmake \
+            -S . \
+            -B . \
+            -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
+            -G "${{ matrix.config.generators }}" \
+            -DCMAKE_INSTALL_PREFIX:PATH=instdir \
+            -DBUILD_SHARED_LIBS=${{ matrix.config.shared }}
+          cmake --build . --config ${{ matrix.config.build_type }}
+          cmake --install . --strip
+          ctest -VV -C ${{ matrix.config.build_type }}
+
+      - name: '📦 Pack artifact'
+        if: always()
+        shell: bash
+        working-directory: instdir
+        run: |
+          ls -laR
+          ${{ matrix.config.archiver }} ../${{ matrix.config.artifact }} . ../test*
+
+      - name: '📤 Upload artifact'
+        if: always()
+        uses: actions/upload-artifact@v1
+        with:
+          path: ./${{ matrix.config.artifact }}
+          name: ${{ matrix.config.artifact }}
+
+  Linux:
+    runs-on: ${{ matrix.config.os }}
+    name: ${{ matrix.config.name }} - ${{ matrix.compiler }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {
+            os: ubuntu-latest,
+            arch: x64,
+            python-arch: x64,
+            python-ver: '3.8',
+            name: 'ubuntu-x64 cmake shared',
+            shared: 'yes',
+            artifact: 'ubuntu-cmake-shared-x64.7z',
+            build_type: 'Release',
+            archiver: '7z a',
+            generators: 'Ninja'
+          }
+          - {
+            os: ubuntu-latest,
+            arch: x86,
+            python-arch: x86,
+            python-ver: '3.8',
+            name: 'ubuntu-x86 cmake shared',
+            shared: 'yes',
+            artifact: 'ubuntu-cmake-shared-x86.7z',
+            build_type: 'Release',
+            archiver: '7z a',
+            generators: 'Ninja'
+          }
+          - {
+            os: ubuntu-latest,
+            arch: aarch64,
+            python-arch: aarch64,
+            python-ver: '3.8',
+            name: 'ubuntu-aarch64 cmake',
+            artifact: 'ubuntu-cmake-aarch64.7z',
+            build_type: 'Release',
+            archiver: '7z a',
+            generators: 'Ninja',
+            distro: ubuntu20.04
+          }
+          - {
+            os: ubuntu-latest,
+            arch: ppc64le,
+            python-arch: ppc,
+            python-ver: '3.8',
+            name: 'ubuntu-ppc64le cmake',
+            artifact: 'ubuntu-cmake-ppc64le.7z',
+            build_type: 'Release',
+            archiver: '7z a',
+            generators: 'Ninja',
+            distro: ubuntu20.04
+          }
+        compiler: [ gcc ]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: '🚧 Linux x64/x86 build'
+        if: contains(matrix.config.arch, 'x64') || contains(matrix.config.arch, 'x86')
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          if [ ${{ matrix.config.arch }} == 'x64' ]; then
+                sudo apt install -q -y libcmocka-dev ninja-build 
+          else
+                export CFLAGS="-m32" LDFLAGS="-m32" LDFLAGS_STATIC="-m32" UNICORN_QEMU_FLAGS="--cpu=i386" 
+                sudo dpkg --add-architecture i386
+                sudo apt install -q -y lib32ncurses-dev lib32z1-dev lib32gcc-9-dev libc6-dev-i386 gcc-multilib \
+                  libcmocka-dev:i386 libcmocka0:i386 libc6:i386 libgcc-s1:i386 ninja-build
+          fi
+          mkdir build
+          mkdir instdir
+          cmake \
+            -S . \
+            -B . \
+            -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
+            -G "${{ matrix.config.generators }}" \
+            -DCMAKE_INSTALL_PREFIX:PATH=instdir \
+            -DBUILD_SHARED_LIBS=${{ matrix.config.shared }}
+          cmake --build . --config ${{ matrix.config.build_type }}
+          cmake --install . --strip
+          ctest -VV -C ${{ matrix.config.build_type }}
+
+      - name: '🚧 Linux ppc64le/aarch64 build'
+        if: contains(matrix.config.arch, 'ppc64le') || contains(matrix.config.arch, 'aarch64')
+        uses: uraimo/run-on-arch-action@v2.0.5
+        with:
+          arch: ${{ matrix.config.arch }}
+          distro: ${{ matrix.config.distro }}
+          setup: |
+            mkdir -p "${PWD}/instdir"
+          dockerRunArgs: |
+            --volume "${PWD}/instdir:/instdir"
+          shell: /bin/sh
+          install: |
+            apt-get update -q -y
+            apt-get install -q -y git cmake build-essential automake libcmocka-dev pkg-config ${{ matrix.compiler }} ninja-build
+          run: |
+            mkdir build
+            cmake \
+              -S . \
+              -B . \
+              -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
+              -G "${{ matrix.config.generators }}" \
+              -DCMAKE_INSTALL_PREFIX:PATH=/instdir
+            cmake --build . --config ${{ matrix.config.build_type }}
+            cmake --install . --strip
+            ctest -VV -C ${{ matrix.config.build_type }}
+
+      - name: '📦 Pack artifact'
+        if: always()
+        shell: bash
+        working-directory: instdir
+        run: |
+          ls -laR
+          ${{ matrix.config.archiver }} ../${{ matrix.config.artifact }} . ../test*
+
+      - name: '📤 Upload artifact'
+        if: always()
+        uses: actions/upload-artifact@v1
+        with:
+          path: ./${{ matrix.config.artifact }}
+          name: ${{ matrix.config.artifact }}
+
+  publish:
+    needs: ["Windows", "Macos", "Linux"]
+    if: ${{ needs.Windows.result == 'success' && needs.Macos.result == 'success' && needs.Linux.result == 'success' }}
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.workflow_run.head_branch }}
 
-      - name: Download and extract artifacts
-        uses: actions/github-script@v6
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
         with:
-          script: |
-            let fs = require('fs');
-            const options = {};
-            options.cwd = './bindings/dotnet/UnicornEngine';
-            
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
-            });
-            
-            let sourceDir = "";
-            let sourceFile = "";
-            let destDir = "";
-            let destFile = "";
-            var output = {};
-            for (const artifact of allArtifacts.data.artifacts) {
-              switch(artifact.name) {
-                case 'ubuntu-cmake-aarch64.7z':
-                  sourceDir = "lib/";
-                  sourceFile = "libunicorn.so.*";
-                  destDir = "runtimes/linux-arm64/native";
-                  destFile = "libunicorn.so";
-                  break;
-                case 'ubuntu-cmake-ppc64le.7z':
-                  sourceDir = "lib/";
-                  sourceFile = "libunicorn.so.*";
-                  destDir = "runtimes/linux-ppc64le/native";
-                  destFile = "libunicorn.so";
-                  break;
-                case 'ubuntu-cmake-shared-x64.7z':
-                  sourceDir = "lib/";
-                  sourceFile = "libunicorn.so.*";
-                  destDir = "runtimes/linux-x64/native";
-                  destFile = "libunicorn.so";
-                  break;
-                case 'ubuntu-cmake-shared-x86.7z':
-                  sourceDir = "lib/";
-                  sourceFile = "libunicorn.so.*";
-                  destDir = "runtimes/linux-x86/native";
-                  destFile = "libunicorn.so";
-                  break;
-                case 'macos-cmake-shared-x64.7z':
-                  sourceDir = "lib/";
-                  sourceFile = "libunicorn.*.dylib";
-                  destDir = "runtimes/osx-x64/native";
-                  destFile = "libunicorn.dylib";
-                  break;
-                case 'windows_msvc64_shared.7z':
-                  sourceDir = "";
-                  sourceFile = "unicorn.dll";
-                  destDir = "runtimes/win-x64/native";
-                  destFile = "unicorn.dll";
-                  break;
-                case 'windows_msvc32_shared.7z':
-                  sourceDir = "";
-                  sourceFile = "unicorn.dll";
-                  destDir = "runtimes/win-x86/native";
-                  destFile = "unicorn.dll";
-                  break;
-                default:
-                  continue;
-              }
-              console.log(`Creating destination directory: ${destDir}`);
-              await exec.exec("mkdir", ["-p", destDir], options);
-            
-              console.log(`Downloading artifact: ${artifact.name}.zip`);            
-              let download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: artifact.id,
-               archive_format: 'zip',
-              });
-              fs.writeFileSync(`/home/runner/${artifact.name}.zip`, Buffer.from(download.data));
-            
-              console.log(`Unzipping: /home/runner/${artifact.name}.zip`);            
-              await exec.exec("unzip", [`/home/runner/${artifact.name}.zip`, "-d", "/home/runner/"]);
-              console.log(`Extracting library from 7z file to: ${destDir}/${sourceFile}`);
-              await exec.exec("7z", ["e", `-o${destDir}/`, `/home/runner/${artifact.name}`, `${sourceDir}${sourceFile}`], options);
-              if (sourceFile != destFile) {
-                output = await exec.getExecOutput("ls", [destDir], options);
-                sourceFile = output.stdout.trim();
-                console.log(`Renaming ${sourceFile} to ${destFile}`);
-                await exec.exec("mv", [`${destDir}/${sourceFile}`, `${destDir}/${destFile}`], options);
-              }
+          path: artifacts
+
+      - name: Extract artifacts
+        shell: python
+        run: |
+          import subprocess
+          import os
+          
+          artifactPath = os.path.join(os.getcwd(), "artifacts")
+          bindingsPath = os.path.join(os.getcwd(), "bindings", "dotnet", "UnicornEngine")
+          
+          ARTIFACT_CONFIG = {
+            "ubuntu-cmake-aarch64.7z": {
+              "sourceDir": "lib/",
+              "sourceFile": "libunicorn.so.*",
+              "destDir": "runtimes/linux-arm64/native",
+              "destFile": "libunicorn.so"
+            },
+            "ubuntu-cmake-ppc64le.7z": {
+              "sourceDir": "lib/",
+              "sourceFile": "libunicorn.so.*",
+              "destDir": "runtimes/linux-ppc64le/native",
+              "destFile": "libunicorn.so"
+            },
+            "ubuntu-cmake-shared-x86.7z": {
+              "sourceDir": "lib/",
+              "sourceFile": "libunicorn.so.*",
+              "destDir": "runtimes/linux-x64/native",
+              "destFile": "libunicorn.so"
+            },
+            "macos-cmake-shared-x64.7z": {
+              "sourceDir": "lib/",
+              "sourceFile": "libunicorn.*.dylib",
+              "destDir": "runtimes/osx-x64/native",
+              "destFile": "libunicorn.dylib"
+            },
+            "windows_msvc64_shared.7z": {
+              "sourceDir": "",
+              "sourceFile": "unicorn.dll",
+              "destDir": "runtimes/win-x64/native",
+              "destFile": "unicorn.dll"
+            },
+            "windows_msvc32_shared.7z": {
+              "sourceDir": "",
+              "sourceFile": "unicorn.dll",
+              "destDir": "runtimes/win-x86/native",
+              "destFile": "unicorn.dll"
             }
+          }
+          
+          if len(os.listdir(artifactPath)) < len(ARTIFACT_CONFIG.keys()):
+            print("Some artifacts are missing. Aborting.")
+            exit(1)
+          
+          for artifact in os.listdir(artifactPath):
+            if artifact in ARTIFACT_CONFIG.keys():
+              print("Working on:", artifact)
+              config = ARTIFACT_CONFIG[artifact]
+              destDir = os.path.join(bindingsPath, config["destDir"])
+              print("Creating dir:", destDir)
+              os.makedirs(destDir, exist_ok=True)
+              
+              print(f"Extracting library from 7z file to: {config['destDir']}/{config['sourceFile']}")
+              result = subprocess.run(["7z", "e", f"-o{destDir}/", os.path.join(artifactPath, artifact), f"{config['sourceDir']}{config['sourceFile']}"])
+              result.check_returncode()
+              
+              if config["sourceFile"] != config["destFile"]:
+                output = subprocess.run(["ls", destDir], stdout=subprocess.PIPE)
+                sourceFile = output.stdout.decode().strip()
+                print(f"Renaming {sourceFile} to {config['destFile']}")
+                os.rename(os.path.join(destDir, sourceFile), os.path.join(destDir, config["destFile"]))
+          
+          print("Done!")
 
       - name: Get short sha
         id: git_short_sha
-        run: echo "result=$(git rev-parse --short "${{ github.event.workflow_run.head_sha }}")" >> $GITHUB_OUTPUT
+        run: echo "result=$(git rev-parse --short "${{ github.sha }}")" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
 
       - name: Authenticate to Github Packages
+        working-directory: bindings/dotnet/UnicornEngine
         run: dotnet nuget add source --username "${{ github.repository_owner }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
 
       - name: List all native libraries
+        working-directory: bindings/dotnet/UnicornEngine
         run: find ./runtimes -type f -print
 
       - name: Package .NET distribution
+        working-directory: bindings/dotnet/UnicornEngine
         run: |
           [[ "${{ github.event.workflow_run.head_branch }}" == "master" ]] \
             && dotnet pack -c Release \
             || dotnet pack -c Release --version-suffix="${{ steps.git_short_sha.outputs.result }}"
 
       - name: 📦 Publish to Github Packages
+        working-directory: bindings/dotnet/UnicornEngine
         run: dotnet nuget push "bin/Release/UnicornEngine.Unicorn.*.nupkg" --source "github" --api-key "${{ secrets.GHPR_TOKEN }}"

--- a/.github/workflows/Nuget-publishing.yml
+++ b/.github/workflows/Nuget-publishing.yml
@@ -1,18 +1,21 @@
 name: Nuget 📦 Distribution
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - "Build UC2"
+    types:
+      - completed
     branches:
       - dev
       - master
-    paths:
-      - "bindings/dotnet/UnicornEngine/**"
 
 permissions:
   packages: write
 
 jobs:
   publish:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     defaults:
@@ -21,10 +24,99 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+
+      - name: 'Download and extract artifacts'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let fs = require('fs');
+            const options = {};
+            options.cwd = './bindings/dotnet/UnicornEngine';
+            
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            
+            let sourceDir = "";
+            let sourceFile = "";
+            let destDir = "";
+            let destFile = "";
+            for (const artifact of allArtifacts.data.artifacts) {
+              switch(artifact.name) {
+                case 'ubuntu-cmake-aarch64.7z':
+                  sourceDir = "lib/";
+                  sourceFile = "libunicorn.so.*";
+                  destDir = "runtimes/linux-arm64/native";
+                  destFile = "libunicorn.so";
+                  break;
+                case 'ubuntu-cmake-ppc64le.7z':
+                  sourceDir = "lib/";
+                  sourceFile = "libunicorn.so.*";
+                  destDir = "runtimes/linux-ppc64le/native";
+                  destFile = "libunicorn.so";
+                  break;
+                case 'ubuntu-cmake-shared-x64.7z':
+                  sourceDir = "lib/";
+                  sourceFile = "libunicorn.so.*";
+                  destDir = "runtimes/linux-x64/native";
+                  destFile = "libunicorn.so";
+                  break;
+                case 'ubuntu-cmake-shared-x86.7z':
+                  sourceDir = "lib/";
+                  sourceFile = "libunicorn.so.*";
+                  destDir = "runtimes/linux-x86/native";
+                  destFile = "libunicorn.so";
+                  break;
+                case 'macos-cmake-shared-x64.7z':
+                  sourceDir = "lib/";
+                  sourceFile = "libunicorn.*.dylib";
+                  destDir = "runtimes/osx-x64/native";
+                  destFile = "libunicorn.dylib";
+                  break;
+                case 'windows_msvc64_shared.7z':
+                  sourceDir = "";
+                  sourceFile = "unicorn.dll";
+                  destDir = "runtimes/win-x64/native";
+                  destFile = "unicorn.dll";
+                  break;
+                case 'windows_msvc32_shared.7z':
+                  sourceDir = "";
+                  sourceFile = "unicorn.dll";
+                  destDir = "runtimes/win-x86/native";
+                  destFile = "unicorn.dll";
+                  break;
+                default:
+                  continue;
+              }
+              console.log(`Creating destination directory: ${destDir}`);
+              await exec.exec("mkdir", ["-p", destDir], options);
+            
+              console.log(`Downloading artifact: ${artifact.name}.zip`);            
+              let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: artifact.id,
+               archive_format: 'zip',
+              });
+              fs.writeFileSync(`/tmp/${artifact.name}.zip`, Buffer.from(download.data));
+            
+              console.log(`Unzipping: /tmp/${artifact.name}.zip`);            
+              await exec.exec("unzip", [`/tmp/${artifact.name}.zip`]);
+              console.log(`Extracting library from 7z file to: ${destDir}${sourceFile}`);
+              await exec.exec("7z", ["e", "-o", destDir, `/tmp/${artifact.name}`, `${sourceDir}${sourceFile}`], options);
+              if (sourceFile != destFile) {
+                console.log(`Renaming library to: ${destFile}`);
+                await exec.exec("mv", [`${destDir}/${sourceFile}`, `${destDir}/${destFile}`], options);
+              }
+            }
 
       - name: Get short sha
         id: git_short_sha
-        run: echo "result=$(git rev-parse --short "${{ github.sha }}")" >> $GITHUB_OUTPUT
+        run: echo "result=$(git rev-parse --short "${{ github.event.workflow_run.head_sha }}")" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-dotnet@v3
         with:
@@ -35,7 +127,7 @@ jobs:
 
       - name: Package .NET bindings
         run: |
-          [[ "${{ github.ref_name }}" == "master" ]] \
+          [[ "${{ github.event.workflow_run.head_branch }}" == "master" ]] \
             && dotnet pack -c Release \
             || dotnet pack -c Release --version-suffix="${{ steps.git_short_sha.outputs.result }}"
 

--- a/.github/workflows/Nuget-publishing.yml
+++ b/.github/workflows/Nuget-publishing.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
 
-      - name: 'Download and extract artifacts'
+      - name: Download and extract artifacts
         uses: actions/github-script@v6
         with:
           script: |
@@ -125,7 +125,10 @@ jobs:
       - name: Authenticate to Github Packages
         run: dotnet nuget add source --username "${{ github.repository_owner }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
 
-      - name: Package .NET bindings
+      - name: List all native libraries
+        run: find ./runtimes -type f -print
+
+      - name: Package .NET distribution
         run: |
           [[ "${{ github.event.workflow_run.head_branch }}" == "master" ]] \
             && dotnet pack -c Release \

--- a/.github/workflows/Nuget-publishing.yml
+++ b/.github/workflows/Nuget-publishing.yml
@@ -5,16 +5,8 @@ on:
     branches:
       - dev
       - master
-    paths-ignore:
-      - ".gitignore"
-      - "docs/**"
-      - "README"
-      - "CREDITS.TXT"
-      - "COPYING_GLIB"
-      - "COPYING.LGPL2"
-      - "AUTHORS.TXT"
-      - "CHANGELOG"
-      - "COPYING"
+    paths:
+      - "bindings/dotnet/UnicornEngine/**"
 
 permissions:
   packages: write

--- a/.github/workflows/Nuget-publishing.yml
+++ b/.github/workflows/Nuget-publishing.yml
@@ -1,0 +1,51 @@
+name: Nuget 📦 Distribution
+
+on:
+  push:
+    branches:
+      - dev
+      - master
+    paths-ignore:
+      - ".gitignore"
+      - "docs/**"
+      - "README"
+      - "CREDITS.TXT"
+      - "COPYING_GLIB"
+      - "COPYING.LGPL2"
+      - "AUTHORS.TXT"
+      - "CHANGELOG"
+      - "COPYING"
+
+permissions:
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: bindings/dotnet/UnicornEngine
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get short sha
+        id: git_short_sha
+        run: echo "result=$(git rev-parse --short "${{ github.sha }}")" >> $GITHUB_OUTPUT
+
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Authenticate to Github Packages
+        run: dotnet nuget add source --username "${{ github.repository_owner }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+
+      - name: Package .NET bindings
+        run: |
+          [[ "${{ github.ref_name }}" == "master" ]] \
+            && dotnet pack -c Release \
+            || dotnet pack -c Release --version-suffix="${{ steps.git_short_sha.outputs.result }}"
+
+      - name: 📦 Publish to Github Packages
+        run: dotnet nuget push "bin/Release/UnicornEngine.Unicorn.*.nupkg" --source "github" --api-key "${{ secrets.GHPR_TOKEN }}"

--- a/.github/workflows/Nuget-publishing.yml
+++ b/.github/workflows/Nuget-publishing.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: '📤 Upload artifact'
         if: always()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           path: ./${{ matrix.config.artifact }}
           name: ${{ matrix.config.artifact }}
@@ -182,7 +182,7 @@ jobs:
 
       - name: '📤 Upload artifact'
         if: always()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           path: ./${{ matrix.config.artifact }}
           name: ${{ matrix.config.artifact }}
@@ -251,9 +251,9 @@ jobs:
         shell: 'script -q -e -c "bash {0}"'
         run: |
           if [ ${{ matrix.config.arch }} == 'x64' ]; then
-                sudo apt install -q -y libcmocka-dev ninja-build 
+                sudo apt install -q -y libcmocka-dev ninja-build
           else
-                export CFLAGS="-m32" LDFLAGS="-m32" LDFLAGS_STATIC="-m32" UNICORN_QEMU_FLAGS="--cpu=i386" 
+                export CFLAGS="-m32" LDFLAGS="-m32" LDFLAGS_STATIC="-m32" UNICORN_QEMU_FLAGS="--cpu=i386"
                 sudo dpkg --add-architecture i386
                 sudo apt install -q -y lib32ncurses-dev lib32z1-dev lib32gcc-9-dev libc6-dev-i386 gcc-multilib \
                   libcmocka-dev:i386 libcmocka0:i386 libc6:i386 libgcc-s1:i386 ninja-build
@@ -307,7 +307,7 @@ jobs:
 
       - name: '📤 Upload artifact'
         if: always()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           path: ./${{ matrix.config.artifact }}
           name: ${{ matrix.config.artifact }}
@@ -320,20 +320,20 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Download artifacts
+      - name: 🛠️ Download artifacts
         uses: actions/download-artifact@v3
         with:
           path: artifacts
 
-      - name: Extract artifacts
+      - name: 🛠️ Extract artifacts
         shell: python
         run: |
           import subprocess
           import os
-          
+
           artifactPath = os.path.join(os.getcwd(), "artifacts")
           bindingsPath = os.path.join(os.getcwd(), "bindings", "dotnet", "UnicornEngine")
-          
+
           ARTIFACT_CONFIG = {
             "ubuntu-cmake-aarch64.7z": {
               "sourceDir": "lib/",
@@ -372,11 +372,11 @@ jobs:
               "destFile": "unicorn.dll"
             }
           }
-          
+
           if len(os.listdir(artifactPath)) < len(ARTIFACT_CONFIG.keys()):
             print("Some artifacts are missing. Aborting.")
             exit(1)
-          
+
           for artifact in os.listdir(artifactPath):
             if artifact in ARTIFACT_CONFIG.keys():
               print("Working on:", artifact)
@@ -384,20 +384,20 @@ jobs:
               destDir = os.path.join(bindingsPath, config["destDir"])
               print("Creating dir:", destDir)
               os.makedirs(destDir, exist_ok=True)
-              
+
               print(f"Extracting library from 7z file to: {config['destDir']}/{config['sourceFile']}")
               result = subprocess.run(["7z", "e", f"-o{destDir}/", os.path.join(artifactPath, artifact), f"{config['sourceDir']}{config['sourceFile']}"])
               result.check_returncode()
-              
+
               if config["sourceFile"] != config["destFile"]:
                 output = subprocess.run(["ls", destDir], stdout=subprocess.PIPE)
                 sourceFile = output.stdout.decode().strip()
                 print(f"Renaming {sourceFile} to {config['destFile']}")
                 os.rename(os.path.join(destDir, sourceFile), os.path.join(destDir, config["destFile"]))
-          
+
           print("Done!")
 
-      - name: Get short sha
+      - name: 🛠️ Get short sha
         id: git_short_sha
         run: echo "result=$(git rev-parse --short "${{ github.sha }}")" >> $GITHUB_OUTPUT
 
@@ -405,21 +405,32 @@ jobs:
         with:
           dotnet-version: 6.0.x
 
-      - name: Authenticate to Github Packages
+      - name: 🛠️ Authenticate to Github Packages
         working-directory: bindings/dotnet/UnicornEngine
         run: dotnet nuget add source --username "${{ github.repository_owner }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text --name github "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
 
-      - name: List all native libraries
+      - name: 🛠️ List all native libraries
         working-directory: bindings/dotnet/UnicornEngine
         run: find ./runtimes -type f -print
 
-      - name: Package .NET distribution
+      - name: 🚧 Package .NET distribution
         working-directory: bindings/dotnet/UnicornEngine
         run: |
           [[ "${{ github.ref_name }}" == "master" ]] \
             && dotnet pack -c Release \
             || dotnet pack -c Release --version-suffix="${{ steps.git_short_sha.outputs.result }}"
 
+      - name: '📤 Upload artifact'
+        uses: actions/upload-artifact@v2
+        with:
+          path: ${{ github.workspace }}/bindings/dotnet/UnicornEngine/bin/Release/UnicornEngine.Unicorn.*.nupkg
+
       - name: 📦 Publish to Github Packages
         working-directory: bindings/dotnet/UnicornEngine
         run: dotnet nuget push "bin/Release/UnicornEngine.Unicorn.*.nupkg" --source "github" --api-key "${{ secrets.GHPR_TOKEN }}"
+
+      - name: 📦 Publish Nuget package
+        working-directory: bindings/dotnet/UnicornEngine
+        run: dotnet nuget push "bin/Release/UnicornEngine.Unicorn.*.nupkg" -k "$NUGET_AUTH_TOKEN" -s https://api.nuget.org/v3/index.json
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.NUGET_KEY }}

--- a/.github/workflows/Nuget-publishing.yml
+++ b/.github/workflows/Nuget-publishing.yml
@@ -416,7 +416,7 @@ jobs:
       - name: Package .NET distribution
         working-directory: bindings/dotnet/UnicornEngine
         run: |
-          [[ "${{ github.event.workflow_run.head_branch }}" == "master" ]] \
+          [[ "${{ github.ref_name }}" == "master" ]] \
             && dotnet pack -c Release \
             || dotnet pack -c Release --version-suffix="${{ steps.git_short_sha.outputs.result }}"
 

--- a/.github/workflows/Nuget-publishing.yml
+++ b/.github/workflows/Nuget-publishing.yml
@@ -107,7 +107,7 @@ jobs:
               console.log(`Unzipping: /tmp/${artifact.name}.zip`);            
               await exec.exec("unzip", [`/tmp/${artifact.name}.zip`]);
               console.log(`Extracting library from 7z file to: ${destDir}${sourceFile}`);
-              await exec.exec("7z", ["e", "-o", destDir, `/tmp/${artifact.name}`, `${sourceDir}${sourceFile}`], options);
+              await exec.exec("7z", ["e", `-o${destDir}`, `/tmp/${artifact.name}`, `${sourceDir}${sourceFile}`], options);
               if (sourceFile != destFile) {
                 console.log(`Renaming library to: ${destFile}`);
                 await exec.exec("mv", [`${destDir}/${sourceFile}`, `${destDir}/${destFile}`], options);

--- a/bindings/const_generator.py
+++ b/bindings/const_generator.py
@@ -90,10 +90,10 @@ template = {
             'comment_close': '',
         },
     'dotnet': {
-            'header': "// For Unicorn Engine. AUTO-GENERATED FILE, DO NOT EDIT\n\nnamespace UnicornManaged.Const\n\nopen System\n\n[<AutoOpen>]\nmodule %s =\n",
+            'header': "// For Unicorn Engine. AUTO-GENERATED FILE, DO NOT EDIT\n\nnamespace UnicornEngine.Const\n\nopen System\n\n[<AutoOpen>]\nmodule %s =\n",
             'footer': "\n",
             'line_format': '    let UC_%s = %s\n',
-            'out_file': os.path.join('dotnet', 'UnicornManaged', 'Const', '%s.fs'),
+            'out_file': os.path.join('dotnet', 'UnicornEngine', 'Const', '%s.fs'),
             # prefixes for constant filenames of all archs - case sensitive
             'arm.h': 'Arm',
             'arm64.h': 'Arm64',

--- a/bindings/dotnet/UnicornDotNet.sln
+++ b/bindings/dotnet/UnicornDotNet.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnicornSamples", "UnicornSamples\UnicornSamples.csproj", "{B80B5987-1E24-4309-8BF9-C4F91270F21C}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "UnicornManaged", "UnicornManaged\UnicornManaged.fsproj", "{0C21F1C1-2725-4A46-9022-1905F85822A5}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "UnicornEngine", "UnicornEngine\UnicornEngine.fsproj", "{0C21F1C1-2725-4A46-9022-1905F85822A5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/bindings/dotnet/UnicornEngine/Binding/BindingFactory.fs
+++ b/bindings/dotnet/UnicornEngine/Binding/BindingFactory.fs
@@ -1,4 +1,4 @@
-﻿namespace UnicornManaged.Binding
+﻿namespace UnicornEngine.Binding
 
 
 module BindingFactory =

--- a/bindings/dotnet/UnicornEngine/Binding/IBinding.fs
+++ b/bindings/dotnet/UnicornEngine/Binding/IBinding.fs
@@ -1,4 +1,4 @@
-﻿namespace UnicornManaged.Binding
+﻿namespace UnicornEngine.Binding
 
 open System
 

--- a/bindings/dotnet/UnicornEngine/Binding/MockBinding.fs
+++ b/bindings/dotnet/UnicornEngine/Binding/MockBinding.fs
@@ -1,4 +1,4 @@
-﻿namespace UnicornManaged.Binding
+﻿namespace UnicornEngine.Binding
 
 open System
 

--- a/bindings/dotnet/UnicornEngine/Binding/NativeBinding.fs
+++ b/bindings/dotnet/UnicornEngine/Binding/NativeBinding.fs
@@ -1,4 +1,4 @@
-﻿namespace UnicornManaged.Binding
+﻿namespace UnicornEngine.Binding
 
 open System
 open System.Runtime.InteropServices

--- a/bindings/dotnet/UnicornEngine/Const/Arm.fs
+++ b/bindings/dotnet/UnicornEngine/Const/Arm.fs
@@ -1,6 +1,6 @@
 // For Unicorn Engine. AUTO-GENERATED FILE, DO NOT EDIT
 
-namespace UnicornManaged.Const
+namespace UnicornEngine.Const
 
 open System
 

--- a/bindings/dotnet/UnicornEngine/Const/Arm64.fs
+++ b/bindings/dotnet/UnicornEngine/Const/Arm64.fs
@@ -1,6 +1,6 @@
 // For Unicorn Engine. AUTO-GENERATED FILE, DO NOT EDIT
 
-namespace UnicornManaged.Const
+namespace UnicornEngine.Const
 
 open System
 

--- a/bindings/dotnet/UnicornEngine/Const/Common.fs
+++ b/bindings/dotnet/UnicornEngine/Const/Common.fs
@@ -1,6 +1,6 @@
 // For Unicorn Engine. AUTO-GENERATED FILE, DO NOT EDIT
 
-namespace UnicornManaged.Const
+namespace UnicornEngine.Const
 
 open System
 

--- a/bindings/dotnet/UnicornEngine/Const/M68k.fs
+++ b/bindings/dotnet/UnicornEngine/Const/M68k.fs
@@ -1,6 +1,6 @@
 // For Unicorn Engine. AUTO-GENERATED FILE, DO NOT EDIT
 
-namespace UnicornManaged.Const
+namespace UnicornEngine.Const
 
 open System
 

--- a/bindings/dotnet/UnicornEngine/Const/Mips.fs
+++ b/bindings/dotnet/UnicornEngine/Const/Mips.fs
@@ -1,6 +1,6 @@
 // For Unicorn Engine. AUTO-GENERATED FILE, DO NOT EDIT
 
-namespace UnicornManaged.Const
+namespace UnicornEngine.Const
 
 open System
 

--- a/bindings/dotnet/UnicornEngine/Const/Ppc.fs
+++ b/bindings/dotnet/UnicornEngine/Const/Ppc.fs
@@ -1,6 +1,6 @@
 // For Unicorn Engine. AUTO-GENERATED FILE, DO NOT EDIT
 
-namespace UnicornManaged.Const
+namespace UnicornEngine.Const
 
 open System
 

--- a/bindings/dotnet/UnicornEngine/Const/Riscv.fs
+++ b/bindings/dotnet/UnicornEngine/Const/Riscv.fs
@@ -1,6 +1,6 @@
 // For Unicorn Engine. AUTO-GENERATED FILE, DO NOT EDIT
 
-namespace UnicornManaged.Const
+namespace UnicornEngine.Const
 
 open System
 

--- a/bindings/dotnet/UnicornEngine/Const/S390x.fs
+++ b/bindings/dotnet/UnicornEngine/Const/S390x.fs
@@ -1,6 +1,6 @@
 // For Unicorn Engine. AUTO-GENERATED FILE, DO NOT EDIT
 
-namespace UnicornManaged.Const
+namespace UnicornEngine.Const
 
 open System
 

--- a/bindings/dotnet/UnicornEngine/Const/Sparc.fs
+++ b/bindings/dotnet/UnicornEngine/Const/Sparc.fs
@@ -1,6 +1,6 @@
 // For Unicorn Engine. AUTO-GENERATED FILE, DO NOT EDIT
 
-namespace UnicornManaged.Const
+namespace UnicornEngine.Const
 
 open System
 

--- a/bindings/dotnet/UnicornEngine/Const/TriCore.fs
+++ b/bindings/dotnet/UnicornEngine/Const/TriCore.fs
@@ -1,6 +1,6 @@
 // For Unicorn Engine. AUTO-GENERATED FILE, DO NOT EDIT
 
-namespace UnicornManaged.Const
+namespace UnicornEngine.Const
 
 open System
 

--- a/bindings/dotnet/UnicornEngine/Const/X86.fs
+++ b/bindings/dotnet/UnicornEngine/Const/X86.fs
@@ -1,6 +1,6 @@
 // For Unicorn Engine. AUTO-GENERATED FILE, DO NOT EDIT
 
-namespace UnicornManaged.Const
+namespace UnicornEngine.Const
 
 open System
 

--- a/bindings/dotnet/UnicornEngine/ConvertUtility.fs
+++ b/bindings/dotnet/UnicornEngine/ConvertUtility.fs
@@ -1,4 +1,4 @@
-﻿namespace UnicornManaged
+﻿namespace UnicornEngine
 
 open System
 

--- a/bindings/dotnet/UnicornEngine/InternalHooks.fs
+++ b/bindings/dotnet/UnicornEngine/InternalHooks.fs
@@ -1,4 +1,4 @@
-﻿namespace UnicornManaged
+﻿namespace UnicornEngine
 
 open System
 open System.Runtime.InteropServices

--- a/bindings/dotnet/UnicornEngine/Unicorn.fs
+++ b/bindings/dotnet/UnicornEngine/Unicorn.fs
@@ -1,11 +1,11 @@
-﻿namespace UnicornManaged
+﻿namespace UnicornEngine
 
 open System
 open System.Collections.Generic
 open System.Runtime.InteropServices
 open System.Linq
-open UnicornManaged.Const
-open UnicornManaged.Binding
+open UnicornEngine.Const
+open UnicornEngine.Binding
 
 // exported hooks
 type CodeHook = delegate of Unicorn * Int64 * Int32 * Object -> unit

--- a/bindings/dotnet/UnicornEngine/UnicornEngine.fsproj
+++ b/bindings/dotnet/UnicornEngine/UnicornEngine.fsproj
@@ -42,4 +42,8 @@
     <Compile Include="ConvertUtility.fs" />
     <Compile Include="Unicorn.fs" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="runtimes\**" PackagePath="runtimes" Visible="false" />
+  </ItemGroup>
 </Project>

--- a/bindings/dotnet/UnicornEngine/UnicornEngine.fsproj
+++ b/bindings/dotnet/UnicornEngine/UnicornEngine.fsproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <RootNamespace>UnicornManaged</RootNamespace>
-    <AssemblyName>UnicornManaged</AssemblyName>
+    <PackageId>UnicornEngine.Unicorn</PackageId>
+    <Authors>UnicornEngine</Authors>
     <Copyright>Copyright © Antonio Parata 2016</Copyright>
     <RepositoryUrl>https://github.com/unicorn-engine/unicorn</RepositoryUrl>
-    <Version>2.0.0</Version>
+    <PackageDescription>.NET bindings for unicorn</PackageDescription>
+    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <ProjectGuid>0c21f1c1-2725-4a46-9022-1905f85822a5</ProjectGuid>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -13,6 +15,10 @@
 
   <PropertyGroup>
     <WarningLevel>3</WarningLevel>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugType>none</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/bindings/dotnet/UnicornEngine/UnicornEngineException.fs
+++ b/bindings/dotnet/UnicornEngine/UnicornEngineException.fs
@@ -1,4 +1,4 @@
-﻿namespace UnicornManaged
+﻿namespace UnicornEngine
 
 open System
 

--- a/bindings/dotnet/UnicornSamples/ShellcodeSample.cs
+++ b/bindings/dotnet/UnicornSamples/ShellcodeSample.cs
@@ -3,8 +3,8 @@ using Gee.External.Capstone.X86;
 using System;
 using System.Diagnostics;
 using System.Text;
-using UnicornManaged;
-using UnicornManaged.Const;
+using UnicornEngine;
+using UnicornEngine.Const;
 
 namespace UnicornSamples
 {

--- a/bindings/dotnet/UnicornSamples/UnicornSamples.csproj
+++ b/bindings/dotnet/UnicornSamples/UnicornSamples.csproj
@@ -17,9 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\UnicornManaged\UnicornManaged.fsproj">
+    <ProjectReference Include="..\UnicornEngine\UnicornEngine.fsproj">
       <Project>{0c21f1c1-2725-4a46-9022-1905f85822a5}</Project>
-      <Name>UnicornManaged</Name>
+      <Name>UnicornEngine</Name>
     </ProjectReference>
   </ItemGroup>
   

--- a/bindings/dotnet/UnicornSamples/X86Sample32.cs
+++ b/bindings/dotnet/UnicornSamples/X86Sample32.cs
@@ -3,8 +3,8 @@ using Gee.External.Capstone.X86;
 using System;
 using System.Diagnostics;
 using System.Text;
-using UnicornManaged;
-using UnicornManaged.Const;
+using UnicornEngine;
+using UnicornEngine.Const;
 
 namespace UnicornSamples
 {


### PR DESCRIPTION
This PR makes a few changes to the dotnet bindings, so it can be packaged as a Nuget.
Additionally it adds a new workflow to automatically publish the .NET bindings as a Nuget package if they changed in `dev` or `master`.

Packages created from `dev` get a suffix, this way they are marked as prereleases and don't change the latest release.

At the moment this workflow only publishes to Github Packages, but this could be changed to also publish to Nuget.org if you want.
You can read more about the necessary steps [here](https://learn.microsoft.com/en-us/nuget/nuget-org/publish-a-package).

To actually make the workflow work a secret [API key](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-nuget-registry#authenticating-to-github-packages) (`GHPR_TOKEN`) needs to be added. This could be a PAT or the access token of a Github app.

Since this Nuget package will only include the bindings and not the actual binaries, I have a few questions I'd like to ask:

- Should the binaries be included here as well, or should a separate Nuget package be used to include them? A separate package could also declare a dependency on the first one.
- If you want to include the binaries somehow would you prefer one Nuget package for all architectures, or separate packages for each one? This might be a lot harder to do, but also sounds like the best way to reduce file/download size.

Nuget people seem to be happy as long as we only include [one assembly](https://learn.microsoft.com/en-us/nuget/create-packages/select-assemblies-referenced-by-projects#recommended-one-assembly-per-package) in each package.