### PR TITLE
use int128_get64 in memory_unmap

### DIFF
--- a/qemu/softmmu/memory.c
+++ b/qemu/softmmu/memory.c
@@ -155,13 +155,13 @@ void memory_unmap(struct uc_struct *uc, MemoryRegion *mr)
 
     if (uc->cpu) {
         // We also need to remove all tb cache
-        uc->uc_invalidate_tb(uc, mr->addr, mr->size);
+        uc->uc_invalidate_tb(uc, mr->addr, int128_get64(mr->size));
 
         // Make sure all pages associated with the MemoryRegion are flushed
         // Only need to do this if we are in a running state
         for (addr = mr->addr; (int64_t)(mr->end - addr) > 0; addr += uc->target_page_size) {
            tlb_flush_page(uc->cpu, addr);
-        }        
+        }
     }
     memory_region_del_subregion(uc->system_memory, mr);
 


### PR DESCRIPTION
This fixes build errors introduced by bbbc7856accbae7697db84d10a28c5a6aec81856