### PR TITLE
[dotnet] Fix garbage collected hooks and wrong signature

### DIFF
--- a/bindings/dotnet/UnicornEngine/InternalHooks.fs
+++ b/bindings/dotnet/UnicornEngine/InternalHooks.fs
@@ -14,10 +14,10 @@ type internal BlockHookInternal = delegate of IntPtr * Int64 * Int32 * IntPtr ->
 type internal InterruptHookInternal = delegate of IntPtr * Int32 * IntPtr -> unit
 
 [<UnmanagedFunctionPointer(CallingConvention.Cdecl)>]
-type internal MemReadHookInternal = delegate of IntPtr * Int64 * Int32 * IntPtr -> unit
+type internal MemReadHookInternal = delegate of IntPtr * Int32 * Int64 * Int32 * IntPtr -> unit
 
 [<UnmanagedFunctionPointer(CallingConvention.Cdecl)>]
-type internal MemWriteHookInternal = delegate of IntPtr * Int64 * Int32 * Int64 * IntPtr -> unit
+type internal MemWriteHookInternal = delegate of IntPtr * Int32 * Int64 * Int32 * Int64 * IntPtr -> unit
 
 [<UnmanagedFunctionPointer(CallingConvention.Cdecl)>]
 type internal EventMemHookInternal = delegate of IntPtr * Int32 * Int64 * Int32 * Int64 * IntPtr-> Boolean


### PR DESCRIPTION
`*HookInternal` objects can be garbage collected, so their reference should be kept somewhere. With this PR, Unicorn object has `_hookInternals` member where all the hook internal objects are stored.
```
Process terminated. A callback was made on a garbage collected delegate of type 'UnicornEngine!UnicornEngine.MemReadHookInternal::Invoke'.
```

And, `MemReadHook` and `MemWriteHook` trampolines have a wrong callback signature. The second argument should be the event type.
https://github.com/unicorn-engine/unicorn/blob/7b8c63dfe650b5d4d2bf684526161971925e6350/qemu/accel/tcg/cputlb.c#L1469