### PR TITLE
Fix warning and build error for ./setup.py

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -8,6 +8,7 @@ import subprocess
 import shutil
 import sys
 import platform
+import setuptools
 
 from distutils import log
 from distutils.core import setup


### PR DESCRIPTION
This fixes a warning when calling `./setup.py` directly:

```bash
/usr/lib/python3/dist-packages/_distutils_hack/__init__.py:18: UserWarning: Distutils was imported before Setuptools, but importing Setuptools also replaces the `distutils` module in `sys.modules`. This may lead to undesirable behaviors or errors. To avoid these issues, avoid using distutils directly, ensure that setuptools is installed in the traditional way (e.g. not an editable install), and/or make sure that setuptools is always imported before distutils.
```

This leads to an error down the line, installation seems to fail.

Pip installation still works without this fix, however.