### PR TITLE
Fix SPARC I0-7 registers write

### DIFF
--- a/qemu/target/sparc/unicorn.c
+++ b/qemu/target/sparc/unicorn.c
@@ -78,6 +78,7 @@ uc_err reg_read(void *_env, int mode, unsigned int regid, void *value,
         CHECK_REG_TYPE(uint32_t);
         *(uint32_t *)value = env->regwptr[8 + regid - UC_SPARC_REG_L0];
     } else if (regid >= UC_SPARC_REG_I0 && regid <= UC_SPARC_REG_I7) {
+        CHECK_REG_TYPE(uint32_t);
         *(uint32_t *)value = env->regwptr[16 + regid - UC_SPARC_REG_I0];
     } else {
         switch (regid) {


### PR DESCRIPTION
Fix a bug in which writes to I0 to I7 registers resulted in an error.