### PR TITLE
Update cmake minimum required to version 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # CMake setup for Unicorn 2.
 # By Huitao Chen & Nguyen Anh Quynh, 2019-2020
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 # Only required for MSVC, but we can't know the compiler at this point because we haven't
 # called enable_language() or project(), and if we did that it would lock in the old
@@ -17,10 +17,8 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.15")
     cmake_policy(SET CMP0092 NEW)
 endif()
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.3")
-    # Honor visibility properties for all target types.
-    cmake_policy(SET CMP0063 NEW)
-endif()
+# Honor visibility properties for all target types.
+cmake_policy(SET CMP0063 NEW)
 
 option(ZIG_BUILD "Enable zig build" OFF)
 if(ZIG_BUILD)


### PR DESCRIPTION
Fix the following warning during cmake configuration:
> CMake Deprecation Warning at CMakeLists.txt:4 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.
>
 > Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.