### PR TITLE
Add py.typed to the Python binding package

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -251,6 +251,6 @@ setup(
     include_package_data=True,
     is_pure=False,
     package_data={
-        'unicorn': ['lib/*', 'include/unicorn/*']
+        'unicorn': ['unicorn/py.typed', 'lib/*', 'include/unicorn/*']
     }
 )


### PR DESCRIPTION
It seems that the python bindings have great type hints, but due to the lack of a `py.typed` file, `mypy` doesn't use them.
This PR solves the issue.
