### PR TITLE
Add arch list feature control in Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,16 @@ cmake = { version = "0.1" }
 pkg-config = { version = "0.3" }
 
 [features]
-default = []
+default = ["arch_all"]
 dynamic_linkage = []
+arch_all = ["arch_x86", "arch_arm", "arch_aarch64", "arch_riscv", "arch_mips", "arch_sparc", "arch_m68k", "arch_ppc", "arch_s390x", "arch_tricore"]
+arch_x86 = []
+arch_arm = []
+arch_aarch64 = []
+arch_riscv = []
+arch_mips = []
+arch_sparc = []
+arch_m68k = []
+arch_ppc = []
+arch_s390x = []
+arch_tricore = []

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -84,6 +84,43 @@ fn build_with_cmake() {
         config.generator("Ninja");
     }
 
+    let mut archs = String::new();
+
+    if std::env::var("CARGO_FEATURE_ARCH_X86").is_ok() {
+        archs.push_str("x86;");
+    }
+    if std::env::var("CARGO_FEATURE_ARCH_ARM").is_ok() {
+        archs.push_str("arm;");
+    }
+    if std::env::var("CARGO_FEATURE_ARCH_AARCH64").is_ok() {
+        archs.push_str("aarch64;");
+    }
+    if std::env::var("CARGO_FEATURE_ARCH_RISCV").is_ok() {
+        archs.push_str("riscv;");
+    }
+    if std::env::var("CARGO_FEATURE_ARCH_MIPS").is_ok() {
+        archs.push_str("mips;");
+    }
+    if std::env::var("CARGO_FEATURE_ARCH_SPARC").is_ok() {
+        archs.push_str("sparc;");
+    }
+    if std::env::var("CARGO_FEATURE_ARCH_M68K").is_ok() {
+        archs.push_str("m68k;");
+    }
+    if std::env::var("CARGO_FEATURE_ARCH_PPC").is_ok() {
+        archs.push_str("ppc;");
+    }
+    if std::env::var("CARGO_FEATURE_ARCH_S390X").is_ok() {
+        archs.push_str("s390x;");
+    }
+    if std::env::var("CARGO_FEATURE_ARCH_TRICORE").is_ok() {
+        archs.push_str("tricore;");
+    }
+
+    if !archs.is_empty() {
+        archs.pop();
+    }
+
     // need to clear build target and append "build" to the path because
     // unicorn's CMakeLists.txt doesn't properly support 'install', so we use
     // the build artifacts from the build directory, which cmake crate sets
@@ -91,6 +128,7 @@ fn build_with_cmake() {
     let dst = config
         .define("UNICORN_BUILD_TESTS", "OFF")
         .define("UNICORN_INSTALL", "OFF")
+        .define("UNICORN_ARCH", archs)
         .no_build_target(true)
         .build();
     println!(


### PR DESCRIPTION
In rust, it is supported to control the arch compilation list, and the default is to compile all.

#1748 