### PR TITLE
aarch64: Fix PSTATE write. Expose CPSR register like on aarch32

### DIFF
--- a/include/unicorn/arm64.h
+++ b/include/unicorn/arm64.h
@@ -311,6 +311,7 @@ typedef enum uc_arm64_reg {
     UC_ARM64_REG_TPIDRRO_EL0,
     UC_ARM64_REG_TPIDR_EL1,
 
+    UC_ARM64_REG_CPSR,
     UC_ARM64_REG_PSTATE,
 
     //> exception link registers, depreciated, use UC_ARM64_REG_CP_REG instead

--- a/qemu/target/arm/unicorn_aarch64.c
+++ b/qemu/target/arm/unicorn_aarch64.c
@@ -306,8 +306,12 @@ static uc_err reg_write(CPUARMState *env, unsigned int regid, const void *value)
         case UC_ARM64_REG_NZCV:
             cpsr_write(env, *(uint32_t *)value, CPSR_NZCV, CPSRWriteRaw);
             break;
+        case UC_ARM64_REG_CPSR:
+            cpsr_write(env, *(uint32_t *)value, ~0, CPSRWriteByUnicorn);
+            break;
         case UC_ARM64_REG_PSTATE:
             pstate_write(env, *(uint32_t *)value);
+            arm_rebuild_hflags(env);
             break;
         case UC_ARM64_REG_TTBR0_EL1:
             env->cp15.ttbr0_el[1] = *(uint64_t *)value;


### PR DESCRIPTION
This makes it possible to change the Exception Level correctly (from the default EL1 to EL2 or EL3), and allows to change the processor execution mode (user, monitor, hypervisor, etc..)

Fixes #1843 