### PR TITLE
Modify python version check such that linters recognize it

### DIFF
--- a/bindings/python/unicorn/unicorn.py
+++ b/bindings/python/unicorn/unicorn.py
@@ -8,7 +8,7 @@ from .unicorn_const import (
 
 __version__ = "%u.%u.%u" % (__MAJOR, __MINOR, __PATCH)
 
-if _sys.version_info.major == 2:
-    from .unicorn_py2 import *
-else:
+if _sys.version_info >= (3,):
     from .unicorn_py3 import *
+else:
+    from .unicorn_py2 import *

--- a/bindings/python/unicorn/unicorn_py2.py
+++ b/bindings/python/unicorn/unicorn_py2.py
@@ -23,8 +23,7 @@ ucsubclass = 0
 if not hasattr(sys.modules[__name__], "__file__"):
     __file__ = inspect.getfile(inspect.currentframe())
 
-_python2 = sys.version_info[0] < 3
-if _python2:
+if sys.version_info < (3,):
     range = xrange
 
 _lib = { 'darwin': 'libunicorn.2.dylib',
@@ -55,7 +54,7 @@ def _load_win_support(path):
                 ctypes.cdll.LoadLibrary(lib_file)
                 #print('SUCCESS')
                 _loaded_windows_dlls.add(dll)
-            except OSError as e:
+            except OSError:
                 #print('FAIL to load %s' %lib_file, e)
                 continue
 
@@ -72,7 +71,7 @@ def _load_lib(path):
         dll = ctypes.cdll.LoadLibrary(lib_file)
         #print('SUCCESS')
         return dll
-    except OSError as e:
+    except OSError:
         #print('FAIL to load %s' %lib_file, e)
         return None
 

--- a/bindings/python/unicorn/unicorn_py3/unicorn.py
+++ b/bindings/python/unicorn/unicorn_py3/unicorn.py
@@ -104,7 +104,7 @@ def __load_uc_lib() -> ctypes.CDLL:
     # - global load
     # - python's lib directory
 
-    if sys.version_info.minor >= 12:
+    if sys.version_info >= (3, 12):
         from importlib import resources
 
         canonicals = resources.files('unicorn') / 'lib'

--- a/tests/regress/init.py
+++ b/tests/regress/init.py
@@ -9,7 +9,7 @@ from unicorn import *
 from unicorn.x86_const import *
 
 
-if sys.version_info.major == 2:
+if sys.version_info < (3,):
     range = xrange
 
 


### PR DESCRIPTION
This is sort of a follow up to #2005. Currently many type checkers have a hard time recognizing all the different ways you can compare versions with `sys.version_info` (it's a best-effort kind of thing).

I changed the comparison and made sure that:
1. It works for both python 3 and python 2.7.
2. Mypy and Pyright both understand the comparison and skip the python 2.7 implementation.
