### PR TITLE
Backport from qemu : fix do_nonatomic_op_* vs signed operations

### DIFF
--- a/qemu/tcg/tcg-op.c
+++ b/qemu/tcg/tcg-op.c
@@ -3240,8 +3240,9 @@ static void do_nonatomic_op_i32(TCGContext *tcg_ctx, TCGv_i32 ret, TCGv addr, TC
 
     memop = tcg_canonicalize_memop(memop, 0, 0);
 
-    tcg_gen_qemu_ld_i32(tcg_ctx, t1, addr, idx, memop & ~MO_SIGN);
-    gen(tcg_ctx, t2, t1, val);
+    tcg_gen_qemu_ld_i32(tcg_ctx, t1, addr, idx, memop);
+    tcg_gen_ext_i32(tcg_ctx, t2, val, memop);
+    gen(tcg_ctx, t2, t1, t2);
     tcg_gen_qemu_st_i32(tcg_ctx, t2, addr, idx, memop);
 
     tcg_gen_ext_i32(tcg_ctx, ret, (new_val ? t2 : t1), memop);
@@ -3279,8 +3280,9 @@ static void do_nonatomic_op_i64(TCGContext *tcg_ctx, TCGv_i64 ret, TCGv addr, TC
 
     memop = tcg_canonicalize_memop(memop, 1, 0);
 
-    tcg_gen_qemu_ld_i64(tcg_ctx, t1, addr, idx, memop & ~MO_SIGN);
-    gen(tcg_ctx, t2, t1, val);
+    tcg_gen_qemu_ld_i64(tcg_ctx, t1, addr, idx, memop);
+    tcg_gen_ext_i64(tcg_ctx, t2, val, memop);
+    gen(tcg_ctx, t2, t1, t2);
     tcg_gen_qemu_st_i64(tcg_ctx, t2, addr, idx, memop);
 
     tcg_gen_ext_i64(tcg_ctx, ret, (new_val ? t2 : t1), memop);


### PR DESCRIPTION
This fix makes non-atomic versions of min/max operations aware of sign extension.

The following piece of RISC-V assembly was producing bogus results:
```asm
	la a0, .d
	li a2, 1

	amomin.w a5, a2, (a0)
	lw a6, 0(a0)
.d:
	.word -1
```

The expected result in `a6` is `-1` but without the fix the result is `1`