### PR TITLE
improve aarch64 feature gate in rust bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,9 @@ dynamic_linkage = []
 arch_all = ["arch_x86", "arch_arm", "arch_aarch64", "arch_riscv", "arch_mips", "arch_sparc", "arch_m68k", "arch_ppc", "arch_s390x", "arch_tricore"]
 arch_x86 = []
 arch_arm = []
-arch_aarch64 = []
+# NOTE: unicorn-c only separates on top-level arch name,
+#       not on the bit-length, so we include both arm and aarch64
+arch_aarch64 = ["arch_arm"]
 arch_riscv = []
 arch_mips = []
 arch_sparc = []

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -54,11 +54,9 @@ mod arm;
 pub use crate::arm::*;
 
 // include arm64 support if conditionally compiled in
-// NOTE: unicorn-c only separates on top-level arch name,
-//       not on the bit-length, so we include both
-#[cfg(feature = "arch_arm")]
+#[cfg(feature = "arch_aarch64")]
 mod arm64;
-#[cfg(feature = "arch_arm")]
+#[cfg(feature = "arch_aarch64")]
 pub use crate::arm64::*;
 
 // include m68k support if conditionally compiled in


### PR DESCRIPTION
Found out the arch_aarch64 feature flag doesn't actually enable the arm64 module, and it bothered me a bit. Changed arch_aarch64 to depend on arch_arm of requiring manually enabling both arch_arm and arch_aarch64 at the same time.