### PR TITLE
arm64 python: Avoid nested class in insn hook for 10x hook and 10% overall speedup

### DIFF
--- a/.github/workflows/build-uc2.yml
+++ b/.github/workflows/build-uc2.yml
@@ -479,7 +479,7 @@ jobs:
             artifact: 'ubuntu-cmake-aarch64.7z',
             archiver: '7z a',
             generators: 'Ninja',
-            distro: ubuntu20.04
+            distro: ubuntu22.04
           }
           - {
             os: ubuntu-latest,
@@ -490,7 +490,7 @@ jobs:
             artifact: 'ubuntu-cmake-ppc64le.7z',
             archiver: '7z a',
             generators: 'Ninja',
-            distro: ubuntu20.04
+            distro: ubuntu22.04
           }
         compiler: [ gcc ]
     steps:

--- a/.github/workflows/build-uc2.yml
+++ b/.github/workflows/build-uc2.yml
@@ -471,7 +471,7 @@ jobs:
             generators: 'Ninja'
           }
           - {
-            os: ubuntu-latest,
+            os: ubuntu-22.04,
             arch: aarch64,
             python-arch: aarch64,
             python-ver: '3.8',
@@ -482,7 +482,7 @@ jobs:
             distro: ubuntu22.04
           }
           - {
-            os: ubuntu-latest,
+            os: ubuntu-22.04,
             arch: ppc64le,
             python-arch: ppc,
             python-ver: '3.8',

--- a/.github/workflows/build-wheels-publish.yml
+++ b/.github/workflows/build-wheels-publish.yml
@@ -55,9 +55,9 @@ jobs:
           # x86_64 - musllinux
           - { os: ubuntu-latest, arch: x86_64, cibw_build: 'cp38-musllinux*', cibw_skip: '' }
           # aarch64 - manylinux
-          - { os: ubuntu-latest, arch: aarch64, cibw_build: 'cp38-manylinux*', cibw_skip: '' }
+          - { os: ubuntu-22.04, arch: aarch64, cibw_build: 'cp38-manylinux*', cibw_skip: '' }
           # aarch64 - musllinux
-          - { os: ubuntu-latest, arch: aarch64, cibw_build: 'cp38-musllinux*', cibw_skip: '' }
+          - { os: ubuntu-22.04, arch: aarch64, cibw_build: 'cp38-musllinux*', cibw_skip: '' }
           - { os: macos-13, arch: x86_64, cibw_build: 'cp38*', cibw_skip: '' }
           - { os: macos-latest, arch: arm64, cibw_build: 'cp38*', cibw_skip: '' }
           - { os: windows-2019, arch: AMD64, cibw_build: 'cp38*', cibw_skip: '' }

--- a/bindings/python/unicorn/unicorn_py3/arch/arm64.py
+++ b/bindings/python/unicorn/unicorn_py3/arch/arm64.py
@@ -37,6 +37,15 @@ class UcRegCP64(UcTupledReg[ARM64CPReg]):
         return self.val
 
 
+class CpReg(NamedTuple):
+    crn: int
+    crm: int
+    op0: int
+    op1: int
+    op2: int
+    val: int
+
+
 class UcAArch64(Uc):
     """Unicorn subclass for ARM64 architecture.
     """
@@ -56,14 +65,6 @@ class UcAArch64(Uc):
             @uccallback(self, HOOK_INSN_SYS_CFUNC)
             def __hook_insn_sys_cb(uc: Uc, reg: int, pcp_reg: Any, key: int) -> int:
                 cp_reg = ctypes.cast(pcp_reg, ctypes.POINTER(UcRegCP64)).contents
-
-                class CpReg(NamedTuple):
-                    crn: int
-                    crm: int
-                    op0: int
-                    op1: int
-                    op2: int
-                    val: int
 
                 cp_reg = CpReg(cp_reg.crn, cp_reg.crm, cp_reg.op0, cp_reg.op1, cp_reg.op2, cp_reg.val)
 


### PR DESCRIPTION
Promote CpReg to a module-level class to address unnecessary performance reduction.

In a real-world use case tracing the emulation of real-world machine code, this change reduces time spent in CpReg namedtuple construction from 10% of overall time to below 1%, a ~ 10x speedup of the insn hook itself, or a ~ 10% overall speedup.  Measured using cProfile, python 3.13.