### PR TITLE
Fix clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ exclude = [
 path = "bindings/rust/src/lib.rs"
 
 [dependencies]
-bitflags = "1.3"
+bitflags = "2.3.3"
 libc = "0.2"
 
 [build-dependencies]

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -167,6 +167,7 @@ impl<'a> Unicorn<'a, ()> {
 impl<'a> TryFrom<uc_handle> for Unicorn<'a, ()> {
     type Error = uc_error;
 
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     fn try_from(handle: uc_handle) -> Result<Unicorn<'a, ()>, uc_error> {
         if handle.is_null() {
             return Err(uc_error::HANDLE);
@@ -914,6 +915,7 @@ impl<'a, D> Unicorn<'a, D> {
     /// Remove a hook.
     ///
     /// `hook` is the value returned by `add_*_hook` functions.
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn remove_hook(&mut self, hook: ffi::uc_hook) -> Result<(), uc_error> {
         // drop the hook
         let inner = self.inner_mut();

--- a/bindings/rust/src/unicorn_const.rs
+++ b/bindings/rust/src/unicorn_const.rs
@@ -167,6 +167,7 @@ impl TryFrom<usize> for Arch {
 }
 
 bitflags! {
+    #[derive(Copy, Clone)]
     #[repr(C)]
     pub struct Mode: i32 {
         const LITTLE_ENDIAN = 0;

--- a/bindings/rust/src/unicorn_const.rs
+++ b/bindings/rust/src/unicorn_const.rs
@@ -62,6 +62,7 @@ pub enum TlbType {
 
 bitflags! {
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct HookType: i32 {
         const INTR = 1;
         const INSN = 2;
@@ -71,28 +72,28 @@ bitflags! {
         const MEM_READ_UNMAPPED = 0x10;
         const MEM_WRITE_UNMAPPED = 0x20;
         const MEM_FETCH_UNMAPPED = 0x40;
-        const MEM_UNMAPPED = Self::MEM_READ_UNMAPPED.bits | Self::MEM_WRITE_UNMAPPED.bits | Self::MEM_FETCH_UNMAPPED.bits;
+        const MEM_UNMAPPED = Self::MEM_READ_UNMAPPED.bits() | Self::MEM_WRITE_UNMAPPED.bits() | Self::MEM_FETCH_UNMAPPED.bits();
 
         const MEM_READ_PROT = 0x80;
         const MEM_WRITE_PROT = 0x100;
         const MEM_FETCH_PROT = 0x200;
-        const MEM_PROT = Self::MEM_READ_PROT.bits | Self::MEM_WRITE_PROT.bits | Self::MEM_FETCH_PROT.bits;
+        const MEM_PROT = Self::MEM_READ_PROT.bits() | Self::MEM_WRITE_PROT.bits() | Self::MEM_FETCH_PROT.bits();
 
         const MEM_READ = 0x400;
         const MEM_WRITE = 0x800;
         const MEM_FETCH = 0x1000;
-        const MEM_VALID = Self::MEM_READ.bits | Self::MEM_WRITE.bits | Self::MEM_FETCH.bits;
+        const MEM_VALID = Self::MEM_READ.bits() | Self::MEM_WRITE.bits() | Self::MEM_FETCH.bits();
 
         const MEM_READ_AFTER = 0x2000;
 
         const INSN_INVALID = 0x4000;
 
-        const MEM_READ_INVALID = Self::MEM_READ_UNMAPPED.bits | Self::MEM_READ_PROT.bits;
-        const MEM_WRITE_INVALID = Self::MEM_WRITE_UNMAPPED.bits | Self::MEM_WRITE_PROT.bits;
-        const MEM_FETCH_INVALID = Self::MEM_FETCH_UNMAPPED.bits | Self::MEM_FETCH_PROT.bits;
-        const MEM_INVALID = Self::MEM_READ_INVALID.bits | Self::MEM_WRITE_INVALID.bits | Self::MEM_FETCH_INVALID.bits;
+        const MEM_READ_INVALID = Self::MEM_READ_UNMAPPED.bits() | Self::MEM_READ_PROT.bits();
+        const MEM_WRITE_INVALID = Self::MEM_WRITE_UNMAPPED.bits() | Self::MEM_WRITE_PROT.bits();
+        const MEM_FETCH_INVALID = Self::MEM_FETCH_UNMAPPED.bits() | Self::MEM_FETCH_PROT.bits();
+        const MEM_INVALID = Self::MEM_READ_INVALID.bits() | Self::MEM_WRITE_INVALID.bits() | Self::MEM_FETCH_INVALID.bits();
 
-        const MEM_ALL = Self::MEM_VALID.bits | Self::MEM_INVALID.bits;
+        const MEM_ALL = Self::MEM_VALID.bits() | Self::MEM_INVALID.bits();
 
         const TLB = (1 << 17);
     }
@@ -110,12 +111,13 @@ pub enum Query {
 
 bitflags! {
 #[repr(C)]
+    #[derive(Copy, Clone, Debug)]
 pub struct Permission : u32 {
         const NONE = 0;
         const READ = 1;
         const WRITE = 2;
         const EXEC = 4;
-        const ALL = Self::READ.bits | Self::WRITE.bits | Self::EXEC.bits;
+        const ALL = Self::READ.bits() | Self::WRITE.bits() | Self::EXEC.bits();
     }
 }
 
@@ -178,22 +180,22 @@ bitflags! {
         const ARM926 = 0x80;
         const ARM946 = 0x100;
         const ARM1176 = 0x200;
-        const MICRO = Self::THUMB.bits;
-        const MIPS3 = Self::MCLASS.bits;
-        const MIPS32R6 = Self::V8.bits;
+        const MICRO = Self::THUMB.bits();
+        const MIPS3 = Self::MCLASS.bits();
+        const MIPS32R6 = Self::V8.bits();
         const MIPS32 = 4;
         const MIPS64 = 8;
         const MODE_16 = 2;
-        const MODE_32 = Self::MIPS32.bits;
-        const MODE_64 = Self::MIPS64.bits;
-        const PPC32 = Self::MIPS32.bits;
-        const PPC64 = Self::MIPS64.bits;
-        const QPX = Self::THUMB.bits;
-        const SPARC32 = Self::MIPS32.bits;
-        const SPARC64 = Self::MIPS64.bits;
-        const V9 = Self::THUMB.bits;
-        const RISCV32 = Self::MIPS32.bits;
-        const RISCV64 = Self::MIPS64.bits;
+        const MODE_32 = Self::MIPS32.bits();
+        const MODE_64 = Self::MIPS64.bits();
+        const PPC32 = Self::MIPS32.bits();
+        const PPC64 = Self::MIPS64.bits();
+        const QPX = Self::THUMB.bits();
+        const SPARC32 = Self::MIPS32.bits();
+        const SPARC64 = Self::MIPS64.bits();
+        const V9 = Self::THUMB.bits();
+        const RISCV32 = Self::MIPS32.bits();
+        const RISCV64 = Self::MIPS64.bits();
     }
 }
 
@@ -224,6 +226,7 @@ macro_rules! UC_CTL_READ_WRITE {
 }
 
 #[allow(clippy::upper_case_acronyms)]
+#[repr(u64)]
 pub enum ControlType {
     UC_CTL_UC_MODE = 0,
     UC_CTL_UC_PAGE_SIZE = 1,


### PR DESCRIPTION
This PR fixes a few clippy warnings caused by an outdated bitflags crate. Also adds two allow annotations for the raw pointer handles.