### PR TITLE
fix(arm): correct write to ARM coprocessor

### DIFF
--- a/qemu/target/arm/unicorn_arm.c
+++ b/qemu/target/arm/unicorn_arm.c
@@ -440,10 +440,10 @@ uc_err reg_write(void *_env, int mode, unsigned int regid, const void *value,
             env->regs[15] = (*(uint32_t *)value & ~1);
             *setpc = 1;
             break;
-            // case UC_ARM_REG_C1_C0_2:
-            //     env->cp15.c1_coproc = *(int32_t *)value;
-            //     break;
-
+        case UC_ARM_REG_C1_C0_2:
+            CHECK_REG_TYPE(int32_t);
+            env->cp15.cpacr_el1 = *(int32_t *)value;
+            break;
         case UC_ARM_REG_C13_C0_3:
             CHECK_REG_TYPE(int32_t);
             env->cp15.tpidrro_el[0] = *(int32_t *)value;

--- a/tests/unit/test_arm.c
+++ b/tests/unit/test_arm.c
@@ -932,6 +932,27 @@ static void test_arm_thumb_tcg_opcode_cmn(void)
     TEST_CHECK(cmp_info.size == 32);
 }
 
+static void test_arm_cp15_c1_c0_2(void)
+{
+    uc_engine *uc;
+    uint32_t val = 0x12345678;
+    uint32_t read_val;
+
+    // Initialize emulator in ARM mode
+    OK(uc_open(UC_ARCH_ARM, UC_MODE_ARM, &uc));
+    OK(uc_ctl_set_cpu_model(uc, UC_CPU_ARM_CORTEX_A15));
+
+    // Write to CP15 C1_C0_2
+    OK(uc_reg_write(uc, UC_ARM_REG_C1_C0_2, &val));
+
+    // Read from CP15 C1_C0_2
+    OK(uc_reg_read(uc, UC_ARM_REG_C1_C0_2, &read_val));
+
+    TEST_CHECK(read_val == val);
+
+    OK(uc_close(uc));
+}
+
 TEST_LIST = {{"test_arm_nop", test_arm_nop},
              {"test_arm_thumb_sub", test_arm_thumb_sub},
              {"test_armeb_sub", test_armeb_sub},
@@ -960,4 +981,5 @@ TEST_LIST = {{"test_arm_nop", test_arm_nop},
              {"test_arm_mem_hook_read_write", test_arm_mem_hook_read_write},
              {"test_arm_tcg_opcode_cmp", test_arm_tcg_opcode_cmp},
              {"test_arm_thumb_tcg_opcode_cmn", test_arm_thumb_tcg_opcode_cmn},
+             {"test_arm_cp15_c1_c0_2", test_arm_cp15_c1_c0_2},
              {NULL, NULL}};


### PR DESCRIPTION
### Problem

Any attempt to write to UC_ARM_REG_C1_C0_2 ([The ARM Coprocessor Access Control Register](https://developer.arm.com/documentation/ddi0344/k/system-control-coprocessor/system-control-coprocessor-registers/c1--coprocessor-access-control-register)) fails with UC_ERR_ARG.
The specific switch case handling writes to this register was commented out since 2021, but by default, the error code was initialized to UC_REG_OK, so there was no error returned until #1835, where this was changed to be initialized to UC_REG_ERR_ARG. As a result, any write to UC_ARM_REG_C1_C0_2 returned an error.

### Solution

In this PR, I've uncommented and properly implement the CPACR register write with appropriate size checking. I've also added a unit test to verify that writes no longer fail - before this PR, the test does indeed fail.