### PR TITLE
Fix physical address truncation on 32-bit systems with addressing extensions

### DIFF
--- a/qemu/accel/tcg/cputlb.c
+++ b/qemu/accel/tcg/cputlb.c
@@ -1469,7 +1469,7 @@ load_helper(CPUArchState *env, target_ulong addr, TCGMemOpIdx oi,
     uintptr_t index = tlb_index(env, mmu_idx, addr);
     CPUTLBEntry *entry = tlb_entry(env, mmu_idx, addr);
     target_ulong tlb_addr = code_read ? entry->addr_code : entry->addr_read;
-    target_ulong paddr;
+    hwaddr paddr;
     const size_t tlb_off = code_read ?
         offsetof(CPUTLBEntry, addr_code) : offsetof(CPUTLBEntry, addr_read);
     const MMUAccessType access_type =
@@ -2090,7 +2090,7 @@ store_helper(CPUArchState *env, target_ulong addr, uint64_t val,
     uintptr_t index = tlb_index(env, mmu_idx, addr);
     CPUTLBEntry *entry = tlb_entry(env, mmu_idx, addr);
     target_ulong tlb_addr = tlb_addr_write(entry);
-    target_ulong paddr;
+    hwaddr paddr;
     const size_t tlb_off = offsetof(CPUTLBEntry, addr_write);
     unsigned a_bits = get_alignment_bits(get_memop(oi));
     void *haddr;

--- a/qemu/include/exec/cpu-defs.h
+++ b/qemu/include/exec/cpu-defs.h
@@ -112,7 +112,7 @@ typedef struct CPUTLBEntry {
             target_ulong addr_read;
             target_ulong addr_write;
             target_ulong addr_code;
-            target_ulong paddr;
+            hwaddr paddr;
             /* Addend to virtual address to get host address.  IO accesses
                use the corresponding iotlb value.  */
             uintptr_t addend;

--- a/qemu/include/exec/exec-all.h
+++ b/qemu/include/exec/exec-all.h
@@ -477,7 +477,7 @@ address_space_translate_for_iotlb(CPUState *cpu, int asidx, hwaddr addr,
 hwaddr memory_region_section_get_iotlb(CPUState *cpu,
                                        MemoryRegionSection *section);
 
-static inline bool uc_mem_hook_installed(struct uc_struct *uc, target_ulong paddr)
+static inline bool uc_mem_hook_installed(struct uc_struct *uc, hwaddr paddr)
 {
     if (HOOK_EXISTS_BOUNDED(uc, UC_HOOK_MEM_FETCH_UNMAPPED, paddr))
         return true;


### PR DESCRIPTION
While experimenting with Unicorn to emulate an ARMv7 system that heavily utilizes LPAE, I noticed Unicorn would translate the virtual addresses properly. However, the address got truncated to 32-bits somewhere in the pipeline, which rendered my emulator inoperable.

I tracked down the problem to a couple of types in the `CPUTLBEntry` struct and surrounding functions. I've changed them from `target_ulong` to `hwaddr` (hopefully I didn't miss any).

This change seems to work for my setup, I haven't tried other architectures (such as x86 with PAE) but if my understanding of the code is correct, the change should be architecture-angostic.

When running `cargo test`, all tests seem to pass. However, I have not added new ones for this scenario.