### PR TITLE
Python: Drop deprecated `distutils` import in favor of `sysconfig`

### DIFF
--- a/bindings/python/unicorn/unicorn.py
+++ b/bindings/python/unicorn/unicorn.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 import ctypes
 import ctypes.util
-import distutils.sysconfig
+import sysconfig
 from functools import wraps
 from typing import Any, Callable, List, Tuple, Union
 import pkg_resources
@@ -85,7 +85,7 @@ _path_list = [os.getenv('LIBUNICORN_PATH', None),
               pkg_resources.resource_filename(__name__, 'lib'),
               os.path.join(os.path.split(__file__)[0], 'lib'),
               '',
-              distutils.sysconfig.get_python_lib(),
+              sysconfig.get_path('platlib'),
               "/usr/local/lib/" if sys.platform == 'darwin' else '/usr/lib64',
               os.getenv('PATH', '')]
 


### PR DESCRIPTION
Python 3.12 removed the `distutils` package from the standard library (PEP 632). For `distutils.sysconfig`, we can simply switch to the `sysconfig` standard library module.


I'm not sure if the `master` branch will be used for any future releases, so I'm not sure if the PR is useful. I'll reference the PR for distro packaging though. (It seems like a lot has changed over on the `dev` branch)

Feel free to merge or close :)