### PR TITLE
Allow user to set TCG buffer size

### DIFF
--- a/include/uc_priv.h
+++ b/include/uc_priv.h
@@ -315,6 +315,7 @@ struct uc_struct {
     /* qemu/exec-vary.c */
     TargetPageBits *init_target_page;
     int target_bits; // User defined page bits by uc_ctl
+    unsigned long tcg_buffer_size; // User defined tcg buffer size by uc_ctl
     int cpu_model;
     BounceBuffer bounce;                // qemu/cpu-exec.c
     volatile sig_atomic_t exit_request; // qemu/cpu-exec.c

--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -536,7 +536,11 @@ typedef enum uc_control_type {
     UC_CTL_TB_REMOVE_CACHE,
     // Invalidate all translation blocks.
     // No arguments.
-    UC_CTL_TB_FLUSH
+    UC_CTL_TB_FLUSH,
+    // Current buffer size for TCG
+    // Write: @args = (unsigned long)
+    // Read: @args = (unsigned long*)
+    UC_CTL_TCG_BUFFER_SIZE,
 
 } uc_control_type;
 
@@ -612,6 +616,10 @@ See sample_ctl.c for a detailed example.
 #define uc_ctl_request_cache(uc, address, tb)                                  \
     uc_ctl(uc, UC_CTL_READ_WRITE(UC_CTL_TB_REQUEST_CACHE, 2), (address), (tb))
 #define uc_ctl_flush_tlb(uc) uc_ctl(uc, UC_CTL_WRITE(UC_CTL_TB_FLUSH, 0))
+#define uc_ctl_get_tcg_buffer_size(uc, size)                                   \
+    uc_ctl(uc, UC_CTL_READ(UC_CTL_TCG_BUFFER_SIZE, 1), (size))
+#define uc_ctl_set_tcg_buffer_size(uc, size)                                   \
+    uc_ctl(uc, UC_CTL_WRITE(UC_CTL_TCG_BUFFER_SIZE, 1), (size))
 // Opaque storage for CPU context, used with uc_context_*()
 struct uc_context;
 typedef struct uc_context uc_context;

--- a/qemu/softmmu/vl.c
+++ b/qemu/softmmu/vl.c
@@ -49,8 +49,8 @@ int machine_initialize(struct uc_struct *uc)
 
     uc->target_page(uc);
 
-    /* Init tcg. use DEFAULT_CODE_GEN_BUFFER_SIZE. */
-    uc->tcg_exec_init(uc, 0);
+    /* Init tcg. when tcg_buffer_size is 0 it will use DEFAULT_CODE_GEN_BUFFER_SIZE. */
+    uc->tcg_exec_init(uc, uc->tcg_buffer_size);
 
     /* Init cpu. use default cpu_model. */
     return uc->cpus_init(uc, NULL);

--- a/uc.c
+++ b/uc.c
@@ -2395,6 +2395,17 @@ uc_err uc_ctl(uc_engine *uc, uc_control_type control, ...)
         }
         break;
 
+    case UC_CTL_TCG_BUFFER_SIZE:
+        
+        if (rw == UC_CTL_IO_WRITE) {
+            unsigned long size = va_arg(args, unsigned long);
+            uc->tcg_buffer_size = size;
+        } else {
+            unsigned long *size = va_arg(args, unsigned long *);
+            *size = uc->tcg_buffer_size;
+        }
+        break;
+
     default:
         err = UC_ERR_ARG;
         break;


### PR DESCRIPTION
This partially solves the issue of #1704. The default of 1GiB makes way more sense when an actual VM is used but for emulating shellcode having 1GiB is overkill.