### PR TITLE
qemu/tcg: fix UC_HOOK_MEM_READ on aarch64.

### DIFF
--- a/qemu/include/tcg/tcg.h
+++ b/qemu/include/tcg/tcg.h
@@ -1577,4 +1577,11 @@ struct jit_code_entry {
 void uc_del_inline_hook(uc_engine *uc, struct hook *hk);
 void uc_add_inline_hook(uc_engine *uc, struct hook *hk, void** args, int args_len);
 
+static inline bool tcg_uc_has_hookmem(TCGContext *s)
+{
+    return HOOK_EXISTS(s->uc, UC_HOOK_MEM_READ) ||
+        HOOK_EXISTS(s->uc, UC_HOOK_MEM_READ_AFTER) ||
+        HOOK_EXISTS(s->uc, UC_HOOK_MEM_WRITE);
+}
+
 #endif /* TCG_H */

--- a/qemu/tcg/aarch64/tcg-target.inc.c
+++ b/qemu/tcg/aarch64/tcg-target.inc.c
@@ -1584,6 +1584,7 @@ static inline void tcg_out_adr(TCGContext *s, TCGReg rd, void *target)
 static inline bool has_hookmem(TCGContext *s)
 {
     return HOOK_EXISTS(s->uc, UC_HOOK_MEM_READ) ||
+        HOOK_EXISTS(s->uc, UC_HOOK_MEM_READ_AFTER) ||
         HOOK_EXISTS(s->uc, UC_HOOK_MEM_WRITE);
 }
 

--- a/qemu/tcg/i386/tcg-target.inc.c
+++ b/qemu/tcg/i386/tcg-target.inc.c
@@ -1679,13 +1679,6 @@ static void * const qemu_st_helpers[16] = {
     [MO_BEQ]  = helper_be_stq_mmu,
 };
 
-static inline bool has_hookmem(TCGContext *s)
-{
-    return HOOK_EXISTS(s->uc, UC_HOOK_MEM_READ) ||
-        HOOK_EXISTS(s->uc, UC_HOOK_MEM_READ_AFTER) ||
-        HOOK_EXISTS(s->uc, UC_HOOK_MEM_WRITE);
-}
-
 /* Perform the TLB load and compare.
 
    Inputs:
@@ -1770,7 +1763,7 @@ static inline void tcg_out_tlb_load(TCGContext *s, TCGReg addrlo, TCGReg addrhi,
     tcg_out_mov(s, ttype, r1, addrlo);
 
     // Unicorn: fast path if hookmem is not enable
-    if (!has_hookmem(s))
+    if (!tcg_uc_has_hookmem(s))
         tcg_out_opc(s, OPC_JCC_long + JCC_JNE, 0, 0, 0);
     else
         /* slow_path, so data access will go via load_helper() */

--- a/qemu/tcg/i386/tcg-target.inc.c
+++ b/qemu/tcg/i386/tcg-target.inc.c
@@ -1679,6 +1679,13 @@ static void * const qemu_st_helpers[16] = {
     [MO_BEQ]  = helper_be_stq_mmu,
 };
 
+static inline bool has_hookmem(TCGContext *s)
+{
+    return HOOK_EXISTS(s->uc, UC_HOOK_MEM_READ) ||
+        HOOK_EXISTS(s->uc, UC_HOOK_MEM_READ_AFTER) ||
+        HOOK_EXISTS(s->uc, UC_HOOK_MEM_WRITE);
+}
+
 /* Perform the TLB load and compare.
 
    Inputs:
@@ -1763,7 +1770,7 @@ static inline void tcg_out_tlb_load(TCGContext *s, TCGReg addrlo, TCGReg addrhi,
     tcg_out_mov(s, ttype, r1, addrlo);
 
     // Unicorn: fast path if hookmem is not enable
-    if (!HOOK_EXISTS(s->uc, UC_HOOK_MEM_READ) && !HOOK_EXISTS(s->uc, UC_HOOK_MEM_WRITE))
+    if (!has_hookmem(s))
         tcg_out_opc(s, OPC_JCC_long + JCC_JNE, 0, 0, 0);
     else
         /* slow_path, so data access will go via load_helper() */

--- a/qemu/tcg/ppc/tcg-target.inc.c
+++ b/qemu/tcg/ppc/tcg-target.inc.c
@@ -2011,6 +2011,7 @@ static void add_qemu_ldst_label(TCGContext *s, bool is_ld, TCGMemOpIdx oi,
 static inline bool has_hookmem(TCGContext *s)
 {
     return HOOK_EXISTS(s->uc, UC_HOOK_MEM_READ) ||
+        HOOK_EXISTS(s->uc, UC_HOOK_MEM_READ_AFTER) ||
         HOOK_EXISTS(s->uc, UC_HOOK_MEM_WRITE);
 }
 

--- a/qemu/tcg/ppc/tcg-target.inc.c
+++ b/qemu/tcg/ppc/tcg-target.inc.c
@@ -2008,13 +2008,20 @@ static void add_qemu_ldst_label(TCGContext *s, bool is_ld, TCGMemOpIdx oi,
     label->label_ptr[0] = lptr;
 }
 
+static inline bool has_hookmem(TCGContext *s)
+{
+    return HOOK_EXISTS(s->uc, UC_HOOK_MEM_READ) ||
+        HOOK_EXISTS(s->uc, UC_HOOK_MEM_WRITE);
+}
+
 static bool tcg_out_qemu_ld_slow_path(TCGContext *s, TCGLabelQemuLdst *lb)
 {
     TCGMemOpIdx oi = lb->oi;
     MemOp opc = get_memop(oi);
     TCGReg hi, lo, arg = TCG_REG_R3;
 
-    if (!reloc_pc14(lb->label_ptr[0], s->code_ptr)) {
+    const int type = has_hookmem(s) ? R_PPC_REL24 : R_PPC_REL14;
+    if (!patch_reloc(lb->label_ptr[0], type, (intptr_t)s->code_ptr, 0)) {
         return false;
     }
 
@@ -2062,7 +2069,8 @@ static bool tcg_out_qemu_st_slow_path(TCGContext *s, TCGLabelQemuLdst *lb)
     MemOp s_bits = opc & MO_SIZE;
     TCGReg hi, lo, arg = TCG_REG_R3;
 
-    if (!reloc_pc14(lb->label_ptr[0], s->code_ptr)) {
+    const int type = has_hookmem(s) ? R_PPC_REL24 : R_PPC_REL14;
+    if (!patch_reloc(lb->label_ptr[0], type, (intptr_t)s->code_ptr, 0)) {
         return false;
     }
 
@@ -2142,7 +2150,11 @@ static void tcg_out_qemu_ld(TCGContext *s, const TCGArg *args, bool is_64)
 
     /* Load a pointer into the current opcode w/conditional branch-link. */
     label_ptr = s->code_ptr;
-    tcg_out32(s, BC | BI(7, CR_EQ) | BO_COND_FALSE | LK);
+    // Unicorn: fast path if hookmem is not enabled
+    if (!has_hookmem(s))
+        tcg_out32(s, BC | BI(7, CR_EQ) | BO_COND_FALSE | LK);
+    else
+        tcg_out32(s, B | LK);
 
     rbase = TCG_REG_R3;
 #else  /* !CONFIG_SOFTMMU */
@@ -2217,7 +2229,11 @@ static void tcg_out_qemu_st(TCGContext *s, const TCGArg *args, bool is_64)
 
     /* Load a pointer into the current opcode w/conditional branch-link. */
     label_ptr = s->code_ptr;
-    tcg_out32(s, BC | BI(7, CR_EQ) | BO_COND_FALSE | LK);
+    // Unicorn: fast path if hookmem is not enabled
+    if (!has_hookmem(s))
+        tcg_out32(s, BC | BI(7, CR_EQ) | BO_COND_FALSE | LK);
+    else
+        tcg_out32(s, B | LK);
 
     rbase = TCG_REG_R3;
 #else  /* !CONFIG_SOFTMMU */


### PR DESCRIPTION
Directly jump into the slow path when there is any hookmem enabled. This fixes #1908.