### PR TITLE
gcc compiler warning fixes

### DIFF
--- a/qemu/include/tcg/tcg-apple-jit.h
+++ b/qemu/include/tcg/tcg-apple-jit.h
@@ -94,14 +94,14 @@ static inline void jit_write_protect(int enabled)
 
 #define JIT_CALLBACK_GUARD(x) \
 {                             \
-    (void*)uc;                \
+    (void)uc;                 \
     x;                        \
 }                             \
 
 
 #define JIT_CALLBACK_GUARD_VAR(var, x)  \
 {                                       \
-    (void*)uc;                          \
+    (void)uc;                           \
     var = x;                            \
 }                                       \
 

--- a/qemu/target/ppc/excp_helper.c
+++ b/qemu/target/ppc/excp_helper.c
@@ -1064,7 +1064,7 @@ void helper_store_msr(CPUPPCState *env, target_ulong val)
 #if defined(_MSC_VER) && defined(__clang__)
 void helper_pminsn(CPUPPCState *env, uint32_t insn)
 #else
-void helper_pminsn(CPUPPCState *env, powerpc_pm_insn_t insn)
+void helper_pminsn(CPUPPCState *env, uint32_t /*powerpc_pm_insn_t*/ insn)
 #endif
 {
     CPUState *cs;

--- a/uc.c
+++ b/uc.c
@@ -65,11 +65,11 @@ static void restore_jit_state(uc_engine *uc)
 #else
 static void save_jit_state(uc_engine *uc)
 {
-    (void *)uc;
+    (void)uc;
 }
 static void restore_jit_state(uc_engine *uc)
 {
-    (void *)uc;
+    (void)uc;
 }
 #endif
 


### PR DESCRIPTION
The gcc compiler version 13.2.0 complains about:
- unused variables in two macros (due to casting to void* instead of void)
- enum-int-mismatch in a method parameter

This small PR fixes these issues so the build log is warning and error free for gcc - under linux.