### PR TITLE
make i386 instructions RDTSC and RDTSCP hookable

### DIFF
--- a/bindings/go/unicorn/hook.c
+++ b/bindings/go/unicorn/hook.c
@@ -40,3 +40,7 @@ void hookX86Out_cgo(uc_engine *handle, uint32_t port, uint32_t size, uint32_t va
 void hookX86Syscall_cgo(uc_engine *handle, uintptr_t user) {
     hookX86Syscall(handle, (void *)user);
 }
+
+int hookX86Cpuid_cgo(uc_engine *handle, uintptr_t user) {
+    return hookX86Cpuid(handle, (void *)user);
+}

--- a/bindings/go/unicorn/hook.go
+++ b/bindings/go/unicorn/hook.go
@@ -98,6 +98,12 @@ func hookX86Syscall(handle unsafe.Pointer, user unsafe.Pointer) {
 	hook.Callback.(func(Unicorn))(hook.Uc)
 }
 
+//export hookX86Cpuid
+func hookX86Cpuid(handle unsafe.Pointer, user unsafe.Pointer) bool {
+	hook := hookMap.get(user)
+	return hook.Callback.(func(Unicorn) bool)(hook.Uc)
+}
+
 func (u *uc) HookAdd(htype int, cb interface{}, begin, end uint64, extra ...int) (Hook, error) {
 	var callback unsafe.Pointer
 	var insn C.int
@@ -119,6 +125,8 @@ func (u *uc) HookAdd(htype int, cb interface{}, begin, end uint64, extra ...int)
 			callback = C.hookX86Out_cgo
 		case X86_INS_SYSCALL, X86_INS_SYSENTER:
 			callback = C.hookX86Syscall_cgo
+		case X86_INS_CPUID, X86_INS_RDTSC, X86_INS_RDTSCP:
+			callback = C.hookX86Cpuid_cgo
 		default:
 			return 0, errors.New("Unknown instruction type.")
 		}

--- a/bindings/go/unicorn/hook.h
+++ b/bindings/go/unicorn/hook.h
@@ -7,3 +7,4 @@ void hookInterrupt_cgo(uc_engine *handle, uint32_t intno, uintptr_t user);
 uint32_t hookX86In_cgo(uc_engine *handle, uint32_t port, uint32_t size, uintptr_t user);
 void hookX86Out_cgo(uc_engine *handle, uint32_t port, uint32_t size, uint32_t value, uintptr_t user);
 void hookX86Syscall_cgo(uc_engine *handle, uintptr_t user);
+int hookX86Cpuid_cgo(uc_engine *handle, uintptr_t user);

--- a/qemu/target/i386/unicorn.c
+++ b/qemu/target/i386/unicorn.c
@@ -2000,10 +2000,11 @@ static bool x86_stop_interrupt(struct uc_struct *uc, int intno)
 
 static bool x86_insn_hook_validate(uint32_t insn_enum)
 {
-    // for x86 we can only hook IN, OUT, and SYSCALL
+    // for x86 we can only hook IN, OUT, SYSCALL, SYSENTER, CPUID, RDTSC, and RDTSCP
     if (insn_enum != UC_X86_INS_IN && insn_enum != UC_X86_INS_OUT &&
         insn_enum != UC_X86_INS_SYSCALL && insn_enum != UC_X86_INS_SYSENTER &&
-        insn_enum != UC_X86_INS_CPUID) {
+        insn_enum != UC_X86_INS_CPUID && insn_enum != UC_X86_INS_RDTSC &&
+        insn_enum != UC_X86_INS_RDTSCP) {
         return false;
     }
     return true;


### PR DESCRIPTION
This patch allows the RDTSC and RDTSCP instructions to be hooked. The code is based on the CPUID hook implementation.

Fixes #2065