### PR TITLE
cmake: set C standard to GNU C due to inline assembly usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,6 +412,7 @@ else()
         -D_LARGEFILE_SOURCE
         -Wall
         -fPIC
+        -std=gnu99
     )
     if(APPLE)
         # This warning is disabled by default for gcc and doesn't cause any bug.


### PR DESCRIPTION
Standard ISO C does not have inline assembly support, but is a compiler extension. For compilers which default to ISO C, specify the use of GNU extensions to enable inline assembly.

Fixes compiler errors like this:

```
error: use of undeclared identifier 'asm'
```

---

I'm opening this pull request as a package maintainer, rather than a user of this library. Please feel free to ignore this pull request if it is not fitting for this project. I just want to bring attention to this issue and hopefully safe someone else a couple of headaches. I'm not even sure if this is the proper location to add this flag.

For reference: I'm using clang with extensions disabled by default, when `-std=` is not specified on the command line.

EDIT: I should mention that this is a very niche use case, since you must actively change the C standard (when `-std=` is omitted from the command line) during the configure step when building your own copy of LLVM. No sane compiler distribution will be configured like this.