### PR TITLE
Run apt update in nuget publishing workflow

### DIFF
--- a/.github/workflows/Nuget-publishing.yml
+++ b/.github/workflows/Nuget-publishing.yml
@@ -257,6 +257,7 @@ jobs:
           else
                 export CFLAGS="-m32" LDFLAGS="-m32" LDFLAGS_STATIC="-m32" UNICORN_QEMU_FLAGS="--cpu=i386"
                 sudo dpkg --add-architecture i386
+                sudo apt update
                 sudo apt install -q -y lib32ncurses-dev lib32z1-dev lib32gcc-9-dev libc6-dev-i386 gcc-multilib \
                   libcmocka-dev:i386 libcmocka0:i386 libc6:i386 libgcc-s1:i386 ninja-build
           fi


### PR DESCRIPTION
Currently nuget publishing for x86 ubuntu workflow is failing to install required packages.
https://github.com/unicorn-engine/unicorn/actions/runs/5028417981/jobs/9019092076

Run `apt update` to make sure.