### PR TITLE
qemu: fix UBSAN errors in tcg and arm translation

### DIFF
--- a/qemu/include/tcg/tcg-op.h
+++ b/qemu/include/tcg/tcg-op.h
@@ -46,8 +46,9 @@ static inline void gen_uc_tracecode(TCGContext *tcg_ctx, int32_t size, int32_t t
         0
     };
 
-    if (puc->hooks_count[type] == 1) {
-        cur = puc->hook[type].head;
+    const int hook_type = type & UC_HOOK_IDX_MASK;
+    if (puc->hooks_count[hook_type] == 1) {
+        cur = puc->hook[hook_type].head;
         
         while (cur) {
             hk = cur->data;

--- a/qemu/target/arm/translate.c
+++ b/qemu/target/arm/translate.c
@@ -7761,7 +7761,7 @@ static int t32_expandimm_rot(DisasContext *s, int x)
 /* Return the unrotated immediate from T32ExpandImm.  */
 static int t32_expandimm_imm(DisasContext *s, int x)
 {
-    int imm = extract32(x, 0, 8);
+    uint32_t imm = extract32(x, 0, 8);
 
     switch (extract32(x, 8, 4)) {
     case 0: /* XY */


### PR DESCRIPTION
follow-up to #1904 to target `dev` branch instead of `master`

For the fix in `tcp-op.h`:
```
SanitizerError
UndefinedBehaviorSanitizer: out-of-bounds-index unicorn/qemu/include/tcg/tcg-op.h:49:9 in

Details unicorn/qemu/include/tcg/tcg-op.h:49:9: runtime error: index 66 out of bounds for type 'int[17]'
    #0 0x7f0637b2656d in gen_uc_tracecode unicorn/qemu/include/tcg/tcg-op.h:49:9
    #1 0x7f0637b98b72 in thumb_tr_translate_insn unicorn/qemu/target/arm/translate.c
    #2 0x7f0637adef12 in translator_loop_arm unicorn/qemu/accel/tcg/translator.c:124:9
    #3 0x7f0637b21df6 in gen_intermediate_code_arm unicorn/qemu/target/arm/translate.c:11775:5
    #4 0x7f0637adc01b in tb_gen_code_arm unicorn/qemu/accel/tcg/translate-all.c:1636:5
    #5 0x7f0637ac3dbc in tb_find unicorn/qemu/accel/tcg/cpu-exec.c:259:14
    #6 0x7f0637ac3dbc in cpu_exec_arm unicorn/qemu/accel/tcg/cpu-exec.c:600:18
    #7 0x7f0637a72c5c in tcg_cpu_exec unicorn/qemu/softmmu/cpus.c:96:17
    #8 0x7f0637a72c5c in resume_all_vcpus_arm unicorn/qemu/softmmu/cpus.c:215:13
    #9 0x7f0637a72f98 in vm_start_arm unicorn/qemu/softmmu/cpus.c:234:5
    #10 0x7f0638903426 in uc_emu_start unicorn/uc.c:880:5
```

For the fix in `arm/translate.c`:
```
SanitizerError
UndefinedBehaviorSanitizer: signed-integer-overflow unicorn/qemu/target/arm/translate.c:7777:13

Details
unicorn/qemu/target/arm/translate.c:7777:13: runtime error: signed integer overflow: 255 * 16843009 cannot be represented in type 'int'
    #0 0x7fc28eda0389 in t32_expandimm_imm unicorn/qemu/target/arm/translate.c:7777:13
    #1 0x7fc28eda0389 in disas_t32_extract_s_rri_rot unicorn/qemu/target/arm/decode-t32.inc.c:845:14
    #2 0x7fc28ed9dbad in disas_t32 unicorn/qemu/target/arm/decode-t32.inc.c:1621:21
    #3 0x7fc28ed98cd0 in disas_thumb2_insn unicorn/qemu/target/arm/translate.c:11105:9
    #4 0x7fc28ed98cd0 in thumb_tr_translate_insn unicorn/qemu/target/arm/translate.c:11582:9
    #5 0x7fc28ecdef12 in translator_loop_arm unicorn/qemu/accel/tcg/translator.c:124:9
    #6 0x7fc28ed21df6 in gen_intermediate_code_arm unicorn/qemu/target/arm/translate.c:11775:5
    #7 0x7fc28ecdc01b in tb_gen_code_arm unicorn/qemu/accel/tcg/translate-all.c:1636:5
    #8 0x7fc28ecc3dbc in tb_find unicorn/qemu/accel/tcg/cpu-exec.c:259:14
    #9 0x7fc28ecc3dbc in cpu_exec_arm unicorn/qemu/accel/tcg/cpu-exec.c:600:18
    #10 0x7fc28ec72c5c in tcg_cpu_exec unicorn/qemu/softmmu/cpus.c:96:17
    #11 0x7fc28ec72c5c in resume_all_vcpus_arm unicorn/qemu/softmmu/cpus.c:215:13
    #12 0x7fc28ec72f98 in vm_start_arm unicorn/qemu/softmmu/cpus.c:234:5
    #13 0x7fc28faeb426 in uc_emu_start unicorn/uc.c:880:5
```