### PR TITLE
Let pip deal with whl filename

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -11,7 +11,6 @@ import platform
 
 from distutils import log
 from distutils.core import setup
-from distutils.util import get_platform
 from distutils.command.build import build
 from distutils.command.sdist import sdist
 from setuptools.command.bdist_egg import bdist_egg
@@ -176,25 +175,6 @@ cmdclass = {}
 cmdclass['build'] = custom_build
 cmdclass['sdist'] = custom_sdist
 cmdclass['bdist_egg'] = custom_bdist_egg
-
-if 'bdist_wheel' in sys.argv and '--plat-name' not in sys.argv:
-    idx = sys.argv.index('bdist_wheel') + 1
-    sys.argv.insert(idx, '--plat-name')
-    name = get_platform()
-    if 'linux' in name:
-        # linux_* platform tags are disallowed because the python ecosystem is fubar
-        # linux builds should be built in the centos 5 vm for maximum compatibility
-        # see https://github.com/pypa/manylinux
-        # see also https://github.com/angr/angr-dev/blob/master/bdist.sh
-        sys.argv.insert(idx + 1, 'manylinux1_' + platform.machine())
-    elif 'mingw' in name:
-        if IS_64BITS:
-            sys.argv.insert(idx + 1, 'win_amd64')
-        else:
-            sys.argv.insert(idx + 1, 'win32')
-    else:
-        # https://www.python.org/dev/peps/pep-0425/
-        sys.argv.insert(idx + 1, name.replace('.', '_').replace('-', '_'))
 
 try:
     from setuptools.command.develop import develop


### PR DESCRIPTION
I tried to create a whl from an alpine linux docker image of the latest Unicorn release and the whl build works fine but due to that `if` statement removed in this PR, during pip install it returns the following error:

`ERROR: unicorn-2.0.1.post1-py2.py3-none-manylinux1_x86_64.whl is not a supported wheel on this platform.`

This because the `if` forces to set `manylinux1` tag in the filename and that matters for pip during the installation. In fact, doing a simple rename of the whl file by replacing `manylinux1` with `any`, pip installs the whl without any problems. Of course rather renaming like I did, the proper way to do this is through `auditwheel repair`, which in this case actually repairs and creates a new whl file indeed with appropriate tags.
Doing this you will generate a whl file that will be compatible for both tags platform, hence when installing from alpine for instance the end user will not end up compiling the whl every time since the whl file pushed to pypi will be detected as fine for the given platform.

- whl file created by the current `setup.py`: `unicorn-2.0.1.post1-py2.py3-none-manylinux1_x86_64.whl`
- whl file created by the current `setup.py` after the auditwheel repair: `unicorn-2.0.1.post1-py2.py3-none-manylinux1_x86_64.musllinux_1_2_x86_64.whl`
- whl file created by the `setup.py` modified in this PR: `unicorn-2.0.1.post1-py2.py3-none-any.whl`

The auditwheel repair is not required if this PR gets accepted but if you think that this change will break builds for other platforms then I guess this can be added into your Github Actions during whl creation before pushing to pypi index, just in case.
Of course more tests can be performed using different docker images but this change should be fine enough.
