### PR TITLE
Fix Python 3.8 to 3.11

### DIFF
--- a/bindings/python/unicorn/unicorn_py3/unicorn.py
+++ b/bindings/python/unicorn/unicorn_py3/unicorn.py
@@ -114,14 +114,17 @@ def __load_uc_lib() -> ctypes.CDLL:
     # - global load
     # - python's lib directory
 
-    if sys.version_info.minor >= 12:
+    if sys.version_info >= (3, 9):
         from importlib import resources
 
         canonicals = resources.files('unicorn') / 'lib'
     else:
-        import pkg_resources
+        try:
+            import pkg_resources
 
-        canonicals = pkg_resources.resource_filename('unicorn', 'lib')
+            canonicals = pkg_resources.resource_filename('unicorn', 'lib')
+        except ImportError:
+            canonicals = None
 
     lib_locations = [
         os.getenv('LIBUNICORN_PATH'),


### PR DESCRIPTION
Current logic requires old setuptools on py3.8 up to py3.11. So if new setuptools is installed, importing unicorn always fails with ImportError on these Python versions.

It now tries to use old setuptools on py3.8, but falls back gracefully to not using anything.
So it works on py3.9+ fully, and on py3.8 it also works but with more limited path discovery (I think it is enough, since no one complained yet).

Fixes: [0c34496a395eac567dc24eb6574550938a52b126](https://github.com/unicorn-engine/unicorn/pull/2016/commits/0c34496a395eac567dc24eb6574550938a52b126) ("Modify canonicals import")
Ref: https://github.com/Gallopsled/pwntools/pull/2556