### PR TITLE
Restore python 2 compatibility

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -245,7 +245,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
     ],
-    requires=['ctypes'],
+    requires=['ctypes', 'typing; python_version<"3.5"'],
     cmdclass=cmdclass,
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
Not sure why the py2 wheels made it to PyPI, since importing Unicorn throws a `SyntaxError` every time, but here is a fix.

Another option would be to retain the type annotations and just mark the affected versions on PyPI as python3-only, so that `pip2 install unicorn` at least installs something old that works.