### PR TITLE
fix: Use correct addresses during memory cow

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -35,7 +35,6 @@ extern crate std;
 use alloc::boxed::Box;
 use alloc::rc::Rc;
 use alloc::vec::Vec;
-use bitflags::Flags;
 use core::cell::UnsafeCell;
 use core::ptr;
 

--- a/qemu/accel/tcg/cputlb.c
+++ b/qemu/accel/tcg/cputlb.c
@@ -2156,7 +2156,7 @@ store_helper(CPUArchState *env, target_ulong addr, uint64_t val,
     }
 
     if (uc->snapshot_level && mr->ram && mr->priority < uc->snapshot_level) {
-        mr = memory_cow(uc, mr, addr & TARGET_PAGE_MASK, TARGET_PAGE_SIZE);
+        mr = memory_cow(uc, mr, paddr & TARGET_PAGE_MASK, TARGET_PAGE_SIZE);
         if (!mr) {
             uc->invalid_addr = paddr;
             uc->invalid_error = UC_ERR_NOMEM;
@@ -2164,7 +2164,7 @@ store_helper(CPUArchState *env, target_ulong addr, uint64_t val,
             return;
         }
         /* refill tlb after CoW */
-        tlb_fill(env_cpu(env), paddr, size, MMU_DATA_STORE,
+        tlb_fill(env_cpu(env), addr, size, MMU_DATA_STORE,
                  mmu_idx, retaddr);
         index = tlb_index(env, mmu_idx, addr);
         entry = tlb_entry(env, mmu_idx, addr);


### PR DESCRIPTION
Title is mostly self explanatory. There was an issue where performing snapshots with a non one to one mapping of virtual to physical addresses, resulting in an assertion failure in unicorn. I assume this commit fixes the issue. @PhilippTakacs should check if this is correct now.