### PR TITLE
Allow uc_ctl_set_page_size() for arm64

### DIFF
--- a/tests/unit/test_ctl.c
+++ b/tests/unit/test_ctl.c
@@ -198,6 +198,29 @@ static void test_uc_ctl_change_page_size(void)
 }
 #endif
 
+// Test requires UC_ARCH_ARM64.
+#ifdef UNICORN_HAS_ARM64
+static void test_uc_ctl_change_page_size_arm64(void)
+{
+    uc_engine *uc;
+    uc_engine *uc2;
+    uint32_t pg = 0;
+
+    OK(uc_open(UC_ARCH_ARM64, UC_MODE_ARM, &uc));
+    OK(uc_open(UC_ARCH_ARM64, UC_MODE_ARM, &uc2));
+
+    OK(uc_ctl_set_page_size(uc, 16384));
+    OK(uc_ctl_get_page_size(uc, &pg));
+    TEST_CHECK(pg == 16384);
+
+    OK(uc_mem_map(uc2, 1 << 10, 1 << 10, UC_PROT_ALL));
+    uc_assert_err(UC_ERR_ARG, uc_mem_map(uc, 1 << 10, 1 << 10, UC_PROT_ALL));
+
+    OK(uc_close(uc));
+    OK(uc_close(uc2));
+}
+#endif
+
 // Test requires UC_ARCH_ARM.
 #ifdef UNICORN_HAS_ARM
 // Copy from test_arm.c but with new API.
@@ -414,6 +437,9 @@ TEST_LIST = {{"test_uc_ctl_mode", test_uc_ctl_mode},
 #ifdef UNICORN_HAS_ARM
              {"test_uc_ctl_change_page_size", test_uc_ctl_change_page_size},
              {"test_uc_ctl_arm_cpu", test_uc_ctl_arm_cpu},
+#endif
+#ifdef UNICORN_HAS_ARM64
+             {"test_uc_ctl_change_page_size_arm64", test_uc_ctl_change_page_size_arm64},
 #endif
              {"test_uc_hook_cached_uaf", test_uc_hook_cached_uaf},
              {"test_uc_emu_stop_set_ip", test_uc_emu_stop_set_ip},

--- a/uc.c
+++ b/uc.c
@@ -2543,7 +2543,7 @@ uc_err uc_ctl(uc_engine *uc, uc_control_type control, ...)
                 break;
             }
 
-            if (uc->arch != UC_ARCH_ARM) {
+            if (uc->arch != UC_ARCH_ARM && uc->arch != UC_ARCH_ARM64) {
                 err = UC_ERR_ARG;
                 break;
             }


### PR DESCRIPTION
`uc_ctl_set_page_size()` for arm64 is currently disallowed with `UC_ERR_ARG` despite being implemented and functional.

Allow for arm64, and add test.

Additionally tested with a rather involved arm64 unicorn project that makes extensive use of paging in pages on demand, no issues.