### PR TITLE
Bindings/python: Fix cmake directory location

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -65,6 +65,7 @@ def copy_sources():
     shutil.copytree(os.path.join(ROOT_DIR, '../../tests'), os.path.join(SRC_DIR, 'tests/'))
     shutil.copytree(os.path.join(ROOT_DIR, '../../samples'), os.path.join(SRC_DIR, 'samples/'))
     shutil.copytree(os.path.join(ROOT_DIR, '../../glib_compat'), os.path.join(SRC_DIR, 'glib_compat/'))
+    shutil.copytree(os.path.join(ROOT_DIR, '../../cmake'), os.path.join(SRC_DIR, 'cmake/'))
 
     try:
         # remove site-specific configuration file
@@ -75,7 +76,6 @@ def copy_sources():
 
     src.extend(glob.glob(os.path.join(ROOT_DIR, "../../*.[ch]")))
     src.extend(glob.glob(os.path.join(ROOT_DIR, "../../*.mk")))
-    src.extend(glob.glob(os.path.join(ROOT_DIR, "../../cmake/*.cmake")))
 
     src.extend(glob.glob(os.path.join(ROOT_DIR, "../../LICENSE*")))
     src.extend(glob.glob(os.path.join(ROOT_DIR, "../../README.md")))


### PR DESCRIPTION
https://github.com/termux/termux-packages/issues/22989
Before fix: 
```bash
      CMake Error at CMakeLists.txt:58 (include):
        include could not find requested file:
          cmake/bundle_static.cmake
```

[log.txt](https://github.com/user-attachments/files/18499538/log.txt)

After fix:
```bash
~ $ pip3 install unicorn-2.1.1.tar.gz 
Processing ./unicorn-2.1.1.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: unicorn
  Building wheel for unicorn (pyproject.toml) ... done
  Created wheel for unicorn: filename=unicorn-2.1.1-py2.py3-none-manylinux1_aarch64.whl size=13477284 sha256=ca1a7919ecf9f0e0d03a271e9a3ee8d2e329cb04e4edb37180d90fd93d6ed425
  Stored in directory: /data/data/com.termux/files/home/.cache/pip/wheels/e1/5e/89/528be1cdb712b67dba0fca4409fc2d4aca55bfe8a22359bab6
Successfully built unicorn
Installing collected packages: unicorn
Successfully installed unicorn-2.1.1
```