### PR TITLE
Optimize memory handling

### DIFF
--- a/include/qemu.h
+++ b/include/qemu.h
@@ -43,6 +43,7 @@ typedef struct {
 typedef struct RAMList {
     bool freed;
     RAMBlock *mru_block;
+    RAMBlock *last_block;
     QLIST_HEAD(, RAMBlock) blocks;
 } RAMList;
 

--- a/include/uc_priv.h
+++ b/include/uc_priv.h
@@ -427,6 +427,8 @@ struct uc_context {
     uc_mode mode;        // the mode of this context
     uc_arch arch;        // the arch of this context
     int snapshot_level;  // the memory snapshot level to restore
+    bool ramblock_freed; // wheter there was a some ramblock freed
+    RAMBlock *last_block;// The last element of the ramblock list
     char data[0];        // context
 };
 

--- a/include/uc_priv.h
+++ b/include/uc_priv.h
@@ -108,6 +108,8 @@ typedef MemoryRegion *(*uc_memory_mapping_t)(struct uc_struct *, hwaddr addr);
 
 typedef void (*uc_memory_filter_t)(MemoryRegion *, int32_t);
 
+typedef bool (*uc_flatview_copy_t)(struct uc_struct *, FlatView *, FlatView *, bool);
+
 typedef void (*uc_readonly_mem_t)(MemoryRegion *mr, bool readonly);
 
 typedef int (*uc_cpus_init)(struct uc_struct *, const char *);
@@ -288,6 +290,7 @@ struct uc_struct {
     uc_args_uc_ram_size_ptr_t memory_map_ptr;
     uc_memory_mapping_t memory_mapping;
     uc_memory_filter_t memory_filter_subregions;
+    uc_flatview_copy_t flatview_copy;
     uc_mem_unmap_t memory_unmap;
     uc_mem_unmap_t memory_moveout;
     uc_mem_unmap_t memory_movein;
@@ -429,6 +432,7 @@ struct uc_context {
     int snapshot_level;  // the memory snapshot level to restore
     bool ramblock_freed; // wheter there was a some ramblock freed
     RAMBlock *last_block;// The last element of the ramblock list
+    FlatView *fv;        // The current flatview of the memory
     char data[0];        // context
 };
 

--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -1018,6 +1018,16 @@ struct uc_tlb_entry {
     uc_prot perms;
 };
 
+/*
+ Variables to control which state should be stored in the context.
+ Defaults to UC_CTL_CONTEXT_CPU. The options are used in a bitfield
+ so to enable more then one content the binary or of the required
+ contents can be use.
+ The UC_CTL_CONTEXT_MEMORY stores some pointers to internal allocated
+ memory. Therefor it's not possible to use this context with another
+ unicorn object.
+*/
+
 typedef enum uc_context_content {
     UC_CTL_CONTEXT_CPU = 1,
     UC_CTL_CONTEXT_MEMORY = 2,

--- a/qemu/aarch64.h
+++ b/qemu/aarch64.h
@@ -54,6 +54,7 @@
 #define vm_start vm_start_aarch64
 #define address_space_dispatch_compact address_space_dispatch_compact_aarch64
 #define flatview_translate flatview_translate_aarch64
+#define flatview_copy flatview_copy_aarch64
 #define address_space_translate_for_iotlb address_space_translate_for_iotlb_aarch64
 #define qemu_get_cpu qemu_get_cpu_aarch64
 #define cpu_address_space_init cpu_address_space_init_aarch64
@@ -90,6 +91,7 @@
 #define iotlb_to_section iotlb_to_section_aarch64
 #define address_space_dispatch_new address_space_dispatch_new_aarch64
 #define address_space_dispatch_free address_space_dispatch_free_aarch64
+#define address_space_dispatch_clear address_space_dispatch_clear_aarch64
 #define flatview_read_continue flatview_read_continue_aarch64
 #define address_space_read_full address_space_read_full_aarch64
 #define address_space_write address_space_write_aarch64

--- a/qemu/arm.h
+++ b/qemu/arm.h
@@ -54,6 +54,7 @@
 #define vm_start vm_start_arm
 #define address_space_dispatch_compact address_space_dispatch_compact_arm
 #define flatview_translate flatview_translate_arm
+#define flatview_copy flatview_copy_arm
 #define address_space_translate_for_iotlb address_space_translate_for_iotlb_arm
 #define qemu_get_cpu qemu_get_cpu_arm
 #define cpu_address_space_init cpu_address_space_init_arm
@@ -90,6 +91,7 @@
 #define iotlb_to_section iotlb_to_section_arm
 #define address_space_dispatch_new address_space_dispatch_new_arm
 #define address_space_dispatch_free address_space_dispatch_free_arm
+#define address_space_dispatch_clear address_space_dispatch_clear_arm
 #define flatview_read_continue flatview_read_continue_arm
 #define address_space_read_full address_space_read_full_arm
 #define address_space_write address_space_write_arm

--- a/qemu/exec.c
+++ b/qemu/exec.c
@@ -1074,7 +1074,7 @@ static void ram_block_add(struct uc_struct *uc, RAMBlock *new_block)
      * QLIST (which has an RCU-friendly variant) does not have insertion at
      * tail, so save the last element in last_block.
      */
-    if (new_block->max_length > uc->target_page_size) {
+    if (uc->ram_list.freed || new_block->max_length > uc->target_page_size) {
         RAMBLOCK_FOREACH(block) {
             last_block = block;
             if (block->max_length < new_block->max_length) {
@@ -1171,6 +1171,7 @@ void qemu_ram_free(struct uc_struct *uc, RAMBlock *block)
     QLIST_REMOVE_RCU(block, next);
     uc->ram_list.mru_block = NULL;
     uc->ram_list.freed = true;
+    uc->ram_list.last_block = NULL;
     /* Write list before version */
     //smp_wmb();
     // call_rcu(block, reclaim_ramblock, rcu);

--- a/qemu/exec.c
+++ b/qemu/exec.c
@@ -1455,6 +1455,13 @@ AddressSpaceDispatch *address_space_dispatch_new(struct uc_struct *uc, FlatView 
     return d;
 }
 
+void address_space_dispatch_clear(AddressSpaceDispatch *d)
+{
+    g_free(d->map.sections);
+    g_free(d->map.nodes);
+    g_free(d);
+}
+
 void address_space_dispatch_free(AddressSpaceDispatch *d)
 {
     phys_sections_free(&d->map);

--- a/qemu/include/exec/memory-internal.h
+++ b/qemu/include/exec/memory-internal.h
@@ -45,6 +45,7 @@ void flatview_add_to_dispatch(struct uc_struct *uc, FlatView *fv, MemoryRegionSe
 AddressSpaceDispatch *address_space_dispatch_new(struct uc_struct *uc, FlatView *fv);
 void address_space_dispatch_compact(AddressSpaceDispatch *d);
 void address_space_dispatch_free(AddressSpaceDispatch *d);
+void address_space_dispatch_clear(AddressSpaceDispatch *d);
 
 void mtree_print_dispatch(struct AddressSpaceDispatch *d,
                           MemoryRegion *root);

--- a/qemu/include/exec/memory.h
+++ b/qemu/include/exec/memory.h
@@ -1220,5 +1220,6 @@ void memory_unmap(struct uc_struct *uc, MemoryRegion *mr);
 void memory_moveout(struct uc_struct *uc, MemoryRegion *mr);
 void memory_movein(struct uc_struct *uc, MemoryRegion *mr);
 int memory_free(struct uc_struct *uc);
+bool flatview_copy(struct uc_struct *uc, FlatView *dst, FlatView *src, bool update_dispatcher);
 
 #endif

--- a/qemu/m68k.h
+++ b/qemu/m68k.h
@@ -54,6 +54,7 @@
 #define vm_start vm_start_m68k
 #define address_space_dispatch_compact address_space_dispatch_compact_m68k
 #define flatview_translate flatview_translate_m68k
+#define flatview_copy flatview_copy_m68k
 #define address_space_translate_for_iotlb address_space_translate_for_iotlb_m68k
 #define qemu_get_cpu qemu_get_cpu_m68k
 #define cpu_address_space_init cpu_address_space_init_m68k
@@ -90,6 +91,7 @@
 #define iotlb_to_section iotlb_to_section_m68k
 #define address_space_dispatch_new address_space_dispatch_new_m68k
 #define address_space_dispatch_free address_space_dispatch_free_m68k
+#define address_space_dispatch_clear address_space_dispatch_clear_m68k
 #define flatview_read_continue flatview_read_continue_m68k
 #define address_space_read_full address_space_read_full_m68k
 #define address_space_write address_space_write_m68k

--- a/qemu/mips.h
+++ b/qemu/mips.h
@@ -54,6 +54,7 @@
 #define vm_start vm_start_mips
 #define address_space_dispatch_compact address_space_dispatch_compact_mips
 #define flatview_translate flatview_translate_mips
+#define flatview_copy flatview_copy_mips
 #define address_space_translate_for_iotlb address_space_translate_for_iotlb_mips
 #define qemu_get_cpu qemu_get_cpu_mips
 #define cpu_address_space_init cpu_address_space_init_mips
@@ -90,6 +91,7 @@
 #define iotlb_to_section iotlb_to_section_mips
 #define address_space_dispatch_new address_space_dispatch_new_mips
 #define address_space_dispatch_free address_space_dispatch_free_mips
+#define address_space_dispatch_clear address_space_dispatch_clear_mips
 #define flatview_read_continue flatview_read_continue_mips
 #define address_space_read_full address_space_read_full_mips
 #define address_space_write address_space_write_mips

--- a/qemu/mips64.h
+++ b/qemu/mips64.h
@@ -54,6 +54,7 @@
 #define vm_start vm_start_mips64
 #define address_space_dispatch_compact address_space_dispatch_compact_mips64
 #define flatview_translate flatview_translate_mips64
+#define flatview_copy flatview_copy_mips64
 #define address_space_translate_for_iotlb address_space_translate_for_iotlb_mips64
 #define qemu_get_cpu qemu_get_cpu_mips64
 #define cpu_address_space_init cpu_address_space_init_mips64
@@ -90,6 +91,7 @@
 #define iotlb_to_section iotlb_to_section_mips64
 #define address_space_dispatch_new address_space_dispatch_new_mips64
 #define address_space_dispatch_free address_space_dispatch_free_mips64
+#define address_space_dispatch_clear address_space_dispatch_clear_mips64
 #define flatview_read_continue flatview_read_continue_mips64
 #define address_space_read_full address_space_read_full_mips64
 #define address_space_write address_space_write_mips64

--- a/qemu/mips64el.h
+++ b/qemu/mips64el.h
@@ -54,6 +54,7 @@
 #define vm_start vm_start_mips64el
 #define address_space_dispatch_compact address_space_dispatch_compact_mips64el
 #define flatview_translate flatview_translate_mips64el
+#define flatview_copy flatview_copy_mips64el
 #define address_space_translate_for_iotlb address_space_translate_for_iotlb_mips64el
 #define qemu_get_cpu qemu_get_cpu_mips64el
 #define cpu_address_space_init cpu_address_space_init_mips64el
@@ -90,6 +91,7 @@
 #define iotlb_to_section iotlb_to_section_mips64el
 #define address_space_dispatch_new address_space_dispatch_new_mips64el
 #define address_space_dispatch_free address_space_dispatch_free_mips64el
+#define address_space_dispatch_clear address_space_dispatch_clear_mips64el
 #define flatview_read_continue flatview_read_continue_mips64el
 #define address_space_read_full address_space_read_full_mips64el
 #define address_space_write address_space_write_mips64el

--- a/qemu/mipsel.h
+++ b/qemu/mipsel.h
@@ -54,6 +54,7 @@
 #define vm_start vm_start_mipsel
 #define address_space_dispatch_compact address_space_dispatch_compact_mipsel
 #define flatview_translate flatview_translate_mipsel
+#define flatview_copy flatview_copy_mipsel
 #define address_space_translate_for_iotlb address_space_translate_for_iotlb_mipsel
 #define qemu_get_cpu qemu_get_cpu_mipsel
 #define cpu_address_space_init cpu_address_space_init_mipsel
@@ -90,6 +91,7 @@
 #define iotlb_to_section iotlb_to_section_mipsel
 #define address_space_dispatch_new address_space_dispatch_new_mipsel
 #define address_space_dispatch_free address_space_dispatch_free_mipsel
+#define address_space_dispatch_clear address_space_dispatch_clear_mipsel
 #define flatview_read_continue flatview_read_continue_mipsel
 #define address_space_read_full address_space_read_full_mipsel
 #define address_space_write address_space_write_mipsel

--- a/qemu/ppc.h
+++ b/qemu/ppc.h
@@ -54,6 +54,7 @@
 #define vm_start vm_start_ppc
 #define address_space_dispatch_compact address_space_dispatch_compact_ppc
 #define flatview_translate flatview_translate_ppc
+#define flatview_copy flatview_copy_ppc
 #define address_space_translate_for_iotlb address_space_translate_for_iotlb_ppc
 #define qemu_get_cpu qemu_get_cpu_ppc
 #define cpu_address_space_init cpu_address_space_init_ppc
@@ -90,6 +91,7 @@
 #define iotlb_to_section iotlb_to_section_ppc
 #define address_space_dispatch_new address_space_dispatch_new_ppc
 #define address_space_dispatch_free address_space_dispatch_free_ppc
+#define address_space_dispatch_clear address_space_dispatch_clear_ppc
 #define flatview_read_continue flatview_read_continue_ppc
 #define address_space_read_full address_space_read_full_ppc
 #define address_space_write address_space_write_ppc

--- a/qemu/ppc64.h
+++ b/qemu/ppc64.h
@@ -54,6 +54,7 @@
 #define vm_start vm_start_ppc64
 #define address_space_dispatch_compact address_space_dispatch_compact_ppc64
 #define flatview_translate flatview_translate_ppc64
+#define flatview_copy flatview_copy_ppc64
 #define address_space_translate_for_iotlb address_space_translate_for_iotlb_ppc64
 #define qemu_get_cpu qemu_get_cpu_ppc64
 #define cpu_address_space_init cpu_address_space_init_ppc64
@@ -90,6 +91,7 @@
 #define iotlb_to_section iotlb_to_section_ppc64
 #define address_space_dispatch_new address_space_dispatch_new_ppc64
 #define address_space_dispatch_free address_space_dispatch_free_ppc64
+#define address_space_dispatch_clear address_space_dispatch_clear_ppc64
 #define flatview_read_continue flatview_read_continue_ppc64
 #define address_space_read_full address_space_read_full_ppc64
 #define address_space_write address_space_write_ppc64

--- a/qemu/riscv32.h
+++ b/qemu/riscv32.h
@@ -54,6 +54,7 @@
 #define vm_start vm_start_riscv32
 #define address_space_dispatch_compact address_space_dispatch_compact_riscv32
 #define flatview_translate flatview_translate_riscv32
+#define flatview_copy flatview_copy_riscv32
 #define address_space_translate_for_iotlb address_space_translate_for_iotlb_riscv32
 #define qemu_get_cpu qemu_get_cpu_riscv32
 #define cpu_address_space_init cpu_address_space_init_riscv32
@@ -90,6 +91,7 @@
 #define iotlb_to_section iotlb_to_section_riscv32
 #define address_space_dispatch_new address_space_dispatch_new_riscv32
 #define address_space_dispatch_free address_space_dispatch_free_riscv32
+#define address_space_dispatch_clear address_space_dispatch_clear_riscv32
 #define flatview_read_continue flatview_read_continue_riscv32
 #define address_space_read_full address_space_read_full_riscv32
 #define address_space_write address_space_write_riscv32

--- a/qemu/riscv64.h
+++ b/qemu/riscv64.h
@@ -54,6 +54,7 @@
 #define vm_start vm_start_riscv64
 #define address_space_dispatch_compact address_space_dispatch_compact_riscv64
 #define flatview_translate flatview_translate_riscv64
+#define flatview_copy flatview_copy_riscv64
 #define address_space_translate_for_iotlb address_space_translate_for_iotlb_riscv64
 #define qemu_get_cpu qemu_get_cpu_riscv64
 #define cpu_address_space_init cpu_address_space_init_riscv64
@@ -90,6 +91,7 @@
 #define iotlb_to_section iotlb_to_section_riscv64
 #define address_space_dispatch_new address_space_dispatch_new_riscv64
 #define address_space_dispatch_free address_space_dispatch_free_riscv64
+#define address_space_dispatch_clear address_space_dispatch_clear_riscv64
 #define flatview_read_continue flatview_read_continue_riscv64
 #define address_space_read_full address_space_read_full_riscv64
 #define address_space_write address_space_write_riscv64

--- a/qemu/s390x.h
+++ b/qemu/s390x.h
@@ -54,6 +54,7 @@
 #define vm_start vm_start_s390x
 #define address_space_dispatch_compact address_space_dispatch_compact_s390x
 #define flatview_translate flatview_translate_s390x
+#define flatview_copy flatview_copy_s390x
 #define address_space_translate_for_iotlb address_space_translate_for_iotlb_s390x
 #define qemu_get_cpu qemu_get_cpu_s390x
 #define cpu_address_space_init cpu_address_space_init_s390x
@@ -90,6 +91,7 @@
 #define iotlb_to_section iotlb_to_section_s390x
 #define address_space_dispatch_new address_space_dispatch_new_s390x
 #define address_space_dispatch_free address_space_dispatch_free_s390x
+#define address_space_dispatch_clear address_space_dispatch_clear_s390x
 #define flatview_read_continue flatview_read_continue_s390x
 #define address_space_read_full address_space_read_full_s390x
 #define address_space_write address_space_write_s390x

--- a/qemu/softmmu/memory.c
+++ b/qemu/softmmu/memory.c
@@ -94,6 +94,7 @@ static void make_contained(struct uc_struct *uc, MemoryRegion *current)
 
 MemoryRegion *memory_cow(struct uc_struct *uc, MemoryRegion *current, hwaddr begin, size_t size)
 {
+    hwaddr addr;
     hwaddr offset;
     hwaddr current_offset;
     MemoryRegion *ram = g_new(MemoryRegion, 1);
@@ -118,7 +119,9 @@ MemoryRegion *memory_cow(struct uc_struct *uc, MemoryRegion *current, hwaddr beg
     memory_region_add_subregion_overlap(current->container, offset, ram, uc->snapshot_level);
 
     if (uc->cpu) {
-        tlb_flush(uc->cpu);
+        for (addr = ram->addr; (int64_t)(ram->end - addr) > 0; addr += uc->target_page_size) {
+           tlb_flush_page(uc->cpu, addr);
+        }
     }
 
     uc->memory_region_update_pending = true;

--- a/qemu/softmmu/memory.c
+++ b/qemu/softmmu/memory.c
@@ -195,19 +195,33 @@ MemoryRegion *memory_map_io(struct uc_struct *uc, ram_addr_t begin, size_t size,
     return mmio;
 }
 
+static void memory_region_remove_subregion(MemoryRegion *mr,
+                                 MemoryRegion *subregion)
+{
+    assert(subregion->container == mr);
+    subregion->container = NULL;
+    QTAILQ_REMOVE(&mr->subregions, subregion, subregions_link);
+}
+
 void memory_region_filter_subregions(MemoryRegion *mr, int32_t level)
 {
     MemoryRegion *subregion, *subregion_next;
-    memory_region_transaction_begin();
+    /*
+     * memory transaction/commit are only to rebuild the flatview. At
+     * this point there is need to rebuild the flatview, because this
+     * function is either called as part of a destructor or as part of
+     * a context restore. In the destructor case the caller remove the
+     * complete memory region and should do a transaction/commit. In
+     * the context restore case the flatview is taken from the context so
+     * no need to rebuild it.
+     */
     QTAILQ_FOREACH_SAFE(subregion, &mr->subregions, subregions_link, subregion_next) {
         if (subregion->priority >= level) {
-            memory_region_del_subregion(mr, subregion);
+            memory_region_remove_subregion(mr, subregion);
             subregion->destructor(subregion);
             g_free(subregion);
-            mr->uc->memory_region_update_pending = true;
         }
     }
-    memory_region_transaction_commit(mr);
 }
 
 static void memory_region_remove_mapped_block(struct uc_struct *uc, MemoryRegion *mr, bool free)
@@ -908,6 +922,37 @@ static void flatviews_init(struct uc_struct *uc)
     }
 }
 
+bool flatview_copy(struct uc_struct *uc, FlatView *dst, FlatView *src, bool update_dispatcher)
+{
+    if (!dst->ranges || !dst->nr_allocated || dst->nr_allocated < src->nr) {
+        if (dst->ranges && dst->nr_allocated) {
+            free(dst->ranges);
+        }
+        dst->ranges = calloc(src->nr_allocated, sizeof(*dst->ranges));
+        if (!dst->ranges) {
+            return false;
+        }
+        dst->nr_allocated = src->nr_allocated;
+    }
+    memcpy(dst->ranges, src->ranges, src->nr*sizeof(*dst->ranges));
+    dst->nr = src->nr;
+    if (!update_dispatcher) {
+        return true;
+    }
+    if (dst->dispatch) {
+        address_space_dispatch_clear(dst->dispatch);
+    }
+    dst->dispatch = address_space_dispatch_new(uc, dst);
+    for (size_t j = 0; j < dst->nr; j++) {
+        MemoryRegionSection mrs =
+            section_from_flat_range(&dst->ranges[j], dst);
+	mrs.mr->subpage = false;
+        flatview_add_to_dispatch(uc, dst, &mrs);
+    }
+    address_space_dispatch_compact(dst->dispatch);
+    return true;
+}
+
 static bool flatview_update(FlatView *fv, MemoryRegion *mr)
 {
     struct uc_struct *uc = mr->uc;
@@ -933,7 +978,7 @@ static bool flatview_update(FlatView *fv, MemoryRegion *mr)
         fv->ranges[i].mr = mr;
         fv->ranges[i].offset_in_region = 0;
         fv->ranges[i].readonly = mr->readonly;
-        address_space_dispatch_free(fv->dispatch);
+        address_space_dispatch_clear(fv->dispatch);
         fv->dispatch = address_space_dispatch_new(uc, fv);
         for (size_t j = 0; j < fv->nr; j++) {
             MemoryRegionSection mrs =

--- a/qemu/softmmu/memory.c
+++ b/qemu/softmmu/memory.c
@@ -939,6 +939,7 @@ bool flatview_copy(struct uc_struct *uc, FlatView *dst, FlatView *src, bool upda
     if (!update_dispatcher) {
         return true;
     }
+    MEMORY_LISTENER_CALL_GLOBAL(uc, begin, Forward);
     if (dst->dispatch) {
         address_space_dispatch_clear(dst->dispatch);
     }
@@ -950,6 +951,7 @@ bool flatview_copy(struct uc_struct *uc, FlatView *dst, FlatView *src, bool upda
         flatview_add_to_dispatch(uc, dst, &mrs);
     }
     address_space_dispatch_compact(dst->dispatch);
+    MEMORY_LISTENER_CALL_GLOBAL(uc, commit, Forward);
     return true;
 }
 

--- a/qemu/sparc.h
+++ b/qemu/sparc.h
@@ -54,6 +54,7 @@
 #define vm_start vm_start_sparc
 #define address_space_dispatch_compact address_space_dispatch_compact_sparc
 #define flatview_translate flatview_translate_sparc
+#define flatview_copy flatview_copy_sparc
 #define address_space_translate_for_iotlb address_space_translate_for_iotlb_sparc
 #define qemu_get_cpu qemu_get_cpu_sparc
 #define cpu_address_space_init cpu_address_space_init_sparc
@@ -90,6 +91,7 @@
 #define iotlb_to_section iotlb_to_section_sparc
 #define address_space_dispatch_new address_space_dispatch_new_sparc
 #define address_space_dispatch_free address_space_dispatch_free_sparc
+#define address_space_dispatch_clear address_space_dispatch_clear_sparc
 #define flatview_read_continue flatview_read_continue_sparc
 #define address_space_read_full address_space_read_full_sparc
 #define address_space_write address_space_write_sparc

--- a/qemu/sparc64.h
+++ b/qemu/sparc64.h
@@ -54,6 +54,7 @@
 #define vm_start vm_start_sparc64
 #define address_space_dispatch_compact address_space_dispatch_compact_sparc64
 #define flatview_translate flatview_translate_sparc64
+#define flatview_copy flatview_copy_sparc64
 #define address_space_translate_for_iotlb address_space_translate_for_iotlb_sparc64
 #define qemu_get_cpu qemu_get_cpu_sparc64
 #define cpu_address_space_init cpu_address_space_init_sparc64
@@ -90,6 +91,7 @@
 #define iotlb_to_section iotlb_to_section_sparc64
 #define address_space_dispatch_new address_space_dispatch_new_sparc64
 #define address_space_dispatch_free address_space_dispatch_free_sparc64
+#define address_space_dispatch_clear address_space_dispatch_clear_sparc64
 #define flatview_read_continue flatview_read_continue_sparc64
 #define address_space_read_full address_space_read_full_sparc64
 #define address_space_write address_space_write_sparc64

--- a/qemu/tricore.h
+++ b/qemu/tricore.h
@@ -54,6 +54,7 @@
 #define vm_start vm_start_tricore
 #define address_space_dispatch_compact address_space_dispatch_compact_tricore
 #define flatview_translate flatview_translate_tricore
+#define flatview_copy flatview_copy_tricore
 #define address_space_translate_for_iotlb address_space_translate_for_iotlb_tricore
 #define qemu_get_cpu qemu_get_cpu_tricore
 #define cpu_address_space_init cpu_address_space_init_tricore
@@ -90,6 +91,7 @@
 #define iotlb_to_section iotlb_to_section_tricore
 #define address_space_dispatch_new address_space_dispatch_new_tricore
 #define address_space_dispatch_free address_space_dispatch_free_tricore
+#define address_space_dispatch_clear address_space_dispatch_clear_tricore
 #define flatview_read_continue flatview_read_continue_tricore
 #define address_space_read_full address_space_read_full_tricore
 #define address_space_write address_space_write_tricore

--- a/qemu/unicorn_common.h
+++ b/qemu/unicorn_common.h
@@ -140,6 +140,7 @@ static inline void uc_common_init(struct uc_struct* uc)
     uc->set_tlb = uc_set_tlb;
     uc->memory_mapping = find_memory_mapping;
     uc->memory_filter_subregions = memory_region_filter_subregions;
+    uc->flatview_copy = flatview_copy;
     uc->memory_cow = memory_cow;
 
     if (!uc->release)

--- a/qemu/x86_64.h
+++ b/qemu/x86_64.h
@@ -54,6 +54,7 @@
 #define vm_start vm_start_x86_64
 #define address_space_dispatch_compact address_space_dispatch_compact_x86_64
 #define flatview_translate flatview_translate_x86_64
+#define flatview_copy flatview_copy_x86_64
 #define address_space_translate_for_iotlb address_space_translate_for_iotlb_x86_64
 #define qemu_get_cpu qemu_get_cpu_x86_64
 #define cpu_address_space_init cpu_address_space_init_x86_64
@@ -90,6 +91,7 @@
 #define iotlb_to_section iotlb_to_section_x86_64
 #define address_space_dispatch_new address_space_dispatch_new_x86_64
 #define address_space_dispatch_free address_space_dispatch_free_x86_64
+#define address_space_dispatch_clear address_space_dispatch_clear_x86_64
 #define flatview_read_continue flatview_read_continue_x86_64
 #define address_space_read_full address_space_read_full_x86_64
 #define address_space_write address_space_write_x86_64

--- a/symbols.sh
+++ b/symbols.sh
@@ -54,6 +54,7 @@ resume_all_vcpus \
 vm_start \
 address_space_dispatch_compact \
 flatview_translate \
+flatview_copy \
 address_space_translate_for_iotlb \
 qemu_get_cpu \
 cpu_address_space_init \
@@ -90,6 +91,7 @@ cpu_check_watchpoint \
 iotlb_to_section \
 address_space_dispatch_new \
 address_space_dispatch_free \
+address_space_dispatch_clear \
 flatview_read_continue \
 address_space_read_full \
 address_space_write \

--- a/uc.c
+++ b/uc.c
@@ -2144,7 +2144,7 @@ uc_err uc_context_save(uc_engine *uc, uc_context *context)
 
     if (uc->context_content & UC_CTL_CONTEXT_MEMORY) {
         if (!context->fv) {
-            context->fv = g_malloc(sizeof(*context->fv));
+            context->fv = g_malloc0(sizeof(*context->fv));
         }
         if (!context->fv) {
             return UC_ERR_NOMEM;

--- a/uc.c
+++ b/uc.c
@@ -2147,6 +2147,8 @@ uc_err uc_context_save(uc_engine *uc, uc_context *context)
             restore_jit_state(uc);
             return ret;
         }
+        context->ramblock_freed = uc->ram_list.freed;
+        context->last_block = uc->ram_list.last_block;
     }
 
     context->snapshot_level = uc->snapshot_level;
@@ -2418,6 +2420,8 @@ uc_err uc_context_restore(uc_engine *uc, uc_context *context)
             return ret;
         }
         uc_snapshot(uc);
+        uc->ram_list.freed = context->ramblock_freed;
+        uc->ram_list.last_block = context->last_block;
     }
 
     if (uc->context_content & UC_CTL_CONTEXT_CPU) {
@@ -2870,6 +2874,7 @@ static uc_err uc_restore_latest_snapshot(struct uc_struct *uc)
         g_array_remove_range(uc->unmapped_regions, i, 1);
     }
     uc->snapshot_level--;
+
     return UC_ERR_OK;
 }
 

--- a/uc.c
+++ b/uc.c
@@ -2106,6 +2106,7 @@ uc_err uc_context_alloc(uc_engine *uc, uc_context **context)
         (*_context)->context_size = size - sizeof(uc_context);
         (*_context)->arch = uc->arch;
         (*_context)->mode = uc->mode;
+        (*_context)->fv = NULL;
         restore_jit_state(uc);
         return UC_ERR_OK;
     } else {
@@ -2142,6 +2143,16 @@ uc_err uc_context_save(uc_engine *uc, uc_context *context)
     uc_err ret = UC_ERR_OK;
 
     if (uc->context_content & UC_CTL_CONTEXT_MEMORY) {
+        if (!context->fv) {
+            context->fv = g_malloc(sizeof(*context->fv));
+        }
+        if (!context->fv) {
+            return UC_ERR_NOMEM;
+        }
+        if (!uc->flatview_copy(uc, context->fv, uc->address_space_memory.current_map, false)) {
+            restore_jit_state(uc);
+            return UC_ERR_NOMEM;
+        }
         ret = uc_snapshot(uc);
         if (ret != UC_ERR_OK) {
             restore_jit_state(uc);
@@ -2422,6 +2433,9 @@ uc_err uc_context_restore(uc_engine *uc, uc_context *context)
         uc_snapshot(uc);
         uc->ram_list.freed = context->ramblock_freed;
         uc->ram_list.last_block = context->last_block;
+        if (!uc->flatview_copy(uc, uc->address_space_memory.current_map, context->fv, true)) {
+            return UC_ERR_NOMEM;
+        }
     }
 
     if (uc->context_content & UC_CTL_CONTEXT_CPU) {
@@ -2438,6 +2452,10 @@ uc_err uc_context_restore(uc_engine *uc, uc_context *context)
 UNICORN_EXPORT
 uc_err uc_context_free(uc_context *context)
 {
+    if (context->fv) {
+        free(context->fv->ranges);
+        g_free(context->fv);
+    }
     return uc_free(context);
 }
 


### PR DESCRIPTION
By using the memory snapshots with real examples we found some bottlenecks. Therefor I have implemented some optimizations.

We found that the flatview creation is quite expensive (around 1/4 of all runtime including emulation) when you have a lot of memory regions. By permanently creating new regions with CoW we have a lot of regions and rebuild for each cow the flatview again. I have added a update function does only change affected ranges.

Also we found that the `find_ram_offset_last` optimization doesn't work after a restore. To fix this the context now includes also the `ramblock_freed` bool.

This also includes two smaller optimizations: only clear the affected tlb on memory_cow and save the last `ramblock` of the `ram_list`

It's currently only a draft, because we need to do a few more tests to see if the optimization works as expected.