### PR TITLE
Cache index for find_memory_region

### DIFF
--- a/uc.c
+++ b/uc.c
@@ -1524,7 +1524,7 @@ MemoryRegion *find_memory_region(struct uc_struct *uc, uint64_t address)
 
     if (i < uc->mapped_block_count &&
         address >= uc->mapped_blocks[i]->addr &&
-        address < uc->mapped_blocks[i]->end) {
+        address <= uc->mapped_blocks[i]->end - 1) {
         return uc->mapped_blocks[i];
     }
 
@@ -1532,7 +1532,7 @@ MemoryRegion *find_memory_region(struct uc_struct *uc, uint64_t address)
 
     if (i < uc->mapped_block_count &&
         address >= uc->mapped_blocks[i]->addr &&
-        address < uc->mapped_blocks[i]->end) {
+        address <= uc->mapped_blocks[i]->end - 1) {
         uc->mapped_block_cache_index = i;
         return uc->mapped_blocks[i];
     }

--- a/uc.c
+++ b/uc.c
@@ -1532,8 +1532,10 @@ MemoryRegion *find_memory_region(struct uc_struct *uc, uint64_t address)
 
     if (i < uc->mapped_block_count &&
         address >= uc->mapped_blocks[i]->addr &&
-        address <= uc->mapped_blocks[i]->end - 1)
+        address < uc->mapped_blocks[i]->end) {
+        uc->mapped_block_cache_index = i;
         return uc->mapped_blocks[i];
+    }
 
     // not found
     return NULL;


### PR DESCRIPTION
`find_memory_region` uses a cache index to check whether the most recently used block is the target block, but the index is never set. It looks like it was accidentally removed in this PR: https://github.com/unicorn-engine/unicorn/pull/1414

The cache index is still effective even with the binary search.