### PR TITLE
add rust bindings for uc_ctl

### DIFF
--- a/bindings/rust/src/ffi.rs
+++ b/bindings/rust/src/ffi.rs
@@ -3,7 +3,7 @@
 
 use crate::{Unicorn, UnicornInner};
 
-use super::unicorn_const::{uc_error, Arch, HookType, MemRegion, MemType, Mode, Query};
+use super::unicorn_const::{uc_error, Arch, HookType, MemRegion, MemType, Mode, Query, TlbEntry};
 use alloc::rc::Weak;
 use core::{cell::UnsafeCell, ffi::c_void};
 use libc::{c_char, c_int};
@@ -251,4 +251,26 @@ where
     };
     debug_assert_eq!(uc, user_data_uc.get_handle());
     (user_data.callback)(&mut user_data_uc);
+}
+
+pub extern "C" fn tlb_lookup_hook_proxy<D, F>(uc: uc_handle, vaddr: u64, mem_type: MemType, result: *mut TlbEntry, user_data: *mut UcHook<D, F>) -> bool
+where
+    F: FnMut(&mut crate::Unicorn<D>, u64, MemType) -> Option<TlbEntry>,
+{
+    let user_data = unsafe { &mut *user_data };
+    let mut user_data_uc = Unicorn {
+        inner: user_data.uc.upgrade().unwrap(),
+    };
+    debug_assert_eq!(uc, user_data_uc.get_handle());
+    let r = (user_data.callback)(&mut user_data_uc, vaddr, mem_type);
+    match r {
+        Some(ref e) => {
+            unsafe {
+                let ref_result: &mut TlbEntry = &mut *result;
+                *ref_result = *e;
+            }
+        },
+        None => {},
+    };
+    return r.is_some();
 }

--- a/bindings/rust/src/ffi.rs
+++ b/bindings/rust/src/ffi.rs
@@ -86,6 +86,7 @@ extern "C" {
     pub fn uc_context_alloc(engine: uc_handle, context: *mut uc_context) -> uc_error;
     pub fn uc_context_save(engine: uc_handle, context: uc_context) -> uc_error;
     pub fn uc_context_restore(engine: uc_handle, context: uc_context) -> uc_error;
+    pub fn uc_ctl(engine: uc_handle, control: u32, ...) -> uc_error;
 }
 
 pub struct UcHook<'a, D: 'a, F: 'a> {

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -1189,8 +1189,26 @@ impl<'a, D> Unicorn<'a, D> {
         }
     }
 
-    pub fn ctl_flush_tlb(&self) -> Result<(), uc_error> {
+    pub fn ctl_flush_tb(&self) -> Result<(), uc_error> {
         let err = unsafe { ffi::uc_ctl(self.get_handle(), UC_CTL_WRITE!(ControlType::UC_CTL_TB_FLUSH)) };
+        if err == uc_error::OK {
+            Ok(())
+        } else {
+            Err(err)
+        }
+    }
+
+    pub fn ctl_flush_tlb(&self) -> Result<(), uc_error> {
+        let err = unsafe { ffi::uc_ctl(self.get_handle(), UC_CTL_WRITE!(ControlType::UC_CTL_TLB_FLUSH)) };
+        if err == uc_error::OK {
+            Ok(())
+        } else {
+            Err(err)
+        }
+    }
+
+    pub fn ctl_tlb_type(&self, t: TlbType) -> Result<(), uc_error> {
+        let err = unsafe { ffi::uc_ctl(self.get_handle(), UC_CTL_WRITE!(ControlType::UC_CTL_TLB_TYPE), t as i32) };
         if err == uc_error::OK {
             Ok(())
         } else {

--- a/bindings/rust/src/unicorn_const.rs
+++ b/bindings/rust/src/unicorn_const.rs
@@ -53,6 +53,13 @@ pub enum MemType {
     READ_AFTER = 25,
 }
 
+#[repr(C)]
+#[derive(PartialEq, Debug, Clone, Copy)]
+pub enum TlbType {
+    CPU = 0,
+    VIRTUAL = 1,
+}
+
 bitflags! {
     #[repr(C)]
     pub struct HookType: i32 {
@@ -227,6 +234,8 @@ pub enum ControlType {
     UC_CTL_TB_REQUEST_CACHE = 8,
     UC_CTL_TB_REMOVE_CACHE = 9,
     UC_CTL_TB_FLUSH = 10,
+    UC_CTL_TLB_FLUSH = 11,
+    UC_CTL_TLB_TYPE = 12,
     UC_CTL_IO_READ = 1<<31,
     UC_CTL_IO_WRITE = 1<<30,
 }

--- a/bindings/rust/src/unicorn_const.rs
+++ b/bindings/rust/src/unicorn_const.rs
@@ -187,3 +187,46 @@ bitflags! {
         const RISCV64 = Self::MIPS64.bits;
     }
 }
+
+// Represent a TranslationBlock.
+#[repr(C)]
+pub struct TranslationBlock {
+    pub pc: u64,
+    pub icount: u16,
+    pub size: u16
+}
+
+macro_rules! UC_CTL_READ {
+    ($expr:expr) => {
+        $expr as u32 | ControlType::UC_CTL_IO_READ as u32
+    };
+}
+
+macro_rules! UC_CTL_WRITE {
+    ($expr:expr) => {
+        $expr as u32 | ControlType::UC_CTL_IO_WRITE as u32
+    };
+}
+
+macro_rules! UC_CTL_READ_WRITE {
+    ($expr:expr) => {
+        $expr as u32 | ControlType::UC_CTL_IO_WRITE as u32 | ControlType::UC_CTL_IO_READ as u32
+    };
+}
+
+#[allow(clippy::upper_case_acronyms)]
+pub enum ControlType {
+    UC_CTL_UC_MODE = 0,
+    UC_CTL_UC_PAGE_SIZE = 1,
+    UC_CTL_UC_ARCH = 2,
+    UC_CTL_UC_TIMEOUT = 3,
+    UC_CTL_UC_USE_EXITS = 4,
+    UC_CTL_UC_EXITS_CNT = 5,
+    UC_CTL_UC_EXITS = 6,
+    UC_CTL_CPU_MODEL = 7,
+    UC_CTL_TB_REQUEST_CACHE = 8,
+    UC_CTL_TB_REMOVE_CACHE = 9,
+    UC_CTL_TB_FLUSH = 10,
+    UC_CTL_IO_READ = 1<<31,
+    UC_CTL_IO_WRITE = 1<<30,
+}

--- a/bindings/rust/src/unicorn_const.rs
+++ b/bindings/rust/src/unicorn_const.rs
@@ -93,6 +93,8 @@ bitflags! {
         const MEM_INVALID = Self::MEM_READ_INVALID.bits | Self::MEM_WRITE_INVALID.bits | Self::MEM_FETCH_INVALID.bits;
 
         const MEM_ALL = Self::MEM_VALID.bits | Self::MEM_INVALID.bits;
+
+        const TLB = (1 << 17);
     }
 }
 
@@ -238,4 +240,11 @@ pub enum ControlType {
     UC_CTL_TLB_TYPE = 12,
     UC_CTL_IO_READ = 1<<31,
     UC_CTL_IO_WRITE = 1<<30,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct TlbEntry {
+    pub paddr: u64,
+    pub perms: Permission,
 }


### PR DESCRIPTION
This PR adds a wrapper for the uc_ctl function to unicorn's Rust bindings. Since Rust neither allows overloading of functions let alone variadic functions the implementation may seem a bit odd. I'm open to suggestions if you know of a better way to implement this. At the moment the uc_ctl function takes at most two optional arguments that are either a pointer or value that fits into 64-bit of memory. Consequently we need three functions in the Rust bindings to represent these cases. Since the uc_ctl functions does not define any type for the optional arguments it is hard to define a meaningful function signature with Rust being strongly typed. I defined the arguments as void pointers which means that arguments passed to this function first need to be unsafely transmuted. The other option would be to define a function for each argument count and type which seems even less appealing.