### PR TITLE
fix fxsave fpip value, provide tests

### DIFF
--- a/qemu/target/i386/fpu_helper.c
+++ b/qemu/target/i386/fpu_helper.c
@@ -1170,7 +1170,7 @@ static void do_xsave_fpu(CPUX86State *env, target_ulong ptr, uintptr_t ra)
     /* In 32-bit mode this is eip, sel, dp, sel.
        In 64-bit mode this is rip, rdp.
        But in either case we don't write actual data, just zeros.  */
-    cpu_stq_data_ra(env, ptr + XO(legacy.fpip), 0, ra); /* eip+sel; rip */
+    cpu_stq_data_ra(env, ptr + XO(legacy.fpip), env->fpip, ra); /* eip+sel; rip */
     cpu_stq_data_ra(env, ptr + XO(legacy.fpdp), 0, ra); /* edp+sel; rdp */
 
     addr = ptr + XO(legacy.fpregs);


### PR DESCRIPTION
This is the same fix (and tests) that was merged in unicorn v1 (see https://github.com/unicorn-engine/unicorn/commit/63a445cbba18bf1313ac3699b5d25462b5d529f4/) now ported to unicorn v2. The fix makes sure that the fxsave x86/x64 instruction saves the instruction pointer (instead of zero) into the floating point context dump. This instruction is used in many modern polymorphic shellcodes. This is a new pull request, this time based on the dev branch.