### PR TITLE
GitHub Workflow: Updating jobs with new runners + fixes for Linux and windows x86 jobs

### DIFF
--- a/.github/workflows/Crate-publishing.yml
+++ b/.github/workflows/Crate-publishing.yml
@@ -26,58 +26,58 @@ jobs:
       matrix:
         config:
           - {
-              os: windows-2019,
-              arch: x64,
-              name: 'Windows x86_64'
-            }
+            os: windows-2022,
+            arch: x64,
+            name: 'Windows x86_64'
+          }
           - {
-              os: windows-2019,
-              arch: x86,
-              name: 'Windows x86'
-            }
+            os: windows-2022,
+            arch: x86,
+            name: 'Windows x86'
+          }
           - {
-              os: ubuntu-latest,
-              arch: x64,
-              name: 'Ubuntu x86_64'
-            }
+            os: ubuntu-latest,
+            arch: x64,
+            name: 'Ubuntu x86_64'
+          }
           - {
-             os: macos-latest,
-             arch: x64,
-             name: 'macOS x86_64'
-            }
+            os: macos-latest,
+            arch: x64,
+            name: 'macOS x86_64'
+          }
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: '🛠️ Set up Rust'
-      uses: dtolnay/rust-toolchain@stable
+      - name: '🛠️ Set up Rust'
+        uses: dtolnay/rust-toolchain@stable
 
-    - name: '🛠️ Activate Developer Command Prompt'
-      if: contains(matrix.config.os, 'win')
-      uses: ilammy/msvc-dev-cmd@v1
-      with:
-        arch: ${{ matrix.config.arch }}
+      - name: '🛠️ Activate Developer Command Prompt'
+        if: contains(matrix.config.os, 'win')
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.config.arch }}
 
-    - name: '🛠️ Win build dependencies'
-      if: contains(matrix.config.os, 'win')
-      shell: bash
-      run: |
-        choco install ninja
+      - name: '🛠️ Win build dependencies'
+        if: contains(matrix.config.os, 'win')
+        shell: bash
+        run: |
+          choco install ninja
 
-    - name: '🛠️ macOS build dependencies'
-      if: contains(matrix.config.os, 'macOS')
-      shell: bash
-      run: |
-        brew install ninja
+      - name: '🛠️ macOS build dependencies'
+        if: contains(matrix.config.os, 'macOS')
+        shell: bash
+        run: |
+          brew install ninja
 
-    - name: '🚧 Cargo test'
-      if: "!startsWith(github.ref, 'refs/tags')"
-      run: |
-        cargo test
+      - name: '🚧 Cargo test'
+        if: "!startsWith(github.ref, 'refs/tags')"
+        run: |
+          cargo test
 
-    - name: '📦 Cargo Publish'
-      if: startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/tags/v') && contains(matrix.config.os, 'ubuntu')
-      env:
-        TOKEN: ${{ secrets.cratesio_token }}
-        UNICORN_VERSION: dev
-      run: |
-        cargo login $TOKEN && cargo test && cargo publish
+      - name: '📦 Cargo Publish'
+        if: startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/tags/v') && contains(matrix.config.os, 'ubuntu')
+        env:
+          TOKEN: ${{ secrets.cratesio_token }}
+          UNICORN_VERSION: dev
+        run: |
+          cargo login $TOKEN && cargo test && cargo publish

--- a/.github/workflows/Nuget-publishing.yml
+++ b/.github/workflows/Nuget-publishing.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         config:
           - {
-            os: windows-2019,
+            os: windows-2022,
             arch: x64,
             python-arch: x64,
             python-ver: '3.8',
@@ -45,10 +45,10 @@ jobs:
             shared: 'yes',
             build_type: 'Release',
             archiver: '7z a',
-            generators: 'Visual Studio 16 2019'
+            generators: 'Visual Studio 17 2022'
           }
           - {
-            os: windows-2019,
+            os: windows-2022,
             arch: x86,
             python-arch: x86,
             python-ver: '3.8',
@@ -58,7 +58,7 @@ jobs:
             shared: 'yes',
             build_type: 'Release',
             archiver: '7z a',
-            generators: 'Visual Studio 16 2019'
+            generators: 'Visual Studio 17 2022'
           }
         compiler: [ gcc ]
     steps:
@@ -228,7 +228,7 @@ jobs:
             generators: 'Ninja'
           }
           - {
-            os: ubuntu-22.04,
+            os: ubuntu-24.04-arm,
             arch: aarch64,
             python-arch: aarch64,
             python-ver: '3.8',
@@ -237,7 +237,7 @@ jobs:
             build_type: 'Release',
             archiver: '7z a',
             generators: 'Ninja',
-            distro: ubuntu20.04
+            distro: ubuntu24.04
           }
           - {
             os: ubuntu-22.04,
@@ -249,7 +249,7 @@ jobs:
             build_type: 'Release',
             archiver: '7z a',
             generators: 'Ninja',
-            distro: ubuntu20.04
+            distro: ubuntu22.04
           }
         compiler: [ gcc ]
     steps:
@@ -257,14 +257,15 @@ jobs:
 
       - name: '🚧 Linux x64/x86 build'
         if: contains(matrix.config.arch, 'x64') || contains(matrix.config.arch, 'x86')
-        shell: 'script -q -e -c "bash {0}"'
+        shell: bash
         run: |
           if [ ${{ matrix.config.arch }} == 'x64' ]; then
+                sudo apt update -q -y
                 sudo apt install -q -y libcmocka-dev ninja-build
           else
                 export CFLAGS="-m32" LDFLAGS="-m32" LDFLAGS_STATIC="-m32" UNICORN_QEMU_FLAGS="--cpu=i386"
                 sudo dpkg --add-architecture i386
-                sudo apt update
+                sudo apt update -q -y
                 sudo apt install -q -y lib32ncurses-dev lib32z1-dev lib32gcc-9-dev libc6-dev-i386 gcc-multilib \
                   libcmocka-dev:i386 libcmocka0:i386 libc6:i386 libgcc-s1:i386 ninja-build
           fi
@@ -281,8 +282,26 @@ jobs:
           cmake --install . --strip
           ctest -VV -C ${{ matrix.config.build_type }}
 
-      - name: '🚧 Linux ppc64le/aarch64 build'
-        if: contains(matrix.config.arch, 'ppc64le') || contains(matrix.config.arch, 'aarch64')
+      - name: '🚧 Linux aarch64 build'
+        if: contains(matrix.config.arch, 'aarch64')
+        shell: bash
+        run: |
+          sudo apt-get update -q -y
+          sudo apt-get install -q -y git cmake build-essential automake libcmocka-dev pkg-config ${{ matrix.compiler }} ninja-build
+          mkdir build
+          mkdir instdir
+          cmake \
+            -S . \
+            -B . \
+            -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
+            -G "${{ matrix.config.generators }}" \
+            -DCMAKE_INSTALL_PREFIX:PATH=/instdir
+          cmake --build . --config ${{ matrix.config.build_type }}
+          sudo cmake --install . --strip
+          ctest -VV -C ${{ matrix.config.build_type }}
+
+      - name: '🚧 Linux ppc64le build'
+        if: contains(matrix.config.arch, 'ppc64le')
         uses: uraimo/run-on-arch-action@v2
         with:
           arch: ${{ matrix.config.arch }}
@@ -323,7 +342,7 @@ jobs:
           name: ${{ matrix.config.artifact }}
 
   publish:
-    needs: ["Windows", "Macos", "Linux"]
+    needs: [ "Windows", "Macos", "Linux" ]
     if: ${{ needs.Windows.result == 'success' && needs.Macos.result == 'success' && needs.Linux.result == 'success' }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build-uc2.yml
+++ b/.github/workflows/build-uc2.yml
@@ -37,104 +37,88 @@ jobs:
       matrix:
         config:
           - {
-            os: windows-2019,
+            os: windows-2022,
             arch: x64,
-            python-arch: x64,
-            python-ver: '3.8',
             name: 'windows-x64 MINGW64 shared',
             shared: 'yes',
             mingw: MINGW64,
             mingw-arch: x86_64,
-            artifact: 'windows_mingw64-shared.7z',
+            artifact: 'windows-mingw64-shared.7z',
             archiver: '7z a',
             generators: 'Ninja'
           }
           - {
-            os: windows-2019,
+            os: windows-2022,
             arch: x64,
-            python-arch: x64,
-            python-ver: '3.8',
             name: 'windows-x64 MINGW64 static',
             shared: 'no',
             mingw: MINGW64,
             mingw-arch: x86_64,
-            artifact: 'windows_mingw64-static.7z',
+            artifact: 'windows-mingw64-static.7z',
             archiver: '7z a',
             generators: 'Ninja'
           }
-#          - { # This fails randomly which can't be reproduced.
-#              os: windows-2019,
-#              arch: x64,
-#              python-arch: x64,
-#              python-ver: '3.8',
-#              name: 'windows-x64 MINGW32 shared',
-#              shared: "yes",
-#              mingw: MINGW32,
-#              mingw-arch: i686,
-#              artifact: 'windows_mingw32.7z',
-#              archiver: '7z a',
-#              generators: 'Ninja'
-#            }
-#          - { # This fails randomly which can't be reproduced.
-#              os: windows-2019,
-#              arch: x64,
-#              python-arch: x64,
-#              python-ver: '3.8',
-#              name: 'windows-x64 MINGW32 static',
-#              shared: "no",
-#              mingw: MINGW32,
-#              mingw-arch: i686,
-#              artifact: 'windows_mingw32.7z',
-#              archiver: '7z a',
-#              generators: 'Ninja'
-#            }
-          - {
-            os: windows-2019,
+          - { # This fails randomly which can't be reproduced.
+            os: windows-2022,
             arch: x64,
-            python-arch: x64,
-            python-ver: '3.8',
+            name: 'windows-x64 MINGW32 shared',
+            shared: "yes",
+            mingw: MINGW32,
+            mingw-arch: i686,
+            artifact: 'windows-mingw32-shared.7z',
+            archiver: '7z a',
+            generators: 'Ninja'
+          }
+          - { # This fails randomly which can't be reproduced.
+            os: windows-2022,
+            arch: x64,
+            name: 'windows-x64 MINGW32 static',
+            shared: "no",
+            mingw: MINGW32,
+            mingw-arch: i686,
+            artifact: 'windows-mingw32-static.7z',
+            archiver: '7z a',
+            generators: 'Ninja'
+          }
+          - {
+            os: windows-2022,
+            arch: x64,
             name: 'windows-x64 MSVC 64bit shared',
             msvc-arch: x64,
-            artifact: 'windows_msvc64_shared.7z',
+            artifact: 'windows-msvc64-shared.7z',
             shared: 'yes',
             archiver: '7z a',
-            generators: 'Visual Studio 16 2019'
+            generators: 'Visual Studio 17 2022'
           }
           - {
-            os: windows-2019,
+            os: windows-2022,
             arch: x86,
-            python-arch: x86,
-            python-ver: '3.8',
             name: 'windows-x86 MSVC 32bit shared',
             msvc-arch: x86,
-            artifact: 'windows_msvc32_shared.7z',
+            artifact: 'windows-msvc32-shared.7z',
             shared: 'yes',
             archiver: '7z a',
-            generators: 'Visual Studio 16 2019'
+            generators: 'Visual Studio 17 2022'
           }
           - {
-            os: windows-2019,
+            os: windows-2022,
             arch: x64,
-            python-arch: x64,
-            python-ver: '3.8',
             name: 'windows-x64 MSVC 64bit static',
             msvc-arch: x64,
-            artifact: 'windows_msvc64_static.7z',
+            artifact: 'windows-msvc64-static.7z',
             shared: 'no',
             archiver: '7z a',
-            generators: 'Visual Studio 16 2019'
+            generators: 'Visual Studio 17 2022'
           }
           - {
-            os: windows-2019,
+            os: windows-2022,
             arch: x86,
-            python-arch: x86,
-            python-ver: '3.8',
             name: 'windows-x86 MSVC 32bit static',
             msvc-arch: x86,
-            artifact: 'windows_msvc32_static.7z',
+            artifact: 'windows-msvc32-static.7z',
             shared: 'no',
             archiver: '7z a',
-            generators: 'Visual Studio 16 2019'
+            generators: 'Visual Studio 17 2022'
           }
         compiler: [ gcc ]
     steps:
@@ -263,8 +247,6 @@ jobs:
           - {
             os: macos-13, # x64
             arch: x64,
-            python-arch: x64,
-            python-ver: '3.8',
             name: 'macos-x64 cmake shared',
             shared: 'yes',
             artifact: 'macos-x64-cmake-shared-x64.7z',
@@ -274,8 +256,6 @@ jobs:
           - {
             os: macos-13,
             arch: x64,
-            python-arch: x64,
-            python-ver: '3.8',
             name: 'macos-x64 cmake static',
             shared: 'no',
             artifact: 'macos-x64-cmake-static-x64.7z',
@@ -285,8 +265,6 @@ jobs:
           - {
             os: macos-14, # arm64
             arch: arm64,
-            python-arch: arm64,
-            python-ver: '3.8',
             name: 'macos-arm64 cmake shared',
             shared: 'yes',
             artifact: 'macos-arm64-cmake-shared-x64.7z',
@@ -296,8 +274,6 @@ jobs:
           - {
             os: macos-14,
             arch: arm64,
-            python-arch: arm64,
-            python-ver: '3.8',
             name: 'macos-arm64 cmake static',
             shared: 'no',
             artifact: 'macos-arm64-cmake-static-x64.7z',
@@ -307,8 +283,6 @@ jobs:
           - {
             os: macos-13,
             arch: x86_64,
-            python-arch: x86_64,
-            python-ver: '3.8',
             name: 'android cmake',
             artifact: 'Android-x86_64.7z',
             archiver: '7za a',
@@ -317,12 +291,6 @@ jobs:
         compiler: [ gcc ]
     steps:
       - uses: actions/checkout@v4
-
-#      - name: '🛠️ Python setup'
-#        uses: actions/setup-python@v5
-#        with:
-#          python-version: ${{ matrix.config.python-ver }}
-
       - name: '🚧 Mac build'
         if: contains(matrix.config.name, 'macos')
         shell: bash
@@ -342,10 +310,6 @@ jobs:
           cmake --build . --config ${{ env.BUILD_TYPE }}
           cmake --install . --strip
           ctest -VV -C ${{ env.BUILD_TYPE }}
-      
-#      - name: Setup tmate session
-#        if: ${{ failure() }}
-#        uses: mxschmitt/action-tmate@v3
 
       - name: '🚧 Android x86_64 build'
         if: contains(matrix.config.name, 'android')
@@ -429,8 +393,6 @@ jobs:
           - {
             os: ubuntu-latest,
             arch: x64,
-            python-arch: x64,
-            python-ver: '3.8',
             name: 'ubuntu-x64 cmake shared',
             shared: 'yes',
             artifact: 'ubuntu-cmake-shared-x64.7z',
@@ -440,8 +402,6 @@ jobs:
           - {
             os: ubuntu-latest,
             arch: x86,
-            python-arch: x86,
-            python-ver: '3.8',
             name: 'ubuntu-x86 cmake shared',
             shared: 'yes',
             artifact: 'ubuntu-cmake-shared-x86.7z',
@@ -451,8 +411,6 @@ jobs:
           - {
             os: ubuntu-latest,
             arch: x64,
-            python-arch: x64,
-            python-ver: '3.8',
             name: 'ubuntu-x64 cmake static',
             shared: 'no',
             artifact: 'ubuntu-cmake-static-x64.7z',
@@ -462,8 +420,6 @@ jobs:
           - {
             os: ubuntu-latest,
             arch: x86,
-            python-arch: x86,
-            python-ver: '3.8',
             name: 'ubuntu-x86 cmake static',
             shared: 'no',
             artifact: 'ubuntu-cmake-static-x86.7z',
@@ -471,21 +427,17 @@ jobs:
             generators: 'Ninja'
           }
           - {
-            os: ubuntu-22.04,
+            os: ubuntu-24.04-arm,
             arch: aarch64,
-            python-arch: aarch64,
-            python-ver: '3.8',
             name: 'ubuntu-aarch64 cmake',
             artifact: 'ubuntu-cmake-aarch64.7z',
             archiver: '7z a',
             generators: 'Ninja',
-            distro: ubuntu22.04
+            distro: ubuntu24.04
           }
           - {
             os: ubuntu-22.04,
             arch: ppc64le,
-            python-arch: ppc,
-            python-ver: '3.8',
             name: 'ubuntu-ppc64le cmake',
             artifact: 'ubuntu-cmake-ppc64le.7z',
             archiver: '7z a',
@@ -495,21 +447,17 @@ jobs:
         compiler: [ gcc ]
     steps:
       - uses: actions/checkout@v4
-
-#      - name: '🛠️ Python setup'
-#        uses: actions/setup-python@v5
-#        with:
-#            python-version: ${{ matrix.config.python-ver }}
-
       - name: '🚧 Linux x64/x86 build'
         if: contains(matrix.config.arch, 'x64') || contains(matrix.config.arch, 'x86')
-        shell: 'script -q -e -c "bash {0}"'
+        shell: bash
         run: |
           if [ ${{ matrix.config.arch }} == 'x64' ]; then
+                sudo apt-get update -q -y
                 sudo apt install -q -y libcmocka-dev ninja-build 
           else
                 export CFLAGS="-m32" LDFLAGS="-m32" LDFLAGS_STATIC="-m32" UNICORN_QEMU_FLAGS="--cpu=i386" 
                 sudo dpkg --add-architecture i386
+                sudo apt-get update -q -y
                 sudo apt install -q -y lib32ncurses-dev lib32z1-dev lib32gcc-9-dev libc6-dev-i386 gcc-multilib \
                   libcmocka-dev:i386 libcmocka0:i386 libc6:i386 libgcc-s1:i386 ninja-build
           fi
@@ -526,8 +474,26 @@ jobs:
           cmake --install . --strip
           ctest -VV -C ${{ env.BUILD_TYPE }}
 
-      - name: '🚧 Linux ppc64le/aarch64 build'
-        if: contains(matrix.config.arch, 'ppc64le') || contains(matrix.config.arch, 'aarch64')
+      - name: '🚧 Linux aarch64 build'
+        if: contains(matrix.config.arch, 'aarch64')
+        shell: bash
+        run: |
+          sudo apt-get update -q -y
+          sudo apt-get install -q -y git cmake build-essential automake libcmocka-dev pkg-config ${{ matrix.compiler }} ninja-build
+          mkdir build
+          mkdir instdir
+          cmake \
+            -S . \
+            -B . \
+            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
+            -G "${{ matrix.config.generators }}" \
+            -DCMAKE_INSTALL_PREFIX:PATH=/instdir
+          cmake --build . --config ${{ env.BUILD_TYPE }}
+          sudo cmake --install . --strip
+          ctest -VV -C ${{ env.BUILD_TYPE }}
+
+      - name: '🚧 Linux ppc64le build'
+        if: contains(matrix.config.arch, 'ppc64le')
         uses: uraimo/run-on-arch-action@v2
         with:
           arch: ${{ matrix.config.arch }}


### PR DESCRIPTION
- Switched from windows-2019 to windows-2022
- Switched to ubuntu-24.04-arm image for Linux aarch64 jobs
- Fixed Linux x86 job. It was failing but not reported
- Switched from Visual Studio 16 2019 generators to Visual Studio 17 2022
- Un-commented Windows MINGW32 static and shared jobs
- Generic clean-up