### PR TITLE
[QEMU backport] riscv: fix wfi exception behavior

### DIFF
--- a/qemu/target/riscv/cpu_bits.h
+++ b/qemu/target/riscv/cpu_bits.h
@@ -427,6 +427,7 @@
 #define HSTATUS_SP2P         0x00000100
 #define HSTATUS_SP2V         0x00000200
 #define HSTATUS_VTVM         0x00100000
+#define HSTATUS_VTW          0x00200000
 #define HSTATUS_VTSR         0x00400000
 
 #define HSTATUS32_WPRI       0xFF8FF87E

--- a/qemu/target/riscv/op_helper.c
+++ b/qemu/target/riscv/op_helper.c
@@ -172,11 +172,15 @@ target_ulong helper_mret(CPURISCVState *env, target_ulong cpu_pc_deb)
 void helper_wfi(CPURISCVState *env)
 {
     CPUState *cs = env_cpu(env);
+    bool rvs = riscv_has_ext(env, RVS);
+    bool prv_u = env->priv == PRV_U;
+    bool prv_s = env->priv == PRV_S;
 
-    if ((env->priv == PRV_S &&
-        env->priv_ver >= PRIV_VERSION_1_10_0 &&
-        get_field(env->mstatus, MSTATUS_TW)) ||
-        riscv_cpu_virt_enabled(env)) {
+    if (((prv_s || (!rvs && prv_u)) && get_field(env->mstatus, MSTATUS_TW)) ||
+        (rvs && prv_u && !riscv_cpu_virt_enabled(env))) {
+        riscv_raise_exception(env, RISCV_EXCP_ILLEGAL_INST, GETPC());
+    } else if (riscv_cpu_virt_enabled(env) && (prv_u ||
+        (prv_s && get_field(env->hstatus, HSTATUS_VTW)))) {
         riscv_raise_exception(env, RISCV_EXCP_ILLEGAL_INST, GETPC());
     } else {
         cs->halted = 1;


### PR DESCRIPTION
The QEMU version currently used by Unicorn treats the `wfi` (wait for interrupt) instruction slightly incorrectly per the ratified wording in the RISC-V ISA specification. I believe this is because the QEMU implementation was originally based on an earlier revision (pre-ratification) and then the specification was subsequently refined.

This problem has been fixed in upstream QEMU in [`719f0f60`](https://github.com/qemu/qemu/commit/719f0f603c2289f438b8d6ef4358d9407b4c2905), and so this PR is proposing to backport that change to Unicorn without any modification except for the changed paths now being under the `qemu` directory.

The upstream commit gives the full details but the broad idea is that in U-Mode and S-Mode `wfi` should be treated as an invalid instruction exception in certain situations, which then allows a higher privilege mode to virtualize that instruction. In the context of Unicorn this means that we can use either an invalid instruction hook or an interrupt hook to detect `wfi` and then emulate its effect in the host program.

---

One notable quirk here is that upstream QEMU has also already merged [`e39a8320`](https://github.com/qemu/qemu/commit/e39a8320b088dd5efc9ebaafe387e52b3d962665) which added support for the hypervisor extension's new "virtual instruction fault", and changed several of the `op_helper.c` functions to use it instead of the main illegal instruction exception when running under hardware virtualization (VS-mode or US-mode).

That is a far more intrusive patch and so I've not attempted to backport it here, but that does mean that the effect of this patch is still not quite conforming to the ratified specification. It is, however, no worse than how this was handled before: it will raise the illegal instruction exception in both VS-mode and S-mode, which is consistent with the existing incomplete handling of the hypervisor extension in current Unicorn. (It seems that the currently-used QEMU version is partially implementing a pre-ratification version of that ISA extension, so current Unicorn2 users should not expect conforming behavior when using VS-mode or VU-mode regardless of this PR.)

I believe the effect of this patch is conforming for non-virtualized S-mode and U-mode, which are the two situations important to my use-case.

---

I have verified that `wfi` does indeed trigger the relevant Unicorn hooks using my calling application that's written in Rust.

I did try to write a Unicorn unit test for this but it's currently quite complicated to transition into a lower privilege mode in RISC-V emulation, as I described (and proposed a solution for) in https://github.com/unicorn-engine/unicorn/pull/1989. Since this change was already presumably well tested upstream in QEMU I imagine a Unicorn-specific test is not crucial, but I'd be willing to add one if maintainers consider it important, particularly if https://github.com/unicorn-engine/unicorn/pull/1989 were merged first so that the new test could straightforwardly select S mode and U mode.

Without that PR a test for this would need to include similar `mret` setup boilerplate to drop privilege before executing the `wfi` instruction, which is possible but would result in a test that's harder to read and maintain.
