### PR TITLE
Fix rust compiler warnings

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -56,7 +56,6 @@ use alloc::{boxed::Box, rc::Rc, vec::Vec};
 use core::{cell::UnsafeCell, ptr};
 use ffi::uc_handle;
 use libc::c_void;
-use unicorn_const::{uc_error, Arch, HookType, MemRegion, MemType, Mode, Permission, Query};
 
 #[derive(Debug)]
 pub struct Context {


### PR DESCRIPTION
This PR fixes multiple `warning: private item shadows public glob re-export` warnings caused by an unnecessary use statement