### PR TITLE
fix cow when using uc_mem_write

### DIFF
--- a/qemu/softmmu/memory.c
+++ b/qemu/softmmu/memory.c
@@ -98,6 +98,9 @@ MemoryRegion *memory_cow(struct uc_struct *uc, MemoryRegion *current, hwaddr beg
     hwaddr current_offset;
     MemoryRegion *ram = g_new(MemoryRegion, 1);
 
+    assert((begin & ~TARGET_PAGE_MASK) == 0);
+    assert((size & ~TARGET_PAGE_MASK) == 0);
+
     if (current->container == uc->system_memory) {
         make_contained(uc, current);
     }

--- a/uc.c
+++ b/uc.c
@@ -788,7 +788,10 @@ uc_err uc_mem_write(uc_engine *uc, uint64_t address, const void *_bytes,
 
             len = memory_region_len(uc, mr, address, size - count);
             if (uc->snapshot_level && uc->snapshot_level > mr->priority) {
-                mr = uc->memory_cow(uc, mr, address, len);
+                mr = uc->memory_cow(uc, mr, address & ~uc->target_page_align,
+                                    (len + (address & uc->target_page_align) +
+                                     uc->target_page_align) &
+                                        ~uc->target_page_align);
                 if (!mr) {
                     return UC_ERR_NOMEM;
                 }


### PR DESCRIPTION
memory_cow expect the address and size to be aligned on pagesize.