### PR TITLE
add riscv constants to python binding module

### DIFF
--- a/bindings/python/unicorn/__init__.py
+++ b/bindings/python/unicorn/__init__.py
@@ -1,4 +1,4 @@
 # Unicorn Python bindings, by Nguyen Anh Quynnh <aquynh@gmail.com>
-from . import arm_const, arm64_const, mips_const, sparc_const, m68k_const, x86_const
+from . import arm_const, arm64_const, mips_const, sparc_const, m68k_const, x86_const, riscv_const
 from .unicorn_const import *
 from .unicorn import Uc, uc_version, uc_arch_supported, version_bind, debug, UcError, __version__


### PR DESCRIPTION
The riscv constants have not been added to the python binding module yet. They thus cannot be imported and used properly.