### PR TITLE
Fix PPC32 fault when timer-spr access

### DIFF
--- a/qemu/target/ppc/translate_init.inc.c
+++ b/qemu/target/ppc/translate_init.inc.c
@@ -171,6 +171,7 @@ static void spr_write_ureg(DisasContext *ctx, int sprn, int gprn)
 
 /* SPR common to all non-embedded PowerPC */
 /* DECR */
+#if 0
 static void spr_read_decr(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
@@ -182,7 +183,11 @@ static void spr_read_decr(DisasContext *ctx, int gprn, int sprn)
         gen_stop_exception(ctx);
     }
 }
+#else
+#define spr_read_decr spr_read_generic
+#endif
 
+#if 0
 static void spr_write_decr(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
@@ -194,9 +199,13 @@ static void spr_write_decr(DisasContext *ctx, int sprn, int gprn)
         gen_stop_exception(ctx);
     }
 }
+#else
+#define spr_write_decr spr_write_generic
+#endif
 
 /* SPR common to all non-embedded PowerPC, except 601 */
 /* Time base */
+#if 0
 static void spr_read_tbl(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
@@ -209,7 +218,11 @@ static void spr_read_tbl(DisasContext *ctx, int gprn, int sprn)
         gen_stop_exception(ctx);
     }
 }
+#else
+#define spr_read_tbl spr_read_generic
+#endif
 
+#if 0
 static void spr_read_tbu(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
@@ -222,6 +235,9 @@ static void spr_read_tbu(DisasContext *ctx, int gprn, int sprn)
         gen_stop_exception(ctx);
     }
 }
+#else
+#define spr_read_tbu spr_read_generic
+#endif
 
 #if 0
 // ATTRIBUTE_UNUSED
@@ -239,6 +255,7 @@ static void spr_read_atbu(DisasContext *ctx, int gprn, int sprn)
 }
 #endif
 
+#if 0
 static void spr_write_tbl(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
@@ -251,7 +268,12 @@ static void spr_write_tbl(DisasContext *ctx, int sprn, int gprn)
         gen_stop_exception(ctx);
     }
 }
+#else
+#define spr_write_tbl spr_write_generic
+#endif
 
+
+#if 0
 static void spr_write_tbu(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
@@ -264,6 +286,9 @@ static void spr_write_tbu(DisasContext *ctx, int sprn, int gprn)
         gen_stop_exception(ctx);
     }
 }
+#else
+#define spr_write_tbu spr_write_generic
+#endif
 
 #if 0
 // ATTRIBUTE_UNUSED

--- a/tests/unit/test_ppc.c
+++ b/tests/unit/test_ppc.c
@@ -105,8 +105,23 @@ static void test_ppc32_cr(void)
     OK(uc_close(uc));
 }
 
+static void test_ppc32_spr_time(void)
+{
+    char code[] = ("\x7c\x76\x02\xa6" // mfspr r3, DEC
+                   "\x7c\x6d\x42\xa6" // mfspr r3, TBUr
+    );
+
+    uc_engine *uc;
+    uc_common_setup(&uc, UC_ARCH_PPC, UC_MODE_32 | UC_MODE_BIG_ENDIAN, code,
+                    sizeof(code) - 1);
+
+    OK(uc_emu_start(uc, code_start, code_start + sizeof(code) - 1, 0, 0));
+    OK(uc_close(uc));
+}
+
 TEST_LIST = {{"test_ppc32_add", test_ppc32_add},
              {"test_ppc32_fadd", test_ppc32_fadd},
              {"test_ppc32_sc", test_ppc32_sc},
              {"test_ppc32_cr", test_ppc32_cr},
+             {"test_ppc32_spr_time", test_ppc32_spr_time},
              {NULL, NULL}};


### PR DESCRIPTION
Issue #1909 

Access to TB, DEC (time-related) Special Purpose Registers led to crash.

`spr_read_decr`, `spr_write_decr` and others are changed to `spr_read_generic` and `spr_write_decr`.
So spr read/write won't call Qemu time-related functions.
