### PR TITLE
Support ARM64 atomic instructions, workaround for PAC instructions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,16 @@
 This file details the changelog of Unicorn Engine.
 
 -------------------------------
+[Version 2.0.1.post1]: Nov 22nd, 2022
+
+This is a small release to complement the previous 2.0.1 release.
+
+Fix:
+
+- Fix the endianness detection in tests.
+- Fix the version number in CMakeLists.txt.
+
+-------------------------------
 [Version 2.0.1]: Nov 1st, 2022
 
 Unicorn2 makes the first step to [Debian packages](https://tracker.debian.org/pkg/unicorn-engine) and [vcpkg](https://github.com/microsoft/vcpkg/pull/26101)! Thanks @roehling and @LilyWangL !

--- a/qemu/target/arm/pauth_helper.c
+++ b/qemu/target/arm/pauth_helper.c
@@ -437,6 +437,11 @@ uint64_t HELPER(pacga)(CPUARMState *env, uint64_t x, uint64_t y)
 {
     uint64_t pac;
 
+    int el = arm_current_el(env);
+    if (!pauth_key_enabled(env, el, SCTLR_EnIB)) {
+        return x;
+    }
+
     pauth_check_trap(env, arm_current_el(env), GETPC());
     pac = pauth_computepac(x, y, env->keys.apga);
 
@@ -485,10 +490,20 @@ uint64_t HELPER(autdb)(CPUARMState *env, uint64_t x, uint64_t y)
 
 uint64_t HELPER(xpaci)(CPUARMState *env, uint64_t a)
 {
+    int el = arm_current_el(env);
+    if (!pauth_key_enabled(env, el, SCTLR_EnIB)) {
+        return a;
+    }
+
     return pauth_strip(env, a, false);
 }
 
 uint64_t HELPER(xpacd)(CPUARMState *env, uint64_t a)
 {
+    int el = arm_current_el(env);
+    if (!pauth_key_enabled(env, el, SCTLR_EnIB)) {
+        return a;
+    }
+
     return pauth_strip(env, a, true);
 }

--- a/qemu/target/arm/translate-a64.c
+++ b/qemu/target/arm/translate-a64.c
@@ -5207,152 +5207,152 @@ static void disas_data_proc_1src(DisasContext *s, uint32_t insn)
         handle_cls(s, sf, rn, rd);
         break;
     case MAP(1, 0x01, 0x00): /* PACIA */
-        if (s->pauth_active) {
-            tcg_rd = cpu_reg(s, rd);
-            gen_helper_pacia(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, cpu_reg_sp(s, rn));
-        } else if (!dc_isar_feature(aa64_pauth, s)) {
-            goto do_unallocated;
-        }
+        // if (s->pauth_active) {
+        tcg_rd = cpu_reg(s, rd);
+        gen_helper_pacia(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, cpu_reg_sp(s, rn));
+        // } else if (!dc_isar_feature(aa64_pauth, s)) {
+        //     goto do_unallocated;
+        // }
         break;
     case MAP(1, 0x01, 0x01): /* PACIB */
-        if (s->pauth_active) {
-            tcg_rd = cpu_reg(s, rd);
-            gen_helper_pacib(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, cpu_reg_sp(s, rn));
-        } else if (!dc_isar_feature(aa64_pauth, s)) {
-            goto do_unallocated;
-        }
+        // if (s->pauth_active) {
+        tcg_rd = cpu_reg(s, rd);
+        gen_helper_pacib(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, cpu_reg_sp(s, rn));
+        // } else if (!dc_isar_feature(aa64_pauth, s)) {
+        //     goto do_unallocated;
+        // }
         break;
     case MAP(1, 0x01, 0x02): /* PACDA */
-        if (s->pauth_active) {
-            tcg_rd = cpu_reg(s, rd);
-            gen_helper_pacda(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, cpu_reg_sp(s, rn));
-        } else if (!dc_isar_feature(aa64_pauth, s)) {
-            goto do_unallocated;
-        }
+        // if (s->pauth_active) {
+        tcg_rd = cpu_reg(s, rd);
+        gen_helper_pacda(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, cpu_reg_sp(s, rn));
+        // } else if (!dc_isar_feature(aa64_pauth, s)) {
+        //     goto do_unallocated;
+        // }
         break;
     case MAP(1, 0x01, 0x03): /* PACDB */
-        if (s->pauth_active) {
-            tcg_rd = cpu_reg(s, rd);
-            gen_helper_pacdb(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, cpu_reg_sp(s, rn));
-        } else if (!dc_isar_feature(aa64_pauth, s)) {
-            goto do_unallocated;
-        }
+        // if (s->pauth_active) {
+        tcg_rd = cpu_reg(s, rd);
+        gen_helper_pacdb(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, cpu_reg_sp(s, rn));
+        // } else if (!dc_isar_feature(aa64_pauth, s)) {
+        //     goto do_unallocated;
+        // }
         break;
     case MAP(1, 0x01, 0x04): /* AUTIA */
-        if (s->pauth_active) {
-            tcg_rd = cpu_reg(s, rd);
-            gen_helper_autia(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, cpu_reg_sp(s, rn));
-        } else if (!dc_isar_feature(aa64_pauth, s)) {
-            goto do_unallocated;
-        }
+        // if (s->pauth_active) {
+        tcg_rd = cpu_reg(s, rd);
+        gen_helper_autia(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, cpu_reg_sp(s, rn));
+        // } else if (!dc_isar_feature(aa64_pauth, s)) {
+        //     goto do_unallocated;
+        // }
         break;
     case MAP(1, 0x01, 0x05): /* AUTIB */
-        if (s->pauth_active) {
-            tcg_rd = cpu_reg(s, rd);
-            gen_helper_autib(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, cpu_reg_sp(s, rn));
-        } else if (!dc_isar_feature(aa64_pauth, s)) {
-            goto do_unallocated;
-        }
+        // if (s->pauth_active) {
+        tcg_rd = cpu_reg(s, rd);
+        gen_helper_autib(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, cpu_reg_sp(s, rn));
+        // } else if (!dc_isar_feature(aa64_pauth, s)) {
+        //     goto do_unallocated;
+        // }
         break;
     case MAP(1, 0x01, 0x06): /* AUTDA */
-        if (s->pauth_active) {
-            tcg_rd = cpu_reg(s, rd);
-            gen_helper_autda(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, cpu_reg_sp(s, rn));
-        } else if (!dc_isar_feature(aa64_pauth, s)) {
-            goto do_unallocated;
-        }
+        // if (s->pauth_active) {
+        tcg_rd = cpu_reg(s, rd);
+        gen_helper_autda(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, cpu_reg_sp(s, rn));
+        // } else if (!dc_isar_feature(aa64_pauth, s)) {
+        //     goto do_unallocated;
+        // }
         break;
     case MAP(1, 0x01, 0x07): /* AUTDB */
-        if (s->pauth_active) {
-            tcg_rd = cpu_reg(s, rd);
-            gen_helper_autdb(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, cpu_reg_sp(s, rn));
-        } else if (!dc_isar_feature(aa64_pauth, s)) {
-            goto do_unallocated;
-        }
+        // if (s->pauth_active) {
+        tcg_rd = cpu_reg(s, rd);
+        gen_helper_autdb(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, cpu_reg_sp(s, rn));
+        // } else if (!dc_isar_feature(aa64_pauth, s)) {
+        //     goto do_unallocated;
+        // }
         break;
     case MAP(1, 0x01, 0x08): /* PACIZA */
-        if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
-            goto do_unallocated;
-        } else if (s->pauth_active) {
-            tcg_rd = cpu_reg(s, rd);
-            gen_helper_pacia(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, new_tmp_a64_zero(s));
-        }
+        // if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
+        //     goto do_unallocated;
+        // } else if (s->pauth_active) {
+        tcg_rd = cpu_reg(s, rd);
+        gen_helper_pacia(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, new_tmp_a64_zero(s));
+        // }
         break;
     case MAP(1, 0x01, 0x09): /* PACIZB */
-        if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
-            goto do_unallocated;
-        } else if (s->pauth_active) {
-            tcg_rd = cpu_reg(s, rd);
-            gen_helper_pacib(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, new_tmp_a64_zero(s));
-        }
+        // if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
+        //     goto do_unallocated;
+        // } else if (s->pauth_active) {
+        tcg_rd = cpu_reg(s, rd);
+        gen_helper_pacib(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, new_tmp_a64_zero(s));
+        // }
         break;
     case MAP(1, 0x01, 0x0a): /* PACDZA */
-        if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
-            goto do_unallocated;
-        } else if (s->pauth_active) {
-            tcg_rd = cpu_reg(s, rd);
-            gen_helper_pacda(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, new_tmp_a64_zero(s));
-        }
+        // if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
+        //     goto do_unallocated;
+        // } else if (s->pauth_active) {
+        tcg_rd = cpu_reg(s, rd);
+        gen_helper_pacda(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, new_tmp_a64_zero(s));
+        // }
         break;
     case MAP(1, 0x01, 0x0b): /* PACDZB */
-        if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
-            goto do_unallocated;
-        } else if (s->pauth_active) {
-            tcg_rd = cpu_reg(s, rd);
-            gen_helper_pacdb(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, new_tmp_a64_zero(s));
-        }
+        // if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
+        //     goto do_unallocated;
+        // } else if (s->pauth_active) {
+        tcg_rd = cpu_reg(s, rd);
+        gen_helper_pacdb(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, new_tmp_a64_zero(s));
+        // }
         break;
     case MAP(1, 0x01, 0x0c): /* AUTIZA */
-        if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
-            goto do_unallocated;
-        } else if (s->pauth_active) {
-            tcg_rd = cpu_reg(s, rd);
-            gen_helper_autia(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, new_tmp_a64_zero(s));
-        }
+        // if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
+        //     goto do_unallocated;
+        // } else if (s->pauth_active) {
+        tcg_rd = cpu_reg(s, rd);
+        gen_helper_autia(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, new_tmp_a64_zero(s));
+        // }
         break;
     case MAP(1, 0x01, 0x0d): /* AUTIZB */
-        if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
-            goto do_unallocated;
-        } else if (s->pauth_active) {
-            tcg_rd = cpu_reg(s, rd);
-            gen_helper_autib(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, new_tmp_a64_zero(s));
-        }
+        // if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
+        //     goto do_unallocated;
+        // } else if (s->pauth_active) {
+        tcg_rd = cpu_reg(s, rd);
+        gen_helper_autib(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, new_tmp_a64_zero(s));
+        // }
         break;
     case MAP(1, 0x01, 0x0e): /* AUTDZA */
-        if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
-            goto do_unallocated;
-        } else if (s->pauth_active) {
-            tcg_rd = cpu_reg(s, rd);
-            gen_helper_autda(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, new_tmp_a64_zero(s));
-        }
+        // if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
+        //     goto do_unallocated;
+        // } else if (s->pauth_active) {
+        tcg_rd = cpu_reg(s, rd);
+        gen_helper_autda(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, new_tmp_a64_zero(s));
+        // }
         break;
     case MAP(1, 0x01, 0x0f): /* AUTDZB */
-        if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
-            goto do_unallocated;
-        } else if (s->pauth_active) {
-            tcg_rd = cpu_reg(s, rd);
-            gen_helper_autdb(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, new_tmp_a64_zero(s));
-        }
+        // if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
+        //     goto do_unallocated;
+        // } else if (s->pauth_active) {
+        tcg_rd = cpu_reg(s, rd);
+        gen_helper_autdb(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd, new_tmp_a64_zero(s));
+        // }
         break;
     case MAP(1, 0x01, 0x10): /* XPACI */
-        if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
-            goto do_unallocated;
-        } else if (s->pauth_active) {
-            tcg_rd = cpu_reg(s, rd);
-            gen_helper_xpaci(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd);
-        }
+        // if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
+        //     goto do_unallocated;
+        // } else if (s->pauth_active) {
+        tcg_rd = cpu_reg(s, rd);
+        gen_helper_xpaci(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd);
+        // }
         break;
     case MAP(1, 0x01, 0x11): /* XPACD */
-        if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
-            goto do_unallocated;
-        } else if (s->pauth_active) {
-            tcg_rd = cpu_reg(s, rd);
-            gen_helper_xpacd(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd);
-        }
+        // if (!dc_isar_feature(aa64_pauth, s) || rn != 31) {
+        //     goto do_unallocated;
+        // } else if (s->pauth_active) {
+        tcg_rd = cpu_reg(s, rd);
+        gen_helper_xpacd(tcg_ctx, tcg_rd, tcg_ctx->cpu_env, tcg_rd);
+        // }
         break;
     default:
-    do_unallocated:
-        unallocated_encoding(s);
+    // do_unallocated:
+    //     unallocated_encoding(s);
         break;
     }
 

--- a/qemu/target/arm/translate-a64.c
+++ b/qemu/target/arm/translate-a64.c
@@ -2174,9 +2174,9 @@ static void disas_uncond_b_reg(DisasContext *s, uint32_t insn)
 
         case 2:
         case 3:
-            if (!dc_isar_feature(aa64_pauth, s)) {
-                goto do_unallocated;
-            }
+            // if (!dc_isar_feature(aa64_pauth, s)) {
+            //     goto do_unallocated;
+            // }
             if (opc == 2) {
                 /* RETAA, RETAB */
                 if (rn != 0x1f || op4 != 0x1f) {
@@ -2215,9 +2215,9 @@ static void disas_uncond_b_reg(DisasContext *s, uint32_t insn)
 
     case 8: /* BRAA */
     case 9: /* BLRAA */
-        if (!dc_isar_feature(aa64_pauth, s)) {
-            goto do_unallocated;
-        }
+        // if (!dc_isar_feature(aa64_pauth, s)) {
+        //     goto do_unallocated;
+        // }
         if ((op3 & ~1) != 2) {
             goto do_unallocated;
         }
@@ -2256,9 +2256,9 @@ static void disas_uncond_b_reg(DisasContext *s, uint32_t insn)
 
         case 2: /* ERETAA */
         case 3: /* ERETAB */
-            if (!dc_isar_feature(aa64_pauth, s)) {
-                goto do_unallocated;
-            }
+            // if (!dc_isar_feature(aa64_pauth, s)) {
+            //     goto do_unallocated;
+            // }
             if (rn != 0x1f || op4 != 0x1f) {
                 goto do_unallocated;
             }
@@ -3394,10 +3394,15 @@ static void disas_ldst_pac(DisasContext *s, uint32_t insn,
     int offset;
     TCGv_i64 clean_addr, dirty_addr, tcg_rt;
 
-    if (size != 3 || is_vector || !dc_isar_feature(aa64_pauth, s)) {
+    // if (size != 3 || is_vector || !dc_isar_feature(aa64_pauth, s)) {
+    //     unallocated_encoding(s);
+    //     return;
+    // }
+	if (size != 3 || is_vector) {
         unallocated_encoding(s);
         return;
     }
+
 
     if (rn == 31) {
         gen_check_sp_alignment(s);

--- a/qemu/target/arm/unicorn_aarch64.c
+++ b/qemu/target/arm/unicorn_aarch64.c
@@ -438,6 +438,18 @@ static int arm64_cpus_init(struct uc_struct *uc, const char *cpu_model)
         return -1;
     }
 
+    // enable AARCH64 atomic instruction
+    uint64_t t = cpu->isar.id_aa64isar0;
+    FIELD_DP64(t, ID_AA64ISAR0, ATOMIC, 2, t);
+    cpu->isar.id_aa64isar0 = t;
+
+    t = cpu->isar.id_aa64isar1;
+    FIELD_DP64(t, ID_AA64ISAR1, APA, 1, t); /* PAuth, architected only */
+    FIELD_DP64(t, ID_AA64ISAR1, API, 0, t);
+    FIELD_DP64(t, ID_AA64ISAR1, GPA, 1, t);
+    FIELD_DP64(t, ID_AA64ISAR1, GPI, 0, t);
+    cpu->isar.id_aa64isar1 = t;
+
     return 0;
 }
 

--- a/qemu/target/arm/unicorn_aarch64.c
+++ b/qemu/target/arm/unicorn_aarch64.c
@@ -433,21 +433,19 @@ static int arm64_cpus_init(struct uc_struct *uc, const char *cpu_model)
 {
     ARMCPU *cpu;
 
+    // enable AARCH64 atomic instruction
+    uc->cpu_model = 3; // set to cpu max
+
     cpu = cpu_aarch64_init(uc);
     if (cpu == NULL) {
         return -1;
     }
 
-    // enable AARCH64 atomic instruction
-    uint64_t t = cpu->isar.id_aa64isar0;
-    FIELD_DP64(t, ID_AA64ISAR0, ATOMIC, 2, t);
-    cpu->isar.id_aa64isar0 = t;
-
-    t = cpu->isar.id_aa64isar1;
+    uint64_t t = cpu->isar.id_aa64isar1;
     FIELD_DP64(t, ID_AA64ISAR1, APA, 1, t); /* PAuth, architected only */
-    FIELD_DP64(t, ID_AA64ISAR1, API, 0, t);
+    FIELD_DP64(t, ID_AA64ISAR1, API, 1, t);
     FIELD_DP64(t, ID_AA64ISAR1, GPA, 1, t);
-    FIELD_DP64(t, ID_AA64ISAR1, GPI, 0, t);
+    FIELD_DP64(t, ID_AA64ISAR1, GPI, 1, t);
     cpu->isar.id_aa64isar1 = t;
 
     return 0;

--- a/samples/sample_arm64.c
+++ b/samples/sample_arm64.c
@@ -89,89 +89,6 @@ static void test_arm64_mem_fetch(void)
     uc_close(uc);
 }
 
-static void test_arm64_atomic(void)
-{
-    uc_engine *uc;
-    uc_err err;
-
-    int64_t x9 = ADDRESS + 0x100;
-    int64_t x8 = 1;
-
-    char CODE[] = "\x29\x01\x28\xb8"; // ldadd     w8, w9, [x9]
-    int64_t output = 0;
-
-    printf("Emulate ARM64 LDADD\n");
-
-    // Initialize emulator in ARM mode
-    err = uc_open(UC_ARCH_ARM64, UC_MODE_ARM, &uc);
-    if (err) {
-        printf("Failed on uc_open() with error returned: %u (%s)\n", err,
-               uc_strerror(err));
-        return;
-    }
-
-    // map 2MB memory for this emulation
-    uc_mem_map(uc, ADDRESS, 2 * 1024 * 1024, UC_PROT_ALL);
-
-    // write machine code to be emulated to memory
-    uc_mem_write(uc, ADDRESS, CODE, sizeof(CODE) - 1);
-
-    // initialize machine registers
-    uc_reg_write(uc, UC_ARM64_REG_X8, &x8);
-    uc_reg_write(uc, UC_ARM64_REG_X9, &x9);
-
-    // emulate machine code in infinite time (last param = 0), or when
-    // finishing all the code.
-    err = uc_emu_start(uc, ADDRESS, ADDRESS + sizeof(CODE) - 1, 0, 0);
-    if (err) {
-        printf("Failed on uc_emu_start() with error returned: %u\n", err);
-    }
-
-    uc_reg_read(uc, UC_ARM64_REG_X16, &x9);
-    uc_mem_read(uc, x9, (void *)&output, 8);
-    printf("Output: %llx\n", (uint64_t)output);
-}
-
-static void test_arm64_pacda(void)
-{
-    uc_engine *uc;
-    uc_err err;
-
-    int64_t x16 = 0xFFFFFFF007880F38;
-    int64_t x17 = 0xCDA1FFF00B3CC000;
-    char PACDA_CODE[] = "\x30\x0A\xC1\xDA"; //pacda   x16, x17
-
-    printf("Emulate ARM64 PACDA\n");
-
-    // Initialize emulator in ARM mode
-    err = uc_open(UC_ARCH_ARM64, UC_MODE_ARM, &uc);
-    if (err) {
-        printf("Failed on uc_open() with error returned: %u (%s)\n", err,
-               uc_strerror(err));
-        return;
-    }
-
-    // map 2MB memory for this emulation
-    uc_mem_map(uc, ADDRESS, 2 * 1024 * 1024, UC_PROT_ALL);
-
-    // write machine code to be emulated to memory
-    uc_mem_write(uc, ADDRESS, PACDA_CODE, sizeof(PACDA_CODE) - 1);
-
-    // initialize machine registers
-    uc_reg_write(uc, UC_ARM64_REG_X17, &x17);
-    uc_reg_write(uc, UC_ARM64_REG_X16, &x16);
-
-    // emulate machine code in infinite time (last param = 0), or when
-    // finishing all the code.
-    err = uc_emu_start(uc, ADDRESS, ADDRESS + sizeof(PACDA_CODE) - 1, 0, 0);
-    if (err) {
-        printf("Failed on uc_emu_start() with error returned: %u\n", err);
-    }
-
-    uc_reg_read(uc, UC_ARM64_REG_X16, &x16);
-    printf("X16: %llx\n", (uint64_t)x16);
-}
-
 static void test_arm64(void)
 {
     uc_engine *uc;
@@ -378,12 +295,6 @@ static void test_arm64_hook_mrs()
 
 int main(int argc, char **argv, char **envp)
 {
-    printf("-------------------------\n");
-    test_arm64_atomic();
-
-    printf("-------------------------\n");
-    test_arm64_pacda();
-
     test_arm64_mem_fetch();
     test_arm64();
 


### PR DESCRIPTION
Hi team,

I have modified some code path to enable and workaround some features in order to emulate arm64e binary on iOS/macOS. 