### PR TITLE
Support MIPS64 - write correct PC register width on uc_emu_start

### DIFF
--- a/include/unicorn/mips.h
+++ b/include/unicorn/mips.h
@@ -43,6 +43,8 @@ typedef enum uc_cpu_mips32 {
 
 //> MIPS64 CPUS
 typedef enum uc_cpu_mips64 {
+    // This is used as an index into the array defined in "qemu/target/mips/translate_init.inc.c".
+    // 64-bit CPU models are defined in the array directly after 32-bit models
     UC_CPU_MIPS64_R4000 = UC_CPU_MIPS32_ENDING,
     UC_CPU_MIPS64_VR5432,
     UC_CPU_MIPS64_5KC,

--- a/include/unicorn/mips.h
+++ b/include/unicorn/mips.h
@@ -43,7 +43,7 @@ typedef enum uc_cpu_mips32 {
 
 //> MIPS64 CPUS
 typedef enum uc_cpu_mips64 {
-    UC_CPU_MIPS64_R4000 = 0,
+    UC_CPU_MIPS64_R4000 = UC_CPU_MIPS32_ENDING,
     UC_CPU_MIPS64_VR5432,
     UC_CPU_MIPS64_5KC,
     UC_CPU_MIPS64_5KF,

--- a/include/unicorn/mips.h
+++ b/include/unicorn/mips.h
@@ -43,9 +43,7 @@ typedef enum uc_cpu_mips32 {
 
 //> MIPS64 CPUS
 typedef enum uc_cpu_mips64 {
-    // This is used as an index into the array defined in "qemu/target/mips/translate_init.inc.c".
-    // 64-bit CPU models are defined in the array directly after 32-bit models
-    UC_CPU_MIPS64_R4000 = UC_CPU_MIPS32_ENDING,
+    UC_CPU_MIPS64_R4000 = 0,
     UC_CPU_MIPS64_VR5432,
     UC_CPU_MIPS64_5KC,
     UC_CPU_MIPS64_5KF,

--- a/qemu/target/mips/cpu.c
+++ b/qemu/target/mips/cpu.c
@@ -196,7 +196,7 @@ MIPSCPU *cpu_mips_init(struct uc_struct *uc)
     env = &cpu->env;
     if(uc->mode & UC_MODE_MIPS64){
         // 64-bit CPU models are defined in the array directly after 32-bit models
-        env->cpu_model = &(mips_defs[uc->cpu_model + UC_CPU_MIPS32_ENDING])
+        env->cpu_model = &(mips_defs[uc->cpu_model + UC_CPU_MIPS32_ENDING]);
     } else {
         env->cpu_model = &(mips_defs[uc->cpu_model]);
     }

--- a/qemu/target/mips/cpu.c
+++ b/qemu/target/mips/cpu.c
@@ -194,7 +194,12 @@ MIPSCPU *cpu_mips_init(struct uc_struct *uc)
     mips_cpu_initfn(uc, cs);
 
     env = &cpu->env;
-    env->cpu_model = &(mips_defs[uc->cpu_model]);
+    if(uc->mode & UC_MODE_MIPS64){
+        // 64-bit CPU models are defined in the array directly after 32-bit models
+        env->cpu_model = &(mips_defs[uc->cpu_model + UC_CPU_MIPS32_ENDING])
+    } else {
+        env->cpu_model = &(mips_defs[uc->cpu_model]);
+    }
 
     if (env->cpu_model == NULL) {
         free(cpu);

--- a/tests/regress/mips64.py
+++ b/tests/regress/mips64.py
@@ -32,7 +32,7 @@ class Mips64(regress.RegressTest):
         # This will raise an exception if MIPS64 fails
         uc.emu_start(ADDRESS, 0, count=2)
 
-        assert uc.reg_read(UC_MIPS_REG_PC) == 0x0120003000 + 8
+        self.assertEqual(uc.reg_read(UC_MIPS_REG_PC),0x0120003000 + 8)
 
 
 if __name__ == '__main__':

--- a/tests/regress/mips64.py
+++ b/tests/regress/mips64.py
@@ -2,34 +2,31 @@ import regress
 from unicorn import *
 from unicorn.mips_const import *
 
-# Two instructions:
-#   daddu  $gp, $gp, $ra    # a 64-bit instruction. This is important - it ensures the selected CPU model is 64-bit, otherwise it would crash
-#   move   $t1, $v0
 
-code = b"\x03\x9f\xe0\x2d" + b"\x00\x40\x48\x25"
-
-def run():
-    uc = Uc(UC_ARCH_MIPS, UC_MODE_MIPS64 + UC_MODE_BIG_ENDIAN)
-    # For MIPS64 to be able to reference addresses >= 0x80000000, you need to enable the virtual TLB
-    # See https://github.com/unicorn-engine/unicorn/pull/2111 for more details
-    uc.ctl_set_tlb_mode(UC_TLB_VIRTUAL)
-
-    ADDRESS = 0x0120003000
-
-    uc.reg_write(UC_MIPS_REG_PC, ADDRESS)
-    uc.reg_write(UC_MIPS_REG_GP, 0x123)
-    uc.reg_write(UC_MIPS_REG_RA, 0x456)
-
-    uc.mem_map(ADDRESS, 4 * 1024)
-    uc.mem_write(ADDRESS, code)
-
-    # This will raise an exception if MIPS64 fails
-    uc.emu_start(ADDRESS, 0, count=2)
-
-
-class MipsSingleStep(regress.RegressTest):
+class Mips64(regress.RegressTest):
     def runTest(self):
-        run()
+        # Two instructions:
+        #   daddu  $gp, $gp, $ra    # a 64-bit instruction. This is important - it ensures the selected CPU model is 64-bit, otherwise it would crash
+        #   move   $t1, $v0
+
+        code = b"\x03\x9f\xe0\x2d" + b"\x00\x40\x48\x25"
+
+        uc = Uc(UC_ARCH_MIPS, UC_MODE_MIPS64 + UC_MODE_BIG_ENDIAN)
+        # For MIPS64 to be able to reference addresses >= 0x80000000, you need to enable the virtual TLB
+        # See https://github.com/unicorn-engine/unicorn/pull/2111 for more details
+        uc.ctl_set_tlb_mode(UC_TLB_VIRTUAL)
+
+        ADDRESS = 0x0120003000
+
+        uc.reg_write(UC_MIPS_REG_PC, ADDRESS)
+        uc.reg_write(UC_MIPS_REG_GP, 0x123)
+        uc.reg_write(UC_MIPS_REG_RA, 0x456)
+
+        uc.mem_map(ADDRESS, 4 * 1024)
+        uc.mem_write(ADDRESS, code)
+
+        # This will raise an exception if MIPS64 fails
+        uc.emu_start(ADDRESS, 0, count=2)
 
 
 if __name__ == '__main__':

--- a/tests/regress/mips64.py
+++ b/tests/regress/mips64.py
@@ -1,9 +1,13 @@
+import sys
+import unittest
 import regress
 from unicorn import *
 from unicorn.mips_const import *
 
 
 class Mips64(regress.RegressTest):
+
+    @unittest.skipIf(sys.version_info < (3, 7), reason="requires python3.7 or higher")
     def runTest(self):
         # Two instructions:
         #   daddu  $gp, $gp, $ra    # a 64-bit instruction. This is important - it ensures the selected CPU model is 64-bit, otherwise it would crash

--- a/tests/regress/mips64.py
+++ b/tests/regress/mips64.py
@@ -1,0 +1,38 @@
+import regress
+import sys
+import unittest
+from unicorn import *
+from unicorn.mips_const import *
+
+# Two instructions:
+#   daddu  $gp, $gp, $ra    # a 64-bit instruction. This is important - it ensures the selected CPU model is 64-bit, otherwise it would crash
+#   move   $t1, $v0
+
+code = b"\x03\x9f\xe0\x2d" + b"\x00\x40\x48\x25"
+
+def run():
+    uc = Uc(UC_ARCH_MIPS, UC_MODE_MIPS64 + UC_MODE_BIG_ENDIAN)
+    # For MIPS64 to be able to reference addresses >= 0x80000000, you need to enable the virtual TLB
+    # See https://github.com/unicorn-engine/unicorn/pull/2111 for more details
+    uc.ctl_set_tlb_mode(UC_TLB_VIRTUAL)
+
+    ADDRESS = 0x01_2000_3000
+
+    uc.reg_write(UC_MIPS_REG_PC, ADDRESS)
+    uc.reg_write(UC_MIPS_REG_GP, 0x123)
+    uc.reg_write(UC_MIPS_REG_RA, 0x456)
+
+    uc.mem_map(ADDRESS, 4 * 1024)
+    uc.mem_write(ADDRESS, code)
+
+    # This will raise an exception if MIPS64 fails
+    uc.emu_start(ADDRESS, 0, count=2)
+
+
+class MipsSingleStep(regress.RegressTest):
+    def runTest(self):
+        run()
+
+
+if __name__ == '__main__':
+    regress.main()

--- a/tests/regress/mips64.py
+++ b/tests/regress/mips64.py
@@ -1,6 +1,4 @@
 import regress
-import sys
-import unittest
 from unicorn import *
 from unicorn.mips_const import *
 

--- a/tests/regress/mips64.py
+++ b/tests/regress/mips64.py
@@ -28,6 +28,8 @@ class Mips64(regress.RegressTest):
         # This will raise an exception if MIPS64 fails
         uc.emu_start(ADDRESS, 0, count=2)
 
+        assert uc.reg_read(UC_MIPS_REG_PC) == 0x0120003000 + 8
+
 
 if __name__ == '__main__':
     regress.main()

--- a/tests/regress/mips64.py
+++ b/tests/regress/mips64.py
@@ -14,7 +14,7 @@ def run():
     # See https://github.com/unicorn-engine/unicorn/pull/2111 for more details
     uc.ctl_set_tlb_mode(UC_TLB_VIRTUAL)
 
-    ADDRESS = 0x01_2000_3000
+    ADDRESS = 0x0120003000
 
     uc.reg_write(UC_MIPS_REG_PC, ADDRESS)
     uc.reg_write(UC_MIPS_REG_GP, 0x123)

--- a/uc.c
+++ b/uc.c
@@ -1020,7 +1020,6 @@ uc_err uc_emu_start(uc_engine *uc, uint64_t begin, uint64_t until,
 #endif
 #ifdef UNICORN_HAS_MIPS
     case UC_ARCH_MIPS:
-        // TODO: MIPS32/MIPS64/BIGENDIAN etc
         if (uc->mode & UC_MODE_MIPS64) {
             uc_reg_write(uc, UC_MIPS_REG_PC, &begin);
         } else {

--- a/uc.c
+++ b/uc.c
@@ -1021,7 +1021,7 @@ uc_err uc_emu_start(uc_engine *uc, uint64_t begin, uint64_t until,
 #ifdef UNICORN_HAS_MIPS
     case UC_ARCH_MIPS:
         // TODO: MIPS32/MIPS64/BIGENDIAN etc
-        if (uc->mode & UC_MODE_64) {
+        if (uc->mode & UC_MODE_MIPS64) {
             uc_reg_write(uc, UC_MIPS_REG_PC, &begin);
         } else {
             uc_reg_write(uc, UC_MIPS_REG_PC, &begin_pc32);

--- a/uc.c
+++ b/uc.c
@@ -1021,7 +1021,11 @@ uc_err uc_emu_start(uc_engine *uc, uint64_t begin, uint64_t until,
 #ifdef UNICORN_HAS_MIPS
     case UC_ARCH_MIPS:
         // TODO: MIPS32/MIPS64/BIGENDIAN etc
-        uc_reg_write(uc, UC_MIPS_REG_PC, &begin_pc32);
+        if (uc->mode & UC_MODE_64) {
+            uc_reg_write(uc, UC_MIPS_REG_PC, &begin);
+        } else {
+            uc_reg_write(uc, UC_MIPS_REG_PC, &begin_pc32);
+        }
         break;
 #endif
 #ifdef UNICORN_HAS_SPARC


### PR DESCRIPTION
This PR allows MIPS64 to work - previously MIPS64 would crash immediately after starting the emulator - see #2109.

The current `uc_emu_start` code makes the assumptions that MIPS has a 32-bit program counter. Adding a check to see if it's 64-bit and writing the correct value to PC makes MIPS64 run.

https://github.com/unicorn-engine/unicorn/blob/8d52ece48bbb521060a5234ba1326d601be78315/uc.c#L1021-L1026