### PR TITLE
Python: Fix assertion failure on ctl_flush_tb()

### DIFF
--- a/bindings/python/unicorn/unicorn_py3/unicorn.py
+++ b/bindings/python/unicorn/unicorn_py3/unicorn.py
@@ -1172,7 +1172,7 @@ class Uc(RegStateManager):
 
     @staticmethod
     def __ctl_encode(ctl: int, op: int, nargs: int) -> int:
-        assert nargs and check_maxbits(nargs, 4), f'nargs must not exceed value of 15 (got {nargs})'
+        assert check_maxbits(nargs, 4), f'nargs must not exceed value of 15 (got {nargs})'
         assert op and check_maxbits(op, 2), f'op must not exceed value of 3 (got {op})'
 
         return (op << 30) | (nargs << 26) | ctl


### PR DESCRIPTION
Fix an assertion failure on encoding a ctl with no arguments.
Unbreaks `ctl_flush_tb()`.