### PR TITLE
Feature: Bindings: add start end to block hook

### DIFF
--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -620,6 +620,8 @@ impl<'a, D> Unicorn<'a, D> {
     /// Add a block hook.
     pub fn add_block_hook<F: 'a>(
         &mut self,
+        begin: u64,
+        end: u64,
         callback: F,
     ) -> Result<UcHookId, uc_error>
     where
@@ -638,8 +640,8 @@ impl<'a, D> Unicorn<'a, D> {
                 HookType::BLOCK,
                 ffi::block_hook_proxy::<D, F> as _,
                 user_data.as_mut() as *mut _ as _,
-                1,
-                0,
+                begin,
+                end,
             )
         }
         .and_then(|| {

--- a/tests/rust-tests/main.rs
+++ b/tests/rust-tests/main.rs
@@ -763,7 +763,7 @@ fn x86_block_callback() {
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
 
     let hook = emu
-        .add_block_hook(callback)
+        .add_block_hook(1, 0, callback)
         .expect("failed to add block hook");
     assert_eq!(
         emu.emu_start(0x1000, 0x1002, 10 * SECOND_SCALE, 1000),


### PR DESCRIPTION
The block hook was missing start and end parameters to limit the address range of the hook.