### PR TITLE
Avoid notdirty_write

### DIFF
--- a/qemu/accel/tcg/cputlb.c
+++ b/qemu/accel/tcg/cputlb.c
@@ -614,7 +614,7 @@ void tlb_flush_page_all_cpus_synced(CPUState *src, target_ulong addr)
    can be detected */
 void tlb_protect_code(struct uc_struct *uc, ram_addr_t ram_addr)
 {
-    cpu_physical_memory_test_and_clear_dirty(ram_addr, TARGET_PAGE_SIZE,
+    cpu_physical_memory_test_and_clear_dirty(uc, ram_addr, TARGET_PAGE_SIZE,
                                              DIRTY_MEMORY_CODE);
 }
 
@@ -1153,7 +1153,7 @@ static void notdirty_write(CPUState *cpu, vaddr mem_vaddr, unsigned size,
     if (!cpu_physical_memory_get_dirty_flag(ram_addr, DIRTY_MEMORY_CODE)) {
         struct page_collection *pages
             = page_collection_lock(cpu->uc, ram_addr, ram_addr + size);
-        tb_invalidate_phys_page_fast(cpu->uc, pages, ram_addr, size, retaddr);
+        tb_invalidate_phys_page_fast(cpu->uc, pages, ram_addr, size, retaddr, mem_vaddr);
         page_collection_unlock(pages);
     }
 

--- a/qemu/accel/tcg/translate-all.c
+++ b/qemu/accel/tcg/translate-all.c
@@ -1903,7 +1903,7 @@ void tb_invalidate_phys_range(struct uc_struct *uc, ram_addr_t start, ram_addr_t
  */
 void tb_invalidate_phys_page_fast(struct uc_struct *uc, struct page_collection *pages,
                                   tb_page_addr_t start, int len,
-                                  uintptr_t retaddr)
+                                  uintptr_t retaddr, vaddr mem_vaddr)
 {
     PageDesc *p;
 
@@ -1911,6 +1911,12 @@ void tb_invalidate_phys_page_fast(struct uc_struct *uc, struct page_collection *
 
     p = page_find(uc, start >> TARGET_PAGE_BITS);
     if (!p) {
+        tlb_set_dirty(uc->cpu, mem_vaddr);
+        return;
+    }
+
+    if (!p->first_tb) {
+        tlb_set_dirty(uc->cpu, mem_vaddr);
         return;
     }
 

--- a/qemu/accel/tcg/translate-all.h
+++ b/qemu/accel/tcg/translate-all.h
@@ -28,7 +28,7 @@ struct page_collection *page_collection_lock(struct uc_struct *uc, tb_page_addr_
 void page_collection_unlock(struct page_collection *set);
 void tb_invalidate_phys_page_fast(struct uc_struct *uc, struct page_collection *pages,
                                   tb_page_addr_t start, int len,
-                                  uintptr_t retaddr);
+                                  uintptr_t retaddr, vaddr mem_vaddr);
 void tb_invalidate_phys_page_range(struct uc_struct *uc, tb_page_addr_t start, tb_page_addr_t end);
 void tb_invalidate_phys_range(struct uc_struct *uc, ram_addr_t start, ram_addr_t end);
 void tb_check_watchpoint(CPUState *cpu, uintptr_t retaddr);

--- a/qemu/exec.c
+++ b/qemu/exec.c
@@ -805,10 +805,20 @@ found:
 }
 
 /* Note: start and end must be within the same ram block.  */
-bool cpu_physical_memory_test_and_clear_dirty(ram_addr_t start,
+bool cpu_physical_memory_test_and_clear_dirty(struct uc_struct *uc,
+                                              ram_addr_t start,
                                               ram_addr_t length,
                                               unsigned client)
 {
+    ram_addr_t start1;
+    RAMBlock *block;
+
+    start &= TARGET_PAGE_MASK;
+
+    block = qemu_get_ram_block(uc, start);
+    start1 = (uintptr_t)ramblock_ptr(block, start - block->offset);
+    tlb_reset_dirty(uc->cpu, start1, length);
+
     return false;
 }
 

--- a/qemu/include/exec/ram_addr.h
+++ b/qemu/include/exec/ram_addr.h
@@ -97,7 +97,8 @@ static inline void cpu_physical_memory_set_dirty_lebitmap(unsigned long *bitmap,
 }
 #endif /* not _WIN32 */
 
-bool cpu_physical_memory_test_and_clear_dirty(ram_addr_t start,
+bool cpu_physical_memory_test_and_clear_dirty(struct uc_struct *uc,
+                                              ram_addr_t start,
                                               ram_addr_t length,
                                               unsigned client);
 


### PR DESCRIPTION
Attempt to avoid `notdirty_write` as much as possible. Please refer to #1838 for the context.

If there is no TB in the page, we can skip the slow path, so mark the TLB as `dirty` in such case. And `PageDesc` is allocated only when TB is generated, so we can apply the same logic for the case where `PageDesc` is not found.

If Unicorn generates a TB, we have to take the slow path for the page. In `tb_page_add`, if it's the first tb generated, `tlb_protect_code` will be called, and it will call `cpu_physical_memory_test_and_clear_dirty`. In this function, we reset the dirty flag so that Unicorn calls `notdirty_write` when memory is overwritten in the page.

Tested with `tests/regress/x86_self_modifying.py`.