### PR TITLE
Fix emulator detection

### DIFF
--- a/qemu/target/i386/translate.c
+++ b/qemu/target/i386/translate.c
@@ -7829,11 +7829,15 @@ static target_ulong disas_insn(DisasContext *s, CPUState *cpu)
             gen_op_mov_reg_v(s, MO_64, reg, s->T0);
         } else
 #endif
-        {
+        if (dflag == MO_32) {
             gen_op_mov_v_reg(s, MO_32, s->T0, reg);
             tcg_gen_ext32u_tl(tcg_ctx, s->T0, s->T0);
             tcg_gen_bswap32_tl(tcg_ctx, s->T0, s->T0);
             gen_op_mov_reg_v(s, MO_32, reg, s->T0);
+        }
+        else {
+            tcg_gen_movi_tl(tcg_ctx, s->T0, 0);
+            gen_op_mov_reg_v(s, MO_16, reg, s->T0);
         }
         break;
     case 0xd6: /* salc */


### PR DESCRIPTION
References:
- https://gynvael.coldwind.pl/?id=268
- https://github.com/JonathanSalwan/Triton/issues/1131

This fixes the `bswap ax` detection as well as various other detections related to bad REX prefix handling. This bug is also still upstream in qemu, but they moved the code around quite a bit:

https://github.com/qemu/qemu/blob/ffeddb979400b1580ad28acbee09b6f971c3912d/target/i386/tcg/decode-new.c.inc#L2561-L2570

There are two fixes here:
- `bswap ax` now correctly sets `ax` to zero
- REX prefixes are correctly ignored when appropriate (they only apply when they are right next to the first byte of the instruction)