### PR TITLE
fix: Wrap uc_hook to not expose ffi types in public api

### DIFF
--- a/bindings/rust/src/ffi.rs
+++ b/bindings/rust/src/ffi.rs
@@ -10,6 +10,7 @@ use core::ffi::c_void;
 use libc::{c_char, c_int};
 
 pub type uc_handle = *mut c_void;
+// TODO: Use c_size_t as soon as it is stable. The c api exposes uc_hook as size_t
 pub type uc_hook = *mut c_void;
 pub type uc_context = *mut c_void;
 


### PR DESCRIPTION
The current api exposes raw pointers to the user. This change wraps the internal pointer type into a public facing type. This avoids direct use of the ffi for normal api use. Using the ffi directly is still possible.