### PR TITLE
Snapshot use after free

### DIFF
--- a/tests/unit/test_arm.c
+++ b/tests/unit/test_arm.c
@@ -905,6 +905,7 @@ static void test_arm_tcg_opcode_cmp(void)
     TEST_CHECK(cmp_info.v0 == 5 && cmp_info.v1 == 3);
     TEST_CHECK(cmp_info.pc == 0x1008);
     TEST_CHECK(cmp_info.size == 32);
+    OK(uc_close(uc));
 }
 
 static void test_arm_thumb_tcg_opcode_cmn(void)
@@ -931,6 +932,7 @@ static void test_arm_thumb_tcg_opcode_cmn(void)
     TEST_CHECK(cmp_info.v0 == 5 && cmp_info.v1 == 3);
     TEST_CHECK(cmp_info.pc == 0x1006);
     TEST_CHECK(cmp_info.size == 32);
+    OK(uc_close(uc));
 }
 
 static void test_arm_cp15_c1_c0_2(void)

--- a/tests/unit/test_arm64.c
+++ b/tests/unit/test_arm64.c
@@ -481,6 +481,7 @@ static void test_arm64_mmu(void)
     TEST_CHECK(x1 == 0x4444444444444444);
     TEST_CHECK(x2 == 0x4444444444444444);
     free(data);
+    OK(uc_close(uc));
 }
 
 static void test_arm64_pc_wrap(void)

--- a/tests/unit/test_riscv.c
+++ b/tests/unit/test_riscv.c
@@ -718,6 +718,7 @@ static void test_riscv_mmu(void)
     OK(uc_mem_read(uc, data_address, &data_result, sizeof(data_result)));
 
     TEST_CHECK(data_value == data_result);
+    OK(uc_close(uc));
 }
 
 static void test_riscv_priv(void)

--- a/tests/unit/test_x86.c
+++ b/tests/unit/test_x86.c
@@ -632,7 +632,7 @@ static void test_x86_smc_add(void)
 {
     uc_engine *uc;
     uint64_t stack_base = 0x20000;
-    int r_rsp;
+    uint64_t r_rsp;
     /*
      * mov qword ptr [rip+0x10], rax
      * mov word ptr [rip], 0x0548
@@ -647,6 +647,8 @@ static void test_x86_smc_add(void)
     r_rsp = stack_base + 0x1800;
     OK(uc_reg_write(uc, UC_X86_REG_RSP, &r_rsp));
     OK(uc_emu_start(uc, code_start, -1, 0, 0));
+
+    OK(uc_close(uc));
 }
 
 static void test_x86_smc_mem_hook_callback(uc_engine *uc, uc_mem_type t,
@@ -667,7 +669,7 @@ static void test_x86_smc_mem_hook(void)
     uc_engine *uc;
     uc_hook hook;
     uint64_t stack_base = 0x20000;
-    int r_rsp;
+    uint64_t r_rsp;
     unsigned int i = 0;
     /*
      * mov qword ptr [rip+0x29], rax
@@ -689,6 +691,8 @@ static void test_x86_smc_mem_hook(void)
     r_rsp = stack_base + 0x1800;
     OK(uc_reg_write(uc, UC_X86_REG_RSP, &r_rsp));
     OK(uc_emu_start(uc, code_start, -1, 0, 0));
+
+    OK(uc_close(uc));
 }
 
 static uint64_t test_x86_mmio_uc_mem_rw_read_callback(uc_engine *uc,

--- a/tests/unit/test_x86.c
+++ b/tests/unit/test_x86.c
@@ -1589,6 +1589,8 @@ static void test_x86_mmu(void)
     OK(uc_mem_read(uc, 0x2000, &child, sizeof(child)));
     TEST_CHECK(parrent == 60);
     TEST_CHECK(child == 42);
+    OK(uc_context_free(context));
+    OK(uc_close(uc));
 }
 
 static bool test_x86_vtlb_callback(uc_engine *uc, uint64_t addr,
@@ -1632,6 +1634,7 @@ static void test_x86_segmentation(void)
     OK(uc_open(UC_ARCH_X86, UC_MODE_64, &uc));
     OK(uc_reg_write(uc, UC_X86_REG_GDTR, &gdtr));
     uc_assert_err(UC_ERR_EXCEPTION, uc_reg_write(uc, UC_X86_REG_FS, &fs));
+    OK(uc_close(uc));
 }
 
 static void test_x86_0xff_lcall_callback(uc_engine *uc, uint64_t address,

--- a/uc.c
+++ b/uc.c
@@ -2439,6 +2439,10 @@ uc_err uc_context_restore(uc_engine *uc, uc_context *context)
 
     if (uc->context_content & UC_CTL_CONTEXT_MEMORY) {
         uc->snapshot_level = context->snapshot_level;
+        if (!uc->flatview_copy(uc, uc->address_space_memory.current_map,
+                               context->fv, true)) {
+            return UC_ERR_NOMEM;
+        }
         ret = uc_restore_latest_snapshot(uc);
         if (ret != UC_ERR_OK) {
             restore_jit_state(uc);
@@ -2447,10 +2451,6 @@ uc_err uc_context_restore(uc_engine *uc, uc_context *context)
         uc_snapshot(uc);
         uc->ram_list.freed = context->ramblock_freed;
         uc->ram_list.last_block = context->last_block;
-        if (!uc->flatview_copy(uc, uc->address_space_memory.current_map,
-                               context->fv, true)) {
-            return UC_ERR_NOMEM;
-        }
         uc->tcg_flush_tlb(uc);
     }
 


### PR DESCRIPTION
Fixes use after free on snapshots restore.

Also some cleanup in the unit tests. Mostly forgot to call `uc_close`.

The sanitizer also finds some stack overflow in `test_x86_smc_add` and `test_x86_smc_mem_hook`. I'm currently don't understand the error.

In `test_context_snapshot` of `test_mem` there is an Memory leak which I'm currently debug.