### PR TITLE
Add unicorn_py3 folder to setup.py

### DIFF
--- a/.github/workflows/PyPI-publishing.yml
+++ b/.github/workflows/PyPI-publishing.yml
@@ -110,10 +110,6 @@ jobs:
     - name: '🛠️ pip dependencies'
       run: |
         pip install setuptools wheel
-    
-    - name: '🛠️ run samples'
-      run: |
-        cd bindings/python && pip install -e . && python3 sample_x86.py
 
     - name: '🚧 Build distribution'
       shell: bash 

--- a/.github/workflows/PyPI-publishing.yml
+++ b/.github/workflows/PyPI-publishing.yml
@@ -110,6 +110,10 @@ jobs:
     - name: '🛠️ pip dependencies'
       run: |
         pip install setuptools wheel
+    
+    - name: '🛠️ run samples'
+      run: |
+        cd bindings/python && pip install -e . && python3 sample_x86.py
 
     - name: '🚧 Build distribution'
       shell: bash 

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -232,7 +232,7 @@ Further information is available at http://www.unicorn-engine.org
 
 setup(
     provides=['unicorn'],
-    packages=['unicorn'],
+    packages=setuptools.find_packages(include=["unicorn", "unicorn.*"]),
     name='unicorn',
     version=VERSION,
     author='Nguyen Anh Quynh',
@@ -252,6 +252,6 @@ setup(
     include_package_data=True,
     is_pure=False,
     package_data={
-        'unicorn': ['lib/*', 'include/unicorn/*', 'unicorn_py3/**']
+        'unicorn': ['lib/*', 'include/unicorn/*']
     }
 )

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -252,6 +252,6 @@ setup(
     include_package_data=True,
     is_pure=False,
     package_data={
-        'unicorn': ['lib/*', 'include/unicorn/*']
+        'unicorn': ['lib/*', 'include/unicorn/*', 'unicorn_py3/**']
     }
 )

--- a/bindings/python/unicorn/unicorn_py2.py
+++ b/bindings/python/unicorn/unicorn_py2.py
@@ -17,6 +17,9 @@ from collections import namedtuple
 # years since EOL of Python2 so it should be fine.
 from . import x86_const, arm_const, arm64_const, unicorn_const as uc
 
+# Compatibility placeholder, nothing special here
+ucsubclass = 0
+
 if not hasattr(sys.modules[__name__], "__file__"):
     __file__ = inspect.getfile(inspect.currentframe())
 


### PR DESCRIPTION
New `unicorn_py3` folder is not installed when running `setup.py install`, making unicorn unable to be imported (`import unicorn`) when using Python 3, see error message attached. Double asterisk for recursiveness because inside the folder has `arch` folder also.

Without `unicorn_py3/*`
![image](https://github.com/unicorn-engine/unicorn/assets/29661303/95c94e55-47bd-4111-ac24-169fb3f211b9)

Without double asterisk
![image](https://github.com/unicorn-engine/unicorn/assets/29661303/29691dc7-3577-44de-b660-ac12069fe66b)
