### PR TITLE
Remove semicolons in python files

### DIFF
--- a/bindings/python/sample_x86.py
+++ b/bindings/python/sample_x86.py
@@ -36,7 +36,7 @@ def hook_code(uc, address, size, user_data):
 def hook_code64(uc, address, size, user_data):
     print(">>> Tracing instruction at 0x%x, instruction size = 0x%x" %(address, size))
     rip = uc.reg_read(UC_X86_REG_RIP)
-    print(">>> RIP is 0x%x" %rip);
+    print(">>> RIP is 0x%x" %rip)
 
 
 # callback for tracing invalid memory access (READ or WRITE)

--- a/bindings/python/shellcode.py
+++ b/bindings/python/shellcode.py
@@ -74,7 +74,7 @@ def read_string(uc, address):
 def hook_intr(uc, intno, user_data):
     # only handle Linux syscall
     if intno != 0x80:
-        print("got interrupt %x ???" %intno);
+        print("got interrupt %x ???" %intno)
         uc.emu_stop()
         return
 

--- a/tests/regress/hang.py
+++ b/tests/regress/hang.py
@@ -19,7 +19,7 @@ def hook_intr(uc, intno, user_data):
     # only handle Linux syscall
     rip = uc.reg_read(UC_X86_REG_RIP)
     if intno != 0x80:
-        print("=== 0x%x: got interrupt %x, quit" %(rip, intno));
+        print("=== 0x%x: got interrupt %x, quit" %(rip, intno))
         uc.emu_stop()
         return
 

--- a/tests/regress/hook_readonly_write_local.py
+++ b/tests/regress/hook_readonly_write_local.py
@@ -12,7 +12,7 @@ CODE = b'\xA1\x00\x10\x00\x00\xA1\x00\x10\x00\x00'
 
 def hook_mem_read(uc, access, address, size, value, data):
     print("Reading at " + str(address))
-    uc.mem_write(address, CODE);
+    uc.mem_write(address, CODE)
 
 class REP(regress.RegressTest):
 
@@ -21,7 +21,7 @@ class REP(regress.RegressTest):
 
         mu.mem_map(0, PAGE_SIZE)
         mu.mem_write(0, CODE)
-        mu.mem_map(ACCESS_ADDR, PAGE_SIZE, UC_PROT_READ);
+        mu.mem_map(ACCESS_ADDR, PAGE_SIZE, UC_PROT_READ)
         mu.hook_add(UC_HOOK_MEM_READ, hook_mem_read, begin = ACCESS_ADDR, end = ACCESS_ADDR + PAGE_SIZE)
 
         mu.emu_start(0, len(CODE))

--- a/tests/regress/jmp_ebx_hang.py
+++ b/tests/regress/jmp_ebx_hang.py
@@ -18,13 +18,13 @@ class JumEbxHang(regress.RegressTest):
         # If EBX is zero then an exception is raised, as expected
         mu.reg_write(unicorn.x86_const.UC_X86_REG_EBX, 0x0)
 
-        print(">>> jmp ebx (ebx = 0)");
+        print(">>> jmp ebx (ebx = 0)")
         with self.assertRaises(UcError) as m:
             mu.emu_start(CODE_ADDR, CODE_ADDR + 2, count=1)
 
         self.assertEqual(m.exception.errno, UC_ERR_FETCH_UNMAPPED)
 
-        print(">>> jmp ebx (ebx = 0xaa96a47f)");
+        print(">>> jmp ebx (ebx = 0xaa96a47f)")
         mu = unicorn.Uc(UC_ARCH_X86, UC_MODE_32)
         mu.mem_map(CODE_ADDR, 1024 * 4)
         # If we write this address to EBX then the emulator hangs on emu_start


### PR DESCRIPTION
Noticed an errant semicolon while looking at the x86 sample and was curious if there were more so just cleaned a few more up real quick. 