### PR TITLE
Optimize Notdirty write

### DIFF
--- a/qemu/accel/tcg/cputlb.c
+++ b/qemu/accel/tcg/cputlb.c
@@ -1209,8 +1209,8 @@ static void notdirty_write(CPUState *cpu, vaddr mem_vaddr, unsigned size,
     // - or doing snapshot
     // , then never clean the tlb
     if (!(!mr || mr->priority < cpu->uc->snapshot_level) &&
-            !(HOOK_EXISTS(cpu->uc, UC_HOOK_MEM_READ) || HOOK_EXISTS(cpu->uc, UC_HOOK_MEM_WRITE)) &&
-            !(tlbe->addr_code != -1)) {
+            !(tlbe->addr_code != -1) &&
+            !uc_mem_hook_installed(cpu->uc, tlbe->paddr | (mem_vaddr & ~TARGET_PAGE_MASK))) {
         tlb_set_dirty(cpu, mem_vaddr);
     }
 }

--- a/qemu/accel/tcg/cputlb.c
+++ b/qemu/accel/tcg/cputlb.c
@@ -1208,7 +1208,7 @@ static void notdirty_write(CPUState *cpu, vaddr mem_vaddr, unsigned size,
     // - have memory hooks installed
     // - or doing snapshot
     // , then never clean the tlb
-    if (!(!mr || mr->priority < cpu->uc->snapshot_level) &&
+    if (!(!mr || (tlbe->addr_write != -1 && mr->priority < cpu->uc->snapshot_level)) &&
             !(tlbe->addr_code != -1) &&
             !uc_mem_hook_installed(cpu->uc, tlbe->paddr | (mem_vaddr & ~TARGET_PAGE_MASK))) {
         tlb_set_dirty(cpu, mem_vaddr);

--- a/qemu/accel/tcg/translate-all.c
+++ b/qemu/accel/tcg/translate-all.c
@@ -1839,7 +1839,7 @@ TranslationBlock *tb_gen_code(CPUState *cpu,
     }
 
     /* Undoes tlb_set_dirty in notdirty_write. */
-    if (!(HOOK_EXISTS(cpu->uc, UC_HOOK_MEM_READ) || HOOK_EXISTS(cpu->uc, UC_HOOK_MEM_WRITE))) {
+    if (!uc_mem_hook_installed(cpu->uc, tb->pc)) {
         tlb_reset_dirty_by_vaddr(cpu, pc & TARGET_PAGE_MASK,
                                 (pc & ~TARGET_PAGE_MASK) + tb->size);
     }

--- a/qemu/include/exec/exec-all.h
+++ b/qemu/include/exec/exec-all.h
@@ -477,4 +477,27 @@ address_space_translate_for_iotlb(CPUState *cpu, int asidx, hwaddr addr,
 hwaddr memory_region_section_get_iotlb(CPUState *cpu,
                                        MemoryRegionSection *section);
 
+static inline bool uc_mem_hook_installed(struct uc_struct *uc, target_ulong paddr)
+{
+    if (HOOK_EXISTS_BOUNDED(uc, UC_HOOK_MEM_FETCH_UNMAPPED, paddr))
+        return true;
+    if (HOOK_EXISTS_BOUNDED(uc, UC_HOOK_MEM_READ_UNMAPPED, paddr))
+        return true;
+    if (HOOK_EXISTS_BOUNDED(uc, UC_HOOK_MEM_READ, paddr))
+        return true;
+    if (HOOK_EXISTS_BOUNDED(uc, UC_HOOK_MEM_READ_PROT, paddr))
+        return true;
+    if (HOOK_EXISTS_BOUNDED(uc, UC_HOOK_MEM_FETCH_PROT, paddr))
+        return true;
+    if (HOOK_EXISTS_BOUNDED(uc, UC_HOOK_MEM_READ_AFTER, paddr))
+        return true;
+    if (HOOK_EXISTS_BOUNDED(uc, UC_HOOK_MEM_WRITE, paddr))
+        return true;
+    if (HOOK_EXISTS_BOUNDED(uc, UC_HOOK_MEM_WRITE_UNMAPPED, paddr))
+        return true;
+    if (HOOK_EXISTS_BOUNDED(uc, UC_HOOK_MEM_WRITE_PROT, paddr))
+        return true;
+    return false;
+}
+
 #endif

--- a/qemu/softmmu/cpus.c
+++ b/qemu/softmmu/cpus.c
@@ -93,6 +93,7 @@ static int tcg_cpu_exec(struct uc_struct *uc)
         //                  (cpu->singlestep_enabled & SSTEP_NOTIMER) == 0);
         if (cpu_can_run(cpu)) {
             uc->quit_request = false;
+            uc->size_recur_mem = 0;
             r = cpu_exec(uc, cpu);
 
             // quit current TB but continue emulating?

--- a/uc.c
+++ b/uc.c
@@ -2160,6 +2160,7 @@ uc_err uc_context_save(uc_engine *uc, uc_context *context)
         }
         context->ramblock_freed = uc->ram_list.freed;
         context->last_block = uc->ram_list.last_block;
+        uc->tcg_flush_tlb(uc);
     }
 
     context->snapshot_level = uc->snapshot_level;
@@ -2436,6 +2437,7 @@ uc_err uc_context_restore(uc_engine *uc, uc_context *context)
         if (!uc->flatview_copy(uc, uc->address_space_memory.current_map, context->fv, true)) {
             return UC_ERR_NOMEM;
         }
+        uc->tcg_flush_tlb(uc);
     }
 
     if (uc->context_content & UC_CTL_CONTEXT_CPU) {


### PR DESCRIPTION
This enables `notdirty_write` when used with snapshots. To do this the tlb is cleared on a snapshot and the priority of the mr is compared with the snapshot level.

It also fixes a bug when the mmu doesn't map 1:1. Before this the memory region was looked up with the vaddr, but memory regions are mapped at the paddr.

It's currently a draft because I also want to improve the `MEM_HOOK` check. As you already noticed in #2029 there are some hooks missing in the check. I would also include a range check for the hooks so only skip the optimization when there is a hook on this address.