### PR TITLE
Support additional API on Python 3 bindings

### DIFF
--- a/bindings/python/unicorn/unicorn_py3/arch/arm.py
+++ b/bindings/python/unicorn/unicorn_py3/arch/arm.py
@@ -50,39 +50,11 @@ class UcAArch32(Uc):
         """
 
         reg_class = (
-(UcAArch32.REG_RANGE_CP, UcRegCP),
+            (UcAArch32.REG_RANGE_CP, UcRegCP),
             (UcAArch32.REG_RANGE_Q, UcReg128)
         )
 
         return next((c for rng, c in reg_class if reg_id in rng), cls._DEFAULT_REGTYPE)
 
-    def reg_read(self, reg_id: int, aux: Any = None):
-        # select register class for special cases
-        reg_cls = UcAArch32.__select_reg_class(reg_id)
-
-        if reg_cls is None:
-            if reg_id == const.UC_ARM_REG_CP_REG:
-                return self._reg_read(reg_id, UcRegCP, *aux)
-
-            else:
-                # fallback to default reading method
-                return super().reg_read(reg_id, aux)
-
-        return self._reg_read(reg_id, reg_cls)
-
-    def reg_write(self, reg_id: int, value) -> None:
-        # select register class for special cases
-        reg_cls = UcAArch32.__select_reg_class(reg_id)
-
-        if reg_cls is None:
-            if reg_id == const.UC_ARM_REG_CP_REG:
-                self._reg_write(reg_id, UcRegCP, value)
-
-            else:
-                # fallback to default writing method
-                super().reg_write(reg_id, value)
-
-        else:
-            self._reg_write(reg_id, reg_cls, value)
 
 __all__ = ['UcRegCP', 'UcAArch32']

--- a/bindings/python/unicorn/unicorn_py3/arch/arm.py
+++ b/bindings/python/unicorn/unicorn_py3/arch/arm.py
@@ -2,7 +2,7 @@
 """
 # @author elicn
 
-from typing import Any, Tuple
+from typing import Tuple, Type
 
 import ctypes
 
@@ -40,18 +40,21 @@ class UcAArch32(Uc):
     """Unicorn subclass for ARM architecture.
     """
 
+    REG_RANGE_CP = (const.UC_ARM_REG_CP_REG,)
+
     REG_RANGE_Q = range(const.UC_ARM_REG_Q0, const.UC_ARM_REG_Q15 + 1)
 
-    @staticmethod
-    def __select_reg_class(reg_id: int):
-        """Select class for special architectural registers.
+    @classmethod
+    def _select_reg_class(cls, reg_id: int) -> Type:
+        """Select the appropriate class for the specified architectural register.
         """
 
         reg_class = (
-            (UcAArch32.REG_RANGE_Q, UcReg128),
+(UcAArch32.REG_RANGE_CP, UcRegCP),
+            (UcAArch32.REG_RANGE_Q, UcReg128)
         )
 
-        return next((cls for rng, cls in reg_class if reg_id in rng), None)
+        return next((c for rng, c in reg_class if reg_id in rng), cls._DEFAULT_REGTYPE)
 
     def reg_read(self, reg_id: int, aux: Any = None):
         # select register class for special cases

--- a/bindings/python/unicorn/unicorn_py3/arch/arm.py
+++ b/bindings/python/unicorn/unicorn_py3/arch/arm.py
@@ -10,7 +10,7 @@ import ctypes
 from unicorn import arm_const as const
 
 # newly introduced unicorn imports
-from ..unicorn import Uc
+from ..unicorn import Uc, check_maxbits
 from .types import UcTupledReg, UcReg128
 
 ARMCPReg = Tuple[int, int, int, int, int, int, int, int]
@@ -55,6 +55,56 @@ class UcAArch32(Uc):
         )
 
         return next((c for rng, c in reg_class if reg_id in rng), cls._DEFAULT_REGTYPE)
+
+    # to learn more about accessing aarch32 coprocessor registers, refer to:
+    # https://developer.arm.com/documentation/ddi0601/latest/AArch32-Registers
+
+    def cpr_read(self, coproc: int, opc1: int, crn: int, crm: int, opc2: int, el: int, is_64: bool) -> int:
+        """Read a coprocessor register value.
+
+        Args:
+            coproc  : coprocessor to access, value varies between 0 and 15
+            opc1    : opcode 1, value varies between 0 and 7
+            crn     : coprocessor register to access (CRn), value varies between 0 and 15
+            crm     : additional coprocessor register to access (CRm), value varies between 0 and 15
+            opc2    : opcode 2, value varies between 0 and 7
+            el      : the exception level the coprocessor register belongs to, value varies between 0 and 3
+            is_64   : indicates whether this is a 64-bit register
+
+        Returns: value of coprocessor register
+        """
+
+        assert check_maxbits(coproc, 4)
+        assert check_maxbits(opc1,   3)
+        assert check_maxbits(crn,    4)
+        assert check_maxbits(crm,    4)
+        assert check_maxbits(opc2,   3)
+        assert check_maxbits(el,     2)  # note that unicorn currently supports only EL0 and EL1
+
+        return self.reg_read(const.UC_ARM_REG_CP_REG, (coproc, int(is_64), el, crn, crm, opc1, opc2))
+
+    def cpr_write(self, coproc: int, opc1: int, crn: int, crm: int, opc2: int, el: int, is_64: bool, value: int) -> None:
+        """Write a coprocessor register value.
+
+        Args:
+            coproc  : coprocessor to access, value varies between 0 and 15
+            opc1    : opcode 1, value varies between 0 and 7
+            crn     : coprocessor register to access (CRn), value varies between 0 and 15
+            crm     : additional coprocessor register to access (CRm), value varies between 0 and 15
+            opc2    : opcode 2, value varies between 0 and 7
+            el      : the exception level the coprocessor register belongs to, value varies between 0 and 3
+            is_64   : indicates whether this is a 64-bit register
+            value   : value to write
+        """
+
+        assert check_maxbits(coproc, 4)
+        assert check_maxbits(opc1,   3)
+        assert check_maxbits(crn,    4)
+        assert check_maxbits(crm,    4)
+        assert check_maxbits(opc2,   3)
+        assert check_maxbits(el,     2)  # note that unicorn currently supports only EL0 and EL1
+
+        self.reg_write(const.UC_ARM_REG_CP_REG, (coproc, int(is_64), el, crn, crm, opc1, opc2, value))
 
 
 __all__ = ['UcRegCP', 'UcAArch32']

--- a/bindings/python/unicorn/unicorn_py3/arch/arm64.py
+++ b/bindings/python/unicorn/unicorn_py3/arch/arm64.py
@@ -93,40 +93,12 @@ class UcAArch64(Uc):
         """
 
         reg_class = (
-(UcAArch64.REG_RANGE_CP, UcRegCP64),
+            (UcAArch64.REG_RANGE_CP, UcRegCP64),
             (UcAArch64.REG_RANGE_Q,  UcReg128),
             (UcAArch64.REG_RANGE_V,  UcReg128)
         )
 
         return next((c for rng, c in reg_class if reg_id in rng), cls._DEFAULT_REGTYPE)
 
-    def reg_read(self, reg_id: int, aux: Any = None):
-        # select register class for special cases
-        reg_cls = UcAArch64.__select_reg_class(reg_id)
-
-        if reg_cls is None:
-            if reg_id == const.UC_ARM64_REG_CP_REG:
-                return self._reg_read(reg_id, UcRegCP64, *aux)
-
-            else:
-                # fallback to default reading method
-                return super().reg_read(reg_id, aux)
-
-        return self._reg_read(reg_id, reg_cls)
-
-    def reg_write(self, reg_id: int, value) -> None:
-        # select register class for special cases
-        reg_cls = UcAArch64.__select_reg_class(reg_id)
-
-        if reg_cls is None:
-            if reg_id == const.UC_ARM64_REG_CP_REG:
-                self._reg_write(reg_id, UcRegCP64, value)
-
-            else:
-                # fallback to default writing method
-                super().reg_write(reg_id, value)
-
-        else:
-            self._reg_write(reg_id, reg_cls, value)
 
 __all__ = ['UcRegCP64', 'UcAArch64']

--- a/bindings/python/unicorn/unicorn_py3/arch/intel.py
+++ b/bindings/python/unicorn/unicorn_py3/arch/intel.py
@@ -145,12 +145,10 @@ class UcIntel(Uc):
 
         return next((c for rng, c in reg_class if reg_id in rng), cls._DEFAULT_REGTYPE)
 
-        def msr_read(self, msr_id: int) -> int:
-        return self._reg_read(const.UC_X86_REG_MSR, UcRegMSR, msr_id)
+        return self.reg_read(const.UC_X86_REG_MSR, msr_id)
 
     def msr_write(self, msr_id: int, value: int) -> None:
-        self._reg_write(const.UC_X86_REG_MSR, UcRegMSR, (msr_id, value))
-
+        self.reg_write(const.UC_X86_REG_MSR, (msr_id, value))
 
 
 __all__ = ['UcRegMMR', 'UcRegMSR', 'UcRegFPR', 'UcIntel']

--- a/bindings/python/unicorn/unicorn_py3/arch/intel.py
+++ b/bindings/python/unicorn/unicorn_py3/arch/intel.py
@@ -145,9 +145,25 @@ class UcIntel(Uc):
 
         return next((c for rng, c in reg_class if reg_id in rng), cls._DEFAULT_REGTYPE)
 
+    def msr_read(self, msr_id: int) -> int:
+        """Read a model-specific register.
+
+        Args:
+            msr_id: MSR index
+
+        Returns: MSR value
+        """
+
         return self.reg_read(const.UC_X86_REG_MSR, msr_id)
 
     def msr_write(self, msr_id: int, value: int) -> None:
+        """Write to a model-specific register.
+
+        Args:
+            msr_id: MSR index
+            value: new MSR value
+        """
+
         self.reg_write(const.UC_X86_REG_MSR, (msr_id, value))
 
 

--- a/bindings/python/unicorn/unicorn_py3/arch/intel.py
+++ b/bindings/python/unicorn/unicorn_py3/arch/intel.py
@@ -151,10 +151,6 @@ class UcIntel(Uc):
     def msr_write(self, msr_id: int, value: int) -> None:
         self._reg_write(const.UC_X86_REG_MSR, UcRegMSR, (msr_id, value))
 
-    def reg_read_batch(self, reg_ids: Sequence[int]) -> Tuple:
-        reg_types = [UcIntel.__select_reg_class(rid) or self._DEFAULT_REGTYPE for rid in reg_ids]
-
-        return self._reg_read_batch(reg_ids, reg_types)
 
 
 __all__ = ['UcRegMMR', 'UcRegMSR', 'UcRegFPR', 'UcIntel']

--- a/bindings/python/unicorn/unicorn_py3/arch/intel.py
+++ b/bindings/python/unicorn/unicorn_py3/arch/intel.py
@@ -135,7 +135,7 @@ class UcIntel(Uc):
         """
 
         reg_class = (
-(UcIntel.REG_RANGE_MSR, UcRegMSR),
+            (UcIntel.REG_RANGE_MSR, UcRegMSR),
             (UcIntel.REG_RANGE_MMR, UcRegMMR),
             (UcIntel.REG_RANGE_FP,  UcRegFPR),
             (UcIntel.REG_RANGE_XMM, UcReg128),
@@ -145,43 +145,7 @@ class UcIntel(Uc):
 
         return next((c for rng, c in reg_class if reg_id in rng), cls._DEFAULT_REGTYPE)
 
-    def reg_read(self, reg_id: int, aux: Any = None):
-        # select register class for special cases
-        reg_cls = UcIntel.__select_reg_class(reg_id)
-
-        if reg_cls is None:
-            # backward compatibility: msr read through reg_read
-            if reg_id == const.UC_X86_REG_MSR:
-                if type(aux) is not int:
-                    raise UcError(UC_ERR_ARG)
-
-                value = self.msr_read(aux)
-
-            else:
-                value = super().reg_read(reg_id, aux)
-        else:
-            value = self._reg_read(reg_id, reg_cls)
-
-        return value
-
-    def reg_write(self, reg_id: int, value) -> None:
-        # select register class for special cases
-        reg_cls = UcIntel.__select_reg_class(reg_id)
-
-        if reg_cls is None:
-            # backward compatibility: msr write through reg_write
-            if reg_id == const.UC_X86_REG_MSR:
-                if type(value) is not tuple or len(value) != 2:
-                    raise UcError(UC_ERR_ARG)
-
-                self.msr_write(*value)
-                return
-
-            super().reg_write(reg_id, value)
-        else:
-            self._reg_write(reg_id, reg_cls, value)
-
-    def msr_read(self, msr_id: int) -> int:
+        def msr_read(self, msr_id: int) -> int:
         return self._reg_read(const.UC_X86_REG_MSR, UcRegMSR, msr_id)
 
     def msr_write(self, msr_id: int, value: int) -> None:

--- a/bindings/python/unicorn/unicorn_py3/arch/types.py
+++ b/bindings/python/unicorn/unicorn_py3/arch/types.py
@@ -3,7 +3,7 @@
 # @author elicn
 
 from abc import abstractmethod
-from typing import Generic, Tuple, TypeVar
+from typing import Any, Generic, Tuple, TypeVar
 
 import ctypes
 
@@ -24,7 +24,7 @@ class UcReg(ctypes.Structure):
 
     @property
     @abstractmethod
-    def value(self):
+    def value(self) -> Any:
         """Get register value.
         """
 
@@ -32,7 +32,7 @@ class UcReg(ctypes.Structure):
 
     @classmethod
     @abstractmethod
-    def from_value(cls, value):
+    def from_value(cls, value) -> 'UcReg':
         """Create a register instance from a given value.
         """
 
@@ -52,7 +52,7 @@ class UcTupledReg(UcReg, Generic[VT]):
 
     @classmethod
     def from_value(cls, value: VT):
-        assert type(value) is tuple and len(value) == len(cls._fields_)
+        assert isinstance(value, tuple) and len(value) == len(cls._fields_)
 
         return cls(*value)
 
@@ -72,7 +72,7 @@ class UcLargeReg(UcReg):
 
     @classmethod
     def from_value(cls, value: int):
-        assert type(value) is int
+        assert isinstance(value, int), f'got {type(value).__name__} while expected an integer'
 
         mask = (1 << 64) - 1
         size = cls._fields_[0][1]._length_

--- a/bindings/python/unicorn/unicorn_py3/arch/types.py
+++ b/bindings/python/unicorn/unicorn_py3/arch/types.py
@@ -52,7 +52,11 @@ class UcTupledReg(UcReg, Generic[VT]):
 
     @classmethod
     def from_value(cls, value: VT):
-        assert isinstance(value, tuple) and len(value) == len(cls._fields_)
+        if not isinstance(value, tuple):
+            raise TypeError(f'got {type(value).__name__} while expecting a tuple')
+
+        if len(value) != len(cls._fields_):
+            raise TypeError(f'got {len(value)} elements while expecting {len(cls._fields_)}')
 
         return cls(*value)
 
@@ -72,7 +76,8 @@ class UcLargeReg(UcReg):
 
     @classmethod
     def from_value(cls, value: int):
-        assert isinstance(value, int), f'got {type(value).__name__} while expected an integer'
+        if not isinstance(value, int):
+            raise TypeError(f'got {type(value).__name__} while expecting an integer')
 
         mask = (1 << 64) - 1
         size = cls._fields_[0][1]._length_

--- a/bindings/python/unicorn/unicorn_py3/unicorn.py
+++ b/bindings/python/unicorn/unicorn_py3/unicorn.py
@@ -91,26 +91,19 @@ def __load_uc_lib() -> ctypes.CDLL:
     # - we can get the path to the local libraries by parsing our filename
     # - global load
     # - python's lib directory
-    canonicals = []
-    
-    try:
+
+    if sys.version_info.minor >= 12:
         from importlib import resources
-        canonicals.append(
-            resources.files("unicorn") / 'lib'
-        )
-    except:
-        try:
-            import pkg_resources
-            canonicals.append(
-                pkg_resources.resource_filename("unicorn", 'lib')
-            )
-        except:
-            # maybe importlib_resources, but ignore for now
-            pass
-    
+
+        canonicals = resources.files('unicorn') / 'lib'
+    else:
+        import pkg_resources
+
+        canonicals = pkg_resources.resource_filename('unicorn', 'lib')
+
     lib_locations = [
         os.getenv('LIBUNICORN_PATH'),
-    ] + canonicals + [
+        canonicals,
         PurePath(inspect.getfile(__load_uc_lib)).parent / 'lib',
         '',
         r'/usr/local/lib' if sys.platform == 'darwin' else r'/usr/lib64',

--- a/bindings/python/unicorn/unicorn_py3/unicorn.py
+++ b/bindings/python/unicorn/unicorn_py3/unicorn.py
@@ -334,6 +334,15 @@ class RegStateManager:
 
     _DEFAULT_REGTYPE = ctypes.c_uint64
 
+    @classmethod
+    def _select_reg_class(cls, reg_id: int) -> Type:
+        """An architecture-specific method that returns the appropriate
+        value type for a specified reg identifier. All rich `Uc` subclasses
+        are expected to implement their own
+        """
+
+        return cls._DEFAULT_REGTYPE
+
     def _do_reg_read(self, reg_id: int, reg_obj) -> int:
         """Private register read implementation.
         Must be implemented by the mixin object

--- a/bindings/python/unicorn/unicorn_py3/unicorn.py
+++ b/bindings/python/unicorn/unicorn_py3/unicorn.py
@@ -311,7 +311,7 @@ def uccallback(uc: Uc, functype: Type[_CFP]):
     def decorate(func) -> _CFP:
 
         @functools.wraps(func)
-        def wrapper(handle: Uc, *args, **kwargs):
+        def wrapper(handle: int, *args, **kwargs):
             try:
                 return func(uc, *args, **kwargs)
             except Exception as e:
@@ -345,28 +345,28 @@ class RegStateManager:
         return cls._DEFAULT_REGTYPE
 
     def _do_reg_read(self, reg_id: int, reg_obj) -> int:
-        """Private register read implementation.
+        """Low level register read implementation.
         Must be implemented by the mixin object
         """
 
         raise NotImplementedError
 
     def _do_reg_write(self, reg_id: int, reg_obj) -> int:
-        """Private register write implementation.
+        """Low level register write implementation.
         Must be implemented by the mixin object
         """
 
         raise NotImplementedError
 
     def _do_reg_read_batch(self, reglist, vallist, count) -> int:
-        """Private batch register read implementation.
+        """Low level batch register read implementation.
         Must be implemented by the mixin object
         """
 
         raise NotImplementedError
 
-    def _do_reg_write_batch(self, reglist, count) -> int:
-        """Private batch register write implementation.
+    def _do_reg_write_batch(self, reglist, vallist, count) -> int:
+        """Low level batch register write implementation.
         Must be implemented by the mixin object
         """
 
@@ -452,6 +452,10 @@ class RegStateManager:
 
         if status != uc.UC_ERR_OK:
             raise UcError(status)
+
+    #########################
+    #  External facing API  #
+    #########################
 
     def reg_read(self, reg_id: int, aux: Any = None):
         """Read architectural register value.

--- a/bindings/python/unicorn/unicorn_py3/unicorn.py
+++ b/bindings/python/unicorn/unicorn_py3/unicorn.py
@@ -617,6 +617,15 @@ class Uc(RegStateManager):
                 if status != uc.UC_ERR_OK:
                     raise UcError(status)
 
+@property
+    def errno(self) -> int:
+        """Get last error number.
+
+        Returns: error number (see: UC_ERR_*)
+        """
+
+        return uclib.uc_errno(self._uch)
+
     ###########################
     #  Emulation controllers  #
     ###########################

--- a/tests/regress/arm_memcpy_neon.py
+++ b/tests/regress/arm_memcpy_neon.py
@@ -1,52 +1,68 @@
 from unicorn import *
 from unicorn.arm_const import *
 
-# .text:0001F894                 ADD             PC, PC, R3
-# .text:0001F898 ; ---------------------------------------------------------------------------
-# .text:0001F898                 VLD1.8          {D0}, [R1]!
-# .text:0001F89C                 VST1.8          {D0}, [R12]!
-# .text:0001F8A0                 VLD1.8          {D0}, [R1]!
-# .text:0001F8A4                 VST1.8          {D0}, [R12]!
-# .text:0001F8A8                 VLD1.8          {D0}, [R1]!
-# .text:0001F8AC                 VST1.8          {D0}, [R12]!
-# .text:0001F8B0                 VLD1.8          {D0}, [R1]!
-# .text:0001F8B4                 VST1.8          {D0}, [R12]!
-# .text:0001F8B8                 VLD1.8          {D0}, [R1]!
-# .text:0001F8BC                 VST1.8          {D0}, [R12]!
-# .text:0001F8C0                 VLD1.8          {D0}, [R1]!
-# .text:0001F8C4                 VST1.8          {D0}, [R12]!
-# .text:0001F8C8                 VLD1.8          {D0}, [R1]!
-# .text:0001F8CC                 VST1.8          {D0}, [R12]!
-# .text:0001F8D0                 TST             R2, #4
-# .text:0001F8D4                 LDRNE           R3, [R1],#4
-# .text:0001F8D8                 STRNE           R3, [R12],#4
-# .text:0001F8DC                 MOVS            R2, R2,LSL#31
-# .text:0001F8E0                 LDRHCS          R3, [R1],#2
-# .text:0001F8E4                 LDRBNE          R1, [R1]
-# .text:0001F8E8                 STRHCS          R3, [R12],#2
-# .text:0001F8EC                 STRBNE          R1, [R12]
-shellcode = [0x3, 0xf0, 0x8f, 0xe0, 0xd, 0x7, 0x21, 0xf4, 0xd, 0x7, 0xc, 0xf4, 0xd, 0x7, 0x21, 0xf4, 0xd, 0x7, 0xc, 0xf4, 0xd, 0x7, 0x21, 0xf4, 0xd, 0x7, 0xc, 0xf4, 0xd, 0x7, 0x21, 0xf4, 0xd, 0x7, 0xc, 0xf4, 0xd, 0x7, 0x21, 0xf4, 0xd, 0x7, 0xc, 0xf4, 0xd, 0x7, 0x21, 0xf4, 0xd, 0x7, 0xc, 0xf4, 0xd, 0x7, 0x21, 0xf4, 0xd, 0x7, 0xc, 0xf4, 0x4, 0x0, 0x12, 0xe3, 0x4, 0x30, 0x91, 0x14, 0x4, 0x30, 0x8c, 0x14, 0x82, 0x2f, 0xb0, 0xe1, 0xb2, 0x30, 0xd1, 0x20, 0x0, 0x10, 0xd1, 0x15, 0xb2, 0x30, 0xcc, 0x20, 0x0, 0x10, 0xcc, 0x15]
-base = 0x1F894
-from_address = 0x1000
-to_address = 0x2000
-cplen = 8
-bs = b"c8"*cplen
+
+SHELLCODE = bytes.fromhex(
+    '03 f0 8f e0'   # 0001F894        ADD         PC, PC, R3
+    '0d 07 21 f4'   # 0001F898        VLD1.8      {D0}, [R1]!
+    '0d 07 0c f4'   # 0001F89C        VST1.8      {D0}, [R12]!
+    '0d 07 21 f4'   # 0001F8A0        VLD1.8      {D0}, [R1]!
+    '0d 07 0c f4'   # 0001F8A4        VST1.8      {D0}, [R12]!
+    '0d 07 21 f4'   # 0001F8A8        VLD1.8      {D0}, [R1]!
+    '0d 07 0c f4'   # 0001F8AC        VST1.8      {D0}, [R12]!
+    '0d 07 21 f4'   # 0001F8B0        VLD1.8      {D0}, [R1]!
+    '0d 07 0c f4'   # 0001F8B4        VST1.8      {D0}, [R12]!
+    '0d 07 21 f4'   # 0001F8B8        VLD1.8      {D0}, [R1]!
+    '0d 07 0c f4'   # 0001F8BC        VST1.8      {D0}, [R12]!
+    '0d 07 21 f4'   # 0001F8C0        VLD1.8      {D0}, [R1]!
+    '0d 07 0c f4'   # 0001F8C4        VST1.8      {D0}, [R12]!
+    '0d 07 21 f4'   # 0001F8C8        VLD1.8      {D0}, [R1]!
+    '0d 07 0c f4'   # 0001F8CC        VST1.8      {D0}, [R12]!
+    '04 00 12 e3'   # 0001F8D0        TST         R2, #4
+    '04 30 91 14'   # 0001F8D4        LDRNE       R3, [R1],#4
+    '04 30 8c 14'   # 0001F8D8        STRNE       R3, [R12],#4
+    '82 2f b0 e1'   # 0001F8DC        MOVS        R2, R2,LSL#31
+    'b2 30 d1 20'   # 0001F8E0        LDRHCS      R3, [R1],#2
+    '00 10 d1 15'   # 0001F8E4        LDRBNE      R1, [R1]
+    'b2 30 cc 20'   # 0001F8E8        STRHCS      R3, [R12],#2
+    '00 10 cc 15'   # 0001F8EC        STRBNE      R1, [R12]
+)
+
+BASE = 0x1F894
+COPY_SRC = 0x1000
+COPY_DST = 0x2000
+COPY_LEN = 8
+bs = b'c8' * COPY_LEN
 
 uc = Uc(UC_ARCH_ARM, UC_MODE_ARM)
-uc.mem_map(from_address, 0x1000)
-uc.mem_map(to_address, 0x1000)
-uc.mem_map(0x1F000, 0x1000)
-uc.mem_write(from_address, bs)
-uc.mem_write(base, bytes(shellcode))
-uc.reg_write(UC_ARM_REG_R12, to_address)
-uc.reg_write(UC_ARM_REG_R1, from_address)
-uc.reg_write(UC_ARM_REG_R2, cplen)
-uc.reg_write(UC_ARM_REG_R3, 0x24)
-# enable_vfp
-uc.reg_write(UC_ARM_REG_C1_C0_2, uc.reg_read(UC_ARM_REG_C1_C0_2) | (0xf << 20))
-uc.reg_write(UC_ARM_REG_FPEXC, 0x40000000)
 
-uc.emu_start(base, base+len(shellcode))
-fr = uc.mem_read(from_address, len(bs))
-to = uc.mem_read(to_address, len(bs))
-print(f"memcpy result:\nfrom: {bytes(fr)}\nto: {bytes(to)}")
+uc.mem_map(COPY_SRC, 0x1000)
+uc.mem_map(COPY_DST, 0x1000)
+uc.mem_map(BASE & ~(0x1000 - 1), 0x1000)
+uc.mem_write(COPY_SRC, bs)
+uc.mem_write(BASE, bytes(SHELLCODE))
+
+uc.reg_write_batch((
+	(UC_ARM_REG_R12, COPY_DST),
+	(UC_ARM_REG_R1, COPY_SRC),
+	(UC_ARM_REG_R2, COPY_LEN),
+	(UC_ARM_REG_R3, 0x24)
+))
+
+# enable_vfp
+
+# coproc=15, is64=0, sec=0, CRn=1, CRm=0, opc1=0, opc2=2
+CPACR = (15, 0, 0, 1, 0, 0, 2)
+
+cpacr = uc.reg_read(UC_ARM_REG_CP_REG, CPACR)
+uc.reg_write(UC_ARM_REG_CP_REG, CPACR + (cpacr | (0b11 << 20) | (0b11 << 22),))
+uc.reg_write(UC_ARM_REG_FPEXC, (0b1 << 30))
+
+uc.emu_start(BASE, BASE + len(SHELLCODE))
+src = uc.mem_read(COPY_SRC, len(bs))
+dst = uc.mem_read(COPY_DST, len(bs))
+
+print(f'''memcpy result:
+  from: {bytes(src)}
+  to:   {bytes(dst)}
+''')


### PR DESCRIPTION
Highlights:
 - Redesign certain architecture-specific aspects to better leverage OOP
   - Code de-duplication
   - Easier to extend or support new architectures
 - Now fully support `reg_write_batch` and `reg_read_batch` API
 - Introduced coprocessor register accessors to AArch32 and AArch64, named `cpr_read` and `cpr_write`
 - 1 ARM regression test fixed
 - More comments, documentation and annotations