### PR TITLE
configure: update .h for clock_adjtime

### DIFF
--- a/qemu/configure
+++ b/qemu/configure
@@ -1455,6 +1455,7 @@ fi
 clock_adjtime=no
 cat > $TMPC <<EOF
 #include <time.h>
+#include <sys/timex.h>
 
 int main(void)
 {


### PR DESCRIPTION
man clock_adjtime: #include <sys/timex.h>
for glibc, if _GNU_SOURCE is defined, <time.h> will include <sys/timex.h> but not for musl, so replce <time.h> to <sys/timex.h>

PS it seems clock_adjtime is used nowhere?