### PR TITLE
Remove usage of UC_INIT

### DIFF
--- a/uc.c
+++ b/uc.c
@@ -189,14 +189,6 @@ bool uc_arch_supported(uc_arch arch)
     }
 }
 
-#define UC_INIT(uc)                                                            \
-    if (unlikely(!(uc)->init_done)) {                                          \
-        int __init_ret = uc_init(uc);                                          \
-        if (unlikely(__init_ret != UC_ERR_OK)) {                               \
-            return __init_ret;                                                 \
-        }                                                                      \
-    }
-
 static gint uc_exits_cmp(gconstpointer a, gconstpointer b, gpointer user_data)
 {
     uint64_t lhs = *((uint64_t *)a);
@@ -419,6 +411,12 @@ uc_err uc_open(uc_arch arch, uc_mode mode, uc_engine **result)
         uc->init_done = false;
         uc->cpu_model = INT_MAX; // INT_MAX means the default cpu model.
 
+        int init_res = uc_init(uc);
+        if (init_res != UC_ERR_OK) { 
+            free(uc);
+            return init_res; 
+        }
+
         *result = uc;
 
         return UC_ERR_OK;
@@ -504,8 +502,6 @@ uc_err uc_reg_read_batch(uc_engine *uc, int *ids, void **vals, int count)
 {
     int ret = UC_ERR_OK;
 
-    UC_INIT(uc);
-
     if (uc->reg_read) {
         ret = uc->reg_read(uc, (unsigned int *)ids, vals, count);
     } else {
@@ -520,8 +516,6 @@ uc_err uc_reg_write_batch(uc_engine *uc, int *ids, void *const *vals, int count)
 {
     int ret = UC_ERR_OK;
 
-    UC_INIT(uc);
-
     if (uc->reg_write) {
         ret = uc->reg_write(uc, (unsigned int *)ids, vals, count);
     } else {
@@ -534,14 +528,12 @@ uc_err uc_reg_write_batch(uc_engine *uc, int *ids, void *const *vals, int count)
 UNICORN_EXPORT
 uc_err uc_reg_read(uc_engine *uc, int regid, void *value)
 {
-    UC_INIT(uc);
     return uc_reg_read_batch(uc, &regid, &value, 1);
 }
 
 UNICORN_EXPORT
 uc_err uc_reg_write(uc_engine *uc, int regid, const void *value)
 {
-    UC_INIT(uc);
     return uc_reg_write_batch(uc, &regid, (void *const *)&value, 1);
 }
 
@@ -570,8 +562,6 @@ uc_err uc_mem_read(uc_engine *uc, uint64_t address, void *_bytes, size_t size)
 {
     size_t count = 0, len;
     uint8_t *bytes = _bytes;
-
-    UC_INIT(uc);
 
     // qemu cpu_physical_memory_rw() size is an int
     if (size > INT_MAX)
@@ -615,8 +605,6 @@ uc_err uc_mem_write(uc_engine *uc, uint64_t address, const void *_bytes,
 {
     size_t count = 0, len;
     const uint8_t *bytes = _bytes;
-
-    UC_INIT(uc);
 
     // qemu cpu_physical_memory_rw() size is an int
     if (size > INT_MAX)
@@ -743,8 +731,6 @@ uc_err uc_emu_start(uc_engine *uc, uint64_t begin, uint64_t until,
     uc->size_recur_mem = 0;
     uc->timed_out = false;
     uc->first_tb = true;
-
-    UC_INIT(uc);
 
     // Advance the nested levels. We must decrease the level count by one when
     // we return from uc_emu_start.
@@ -906,8 +892,6 @@ uc_err uc_emu_start(uc_engine *uc, uint64_t begin, uint64_t until,
 UNICORN_EXPORT
 uc_err uc_emu_stop(uc_engine *uc)
 {
-    UC_INIT(uc);
-
     if (uc->emulation_done) {
         return UC_ERR_OK;
     }
@@ -1049,8 +1033,6 @@ uc_err uc_mem_map(uc_engine *uc, uint64_t address, size_t size, uint32_t perms)
 {
     uc_err res;
 
-    UC_INIT(uc);
-
     if (uc->mem_redirect) {
         address = uc->mem_redirect(address);
     }
@@ -1069,8 +1051,6 @@ uc_err uc_mem_map_ptr(uc_engine *uc, uint64_t address, size_t size,
                       uint32_t perms, void *ptr)
 {
     uc_err res;
-
-    UC_INIT(uc);
 
     if (ptr == NULL) {
         return UC_ERR_ARG;
@@ -1095,8 +1075,6 @@ uc_err uc_mmio_map(uc_engine *uc, uint64_t address, size_t size,
                    uc_cb_mmio_write_t write_cb, void *user_data_write)
 {
     uc_err res;
-
-    UC_INIT(uc);
 
     if (uc->mem_redirect) {
         address = uc->mem_redirect(address);
@@ -1387,8 +1365,6 @@ uc_err uc_mem_protect(struct uc_struct *uc, uint64_t address, size_t size,
     size_t count, len;
     bool remove_exec = false;
 
-    UC_INIT(uc);
-
     if (size == 0) {
         // trivial case, no change
         return UC_ERR_OK;
@@ -1471,8 +1447,6 @@ uc_err uc_mem_unmap(struct uc_struct *uc, uint64_t address, size_t size)
     MemoryRegion *mr;
     uint64_t addr;
     size_t count, len;
-
-    UC_INIT(uc);
 
     if (size == 0) {
         // nothing to unmap
@@ -1565,8 +1539,6 @@ uc_err uc_hook_add(uc_engine *uc, uc_hook *hh, int type, void *callback,
 {
     int ret = UC_ERR_OK;
     int i = 0;
-
-    UC_INIT(uc);
 
     struct hook *hook = calloc(1, sizeof(struct hook));
     if (hook == NULL) {
@@ -1681,8 +1653,6 @@ uc_err uc_hook_del(uc_engine *uc, uc_hook hh)
 {
     int i;
     struct hook *hook = (struct hook *)hh;
-
-    UC_INIT(uc);
 
     // we can't dereference hook->type if hook is invalid
     // so for now we need to iterate over all possible types to remove the hook
@@ -1804,8 +1774,6 @@ uc_err uc_mem_regions(uc_engine *uc, uc_mem_region **regions, uint32_t *count)
     uint32_t i;
     uc_mem_region *r = NULL;
 
-    UC_INIT(uc);
-
     *count = uc->mapped_block_count;
 
     if (*count) {
@@ -1830,8 +1798,6 @@ uc_err uc_mem_regions(uc_engine *uc, uc_mem_region **regions, uint32_t *count)
 UNICORN_EXPORT
 uc_err uc_query(uc_engine *uc, uc_query_type type, size_t *result)
 {
-    UC_INIT(uc);
-
     switch (type) {
     default:
         return UC_ERR_ARG;
@@ -1867,8 +1833,6 @@ uc_err uc_context_alloc(uc_engine *uc, uc_context **context)
     struct uc_context **_context = context;
     size_t size = uc_context_size(uc);
 
-    UC_INIT(uc);
-
     *_context = g_malloc(size);
     if (*_context) {
         (*_context)->context_size = size - sizeof(uc_context);
@@ -1890,8 +1854,6 @@ uc_err uc_free(void *mem)
 UNICORN_EXPORT
 size_t uc_context_size(uc_engine *uc)
 {
-    UC_INIT(uc);
-
     if (!uc->context_size) {
         // return the total size of struct uc_context
         return sizeof(uc_context) + uc->cpu_context_size;
@@ -1903,8 +1865,6 @@ size_t uc_context_size(uc_engine *uc)
 UNICORN_EXPORT
 uc_err uc_context_save(uc_engine *uc, uc_context *context)
 {
-    UC_INIT(uc);
-
     if (!uc->context_save) {
         memcpy(context->data, uc->cpu->env_ptr, context->context_size);
         return UC_ERR_OK;
@@ -2080,8 +2040,6 @@ uc_err uc_context_reg_read_batch(uc_context *ctx, int *ids, void **vals,
 UNICORN_EXPORT
 uc_err uc_context_restore(uc_engine *uc, uc_context *context)
 {
-    UC_INIT(uc);
-
     if (!uc->context_restore) {
         memcpy(uc->cpu->env_ptr, context->data, context->context_size);
         return UC_ERR_OK;
@@ -2093,7 +2051,6 @@ uc_err uc_context_restore(uc_engine *uc, uc_context *context)
 UNICORN_EXPORT
 uc_err uc_context_free(uc_context *context)
 {
-
     return uc_free(context);
 }
 
@@ -2158,8 +2115,6 @@ uc_err uc_ctl(uc_engine *uc, uc_control_type control, ...)
     case UC_CTL_UC_PAGE_SIZE: {
         if (rw == UC_CTL_IO_READ) {
 
-            UC_INIT(uc);
-
             uint32_t *page_size = va_arg(args, uint32_t *);
             *page_size = uc->target_page_size;
         } else {
@@ -2205,8 +2160,6 @@ uc_err uc_ctl(uc_engine *uc, uc_control_type control, ...)
 
     case UC_CTL_UC_EXITS_CNT: {
 
-        UC_INIT(uc);
-
         if (!uc->use_exits) {
             err = UC_ERR_ARG;
         } else if (rw == UC_CTL_IO_READ) {
@@ -2219,8 +2172,6 @@ uc_err uc_ctl(uc_engine *uc, uc_control_type control, ...)
     }
 
     case UC_CTL_UC_EXITS: {
-
-        UC_INIT(uc);
 
         if (!uc->use_exits) {
             err = UC_ERR_ARG;
@@ -2253,8 +2204,6 @@ uc_err uc_ctl(uc_engine *uc, uc_control_type control, ...)
 
     case UC_CTL_CPU_MODEL: {
         if (rw == UC_CTL_IO_READ) {
-
-            UC_INIT(uc);
 
             int *model = va_arg(args, int *);
             *model = uc->cpu_model;
@@ -2354,8 +2303,6 @@ uc_err uc_ctl(uc_engine *uc, uc_control_type control, ...)
 
     case UC_CTL_TB_REQUEST_CACHE: {
 
-        UC_INIT(uc);
-
         if (rw == UC_CTL_IO_READ_WRITE) {
             uint64_t addr = va_arg(args, uint64_t);
             uc_tb *tb = va_arg(args, uc_tb *);
@@ -2367,8 +2314,6 @@ uc_err uc_ctl(uc_engine *uc, uc_control_type control, ...)
     }
 
     case UC_CTL_TB_REMOVE_CACHE: {
-
-        UC_INIT(uc);
 
         if (rw == UC_CTL_IO_WRITE) {
             uint64_t addr = va_arg(args, uint64_t);
@@ -2385,8 +2330,6 @@ uc_err uc_ctl(uc_engine *uc, uc_control_type control, ...)
     }
 
     case UC_CTL_TB_FLUSH:
-
-        UC_INIT(uc);
 
         if (rw == UC_CTL_IO_WRITE) {
             uc->tb_flush(uc);


### PR DESCRIPTION
In my opinion the code makes little sense the way it is, the state is only initialized once and the user is required to call uc_open in where we can do the initialization. There is currently nothing that would influence the initialization between uc_open and any subsequent API calls that had UC_INIT. This PR eliminates quite a few lines without actually changing anything API/ABI wise.