### PR TITLE
rust only add mmio callback funktion, if callback is requested

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -388,12 +388,18 @@ impl<'a, D> Unicorn<'a, D> {
                 self.get_handle(),
                 address,
                 size,
-                ffi::mmio_read_callback_proxy::<D, R> as _,
+                match read_data {
+                    Some(_) => ffi::mmio_read_callback_proxy::<D, R> as _,
+                    None => ptr::null_mut(),
+                },
                 match read_data {
                     Some(ref mut d) => d.as_mut() as *mut _ as _,
                     None => ptr::null_mut(),
                 },
-                ffi::mmio_write_callback_proxy::<D, W> as _,
+                match write_data {
+                    Some(_) => ffi::mmio_write_callback_proxy::<D, W> as _,
+                    None => ptr::null_mut(),
+                },
                 match write_data {
                     Some(ref mut d) => d.as_mut() as *mut _ as _,
                     None => ptr::null_mut(),


### PR DESCRIPTION
The C function uc_mmio_map() allows to add seperate callback functions and userdata for read and write. When the callback functions are NULL unicorn don't try to call this functions.

Previous this patch, when i.e. read_callback was None the callback was set to mmio_read_callback_proxy and the userdata was set to NULL. On a callback the mmio_read_callback_proxy then tried to dereference the userdata and caused a segfault.

fixes #1762