### PR TITLE
Fix #2103: qemu/target/ppc/mem_helper.c remove redundant returns

### DIFF
--- a/qemu/target/ppc/mem_helper.c
+++ b/qemu/target/ppc/mem_helper.c
@@ -387,7 +387,6 @@ uint64_t helper_lq_le_parallel(CPUPPCState *env, target_ulong addr,
     return int128_getlo(ret);
 #else
     g_assert_not_reached();
-    return 0;
 #endif
 }
 
@@ -404,7 +403,6 @@ uint64_t helper_lq_be_parallel(CPUPPCState *env, target_ulong addr,
     return int128_getlo(ret);
 #else
     g_assert_not_reached();
-    return 0;
 #endif
 }
 
@@ -420,7 +418,6 @@ void helper_stq_le_parallel(CPUPPCState *env, target_ulong addr,
     helper_atomic_sto_le_mmu(env, addr, val, opidx, GETPC());
 #else
     g_assert_not_reached();
-    return 0;
 #endif
 }
 
@@ -436,7 +433,6 @@ void helper_stq_be_parallel(CPUPPCState *env, target_ulong addr,
     helper_atomic_sto_be_mmu(env, addr, val, opidx, GETPC());
 #else
     g_assert_not_reached();
-    return 0;
 #endif
 }
 #endif
@@ -465,7 +461,6 @@ uint32_t helper_stqcx_le_parallel(CPUPPCState *env, target_ulong addr,
     return env->so + success * CRF_EQ_BIT;
 #else
     g_assert_not_reached();
-    return 0;
 #endif
 }
 
@@ -492,7 +487,6 @@ uint32_t helper_stqcx_be_parallel(CPUPPCState *env, target_ulong addr,
     return env->so + success * CRF_EQ_BIT;
 #else
     g_assert_not_reached();
-    return 0;
 #endif
 }
 


### PR DESCRIPTION
This fixes the issue described in #2103 - compilation errors when building Unicorn Engine:

```
/build/unicorn-2.1.2/src/qemu/target/ppc/mem_helper.c: In function ‘helper_stq_le_parallel’:
/build/unicorn-2.1.2/src/qemu/target/ppc/mem_helper.c:423:12: error: ‘return’ with a value, in function returning void [-Wreturn-mismatch]
  423 |     return 0;
      |            ^
/build/unicorn-2.1.2/src/qemu/target/ppc/mem_helper.c: In function ‘helper_stq_be_parallel’:
/build/unicorn-2.1.2/src/qemu/target/ppc/mem_helper.c:439:12: error: ‘return’ with a value, in function returning void [-Wreturn-mismatch]
  439 |     return 0;
      |            ^
```

As pointed by @patryk4815
 
> Since GCC 14, the -Wreturn-mismatch warning has been promoted to an error by default (as mentioned [here](https://discourse.llvm.org/t/gcc-14-adds-wreturn-mismatch/74868)).