### PR TITLE
Fix Rust binding memory leak

### DIFF
--- a/bindings/rust/src/ffi.rs
+++ b/bindings/rust/src/ffi.rs
@@ -199,7 +199,8 @@ pub extern "C" fn insn_in_hook_proxy<D, F>(
     port: u32,
     size: usize,
     user_data: *mut UcHook<D, F>,
-) where
+) -> u32
+where
     F: FnMut(&mut crate::Unicorn<D>, u32, usize) -> u32,
 {
     let user_data = unsafe { &mut *user_data };
@@ -207,7 +208,7 @@ pub extern "C" fn insn_in_hook_proxy<D, F>(
         inner: user_data.uc.upgrade().unwrap(),
     };
     debug_assert_eq!(uc, user_data_uc.get_handle());
-    (user_data.callback)(&mut user_data_uc, port, size);
+    (user_data.callback)(&mut user_data_uc, port, size)
 }
 
 pub extern "C" fn insn_invalid_hook_proxy<D, F>(uc: uc_handle, user_data: *mut UcHook<D, F>) -> bool

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -369,17 +369,13 @@ impl<'a, D> Unicorn<'a, D> {
         let mut read_data = read_callback.map(|c| {
             Box::new(ffi::UcHook {
                 callback: c,
-                uc: Unicorn {
-                    inner: self.inner.clone(),
-                },
+                uc: Rc::downgrade(&self.inner),
             })
         });
         let mut write_data = write_callback.map(|c| {
             Box::new(ffi::UcHook {
                 callback: c,
-                uc: Unicorn {
-                    inner: self.inner.clone(),
-                },
+                uc: Rc::downgrade(&self.inner),
             })
         });
 
@@ -586,7 +582,8 @@ impl<'a, D> Unicorn<'a, D> {
             return Err(uc_error::ARCH);
         }
 
-        let err: uc_error = unsafe { ffi::uc_reg_read(self.get_handle(), curr_reg_id, value.as_mut_ptr() as _) };
+        let err: uc_error =
+            unsafe { ffi::uc_reg_read(self.get_handle(), curr_reg_id, value.as_mut_ptr() as _) };
 
         if err == uc_error::OK {
             boxed = value.into_boxed_slice();
@@ -622,9 +619,7 @@ impl<'a, D> Unicorn<'a, D> {
         let mut hook_ptr = core::ptr::null_mut();
         let mut user_data = Box::new(ffi::UcHook {
             callback,
-            uc: Unicorn {
-                inner: self.inner.clone(),
-            },
+            uc: Rc::downgrade(&self.inner),
         });
 
         let err = unsafe {
@@ -654,9 +649,7 @@ impl<'a, D> Unicorn<'a, D> {
         let mut hook_ptr = core::ptr::null_mut();
         let mut user_data = Box::new(ffi::UcHook {
             callback,
-            uc: Unicorn {
-                inner: self.inner.clone(),
-            },
+            uc: Rc::downgrade(&self.inner),
         });
 
         let err = unsafe {
@@ -697,9 +690,7 @@ impl<'a, D> Unicorn<'a, D> {
         let mut hook_ptr = core::ptr::null_mut();
         let mut user_data = Box::new(ffi::UcHook {
             callback,
-            uc: Unicorn {
-                inner: self.inner.clone(),
-            },
+            uc: Rc::downgrade(&self.inner),
         });
 
         let err = unsafe {
@@ -730,9 +721,7 @@ impl<'a, D> Unicorn<'a, D> {
         let mut hook_ptr = core::ptr::null_mut();
         let mut user_data = Box::new(ffi::UcHook {
             callback,
-            uc: Unicorn {
-                inner: self.inner.clone(),
-            },
+            uc: Rc::downgrade(&self.inner),
         });
 
         let err = unsafe {
@@ -763,9 +752,7 @@ impl<'a, D> Unicorn<'a, D> {
         let mut hook_ptr = core::ptr::null_mut();
         let mut user_data = Box::new(ffi::UcHook {
             callback,
-            uc: Unicorn {
-                inner: self.inner.clone(),
-            },
+            uc: Rc::downgrade(&self.inner),
         });
 
         let err = unsafe {
@@ -796,9 +783,7 @@ impl<'a, D> Unicorn<'a, D> {
         let mut hook_ptr = core::ptr::null_mut();
         let mut user_data = Box::new(ffi::UcHook {
             callback,
-            uc: Unicorn {
-                inner: self.inner.clone(),
-            },
+            uc: Rc::downgrade(&self.inner),
         });
 
         let err = unsafe {
@@ -830,9 +815,7 @@ impl<'a, D> Unicorn<'a, D> {
         let mut hook_ptr = core::ptr::null_mut();
         let mut user_data = Box::new(ffi::UcHook {
             callback,
-            uc: Unicorn {
-                inner: self.inner.clone(),
-            },
+            uc: Rc::downgrade(&self.inner),
         });
 
         let err = unsafe {
@@ -870,9 +853,7 @@ impl<'a, D> Unicorn<'a, D> {
         let mut hook_ptr = core::ptr::null_mut();
         let mut user_data = Box::new(ffi::UcHook {
             callback,
-            uc: Unicorn {
-                inner: self.inner.clone(),
-            },
+            uc: Rc::downgrade(&self.inner),
         });
 
         let err = unsafe {


### PR DESCRIPTION
Fix https://github.com/unicorn-engine/unicorn/issues/1619 by using Weak references.
This works without unsafe, so it should not have the soundness issue of https://github.com/unicorn-engine/unicorn/pull/1632