### PR TITLE
[dotnet] Add /MT flag for nuget package build

### DIFF
--- a/.github/workflows/Nuget-publishing.yml
+++ b/.github/workflows/Nuget-publishing.yml
@@ -80,6 +80,7 @@ jobs:
             -B . \
             -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
             -G "${{ matrix.config.generators }}" \
+            -DCMAKE_C_FLAGS="//MT" \
             -DCMAKE_INSTALL_PREFIX:PATH=instdir \
             -DBUILD_SHARED_LIBS=${{ matrix.config.shared }}
           cmake --build . --config ${{ matrix.config.build_type }}
@@ -107,6 +108,7 @@ jobs:
             -A "win32" \
             -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
             -G "${{ matrix.config.generators }}" \
+            -DCMAKE_C_FLAGS="//MT" \
             -DCMAKE_INSTALL_PREFIX:PATH=instdir \
             -DBUILD_SHARED_LIBS=${{ matrix.config.shared }}
           cmake --build . --config ${{ matrix.config.build_type }}


### PR DESCRIPTION
Context: https://github.com/unicorn-engine/unicorn/issues/1631#issuecomment-1445287574

vcruntime dll may have CFG enabled which checks whether `jmp_buf` has a zero value for frame in `longjmp`, but Unicorn is setting the frame value to zero. The problem appears only when CFG is enabled, and .NET programs have CFG opted in by default. As a workaround, use `libcmt` statically rather than using `vcruntime` for .NET binding. Unicorn may need to implement its own `setjmp`/`lonjmp` in the future, but this workaround seems to work for now.