### PR TITLE
refactor(lib): mark pointers as const where possible

### DIFF
--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -848,7 +848,7 @@ uc_err uc_reg_read2(uc_engine *uc, int regid, void *value, size_t *size);
  invalid
 */
 UNICORN_EXPORT
-uc_err uc_reg_write_batch(uc_engine *uc, int *regs, void *const *vals,
+uc_err uc_reg_write_batch(uc_engine *uc, int const *regs, void *const *vals,
                           int count);
 
 /*
@@ -863,7 +863,8 @@ uc_err uc_reg_write_batch(uc_engine *uc, int *regs, void *const *vals,
  invalid
 */
 UNICORN_EXPORT
-uc_err uc_reg_read_batch(uc_engine *uc, int *regs, void **vals, int count);
+uc_err uc_reg_read_batch(uc_engine *uc, int const *regs, void **vals,
+                         int count);
 
 /*
  Write multiple register values.
@@ -879,8 +880,8 @@ uc_err uc_reg_read_batch(uc_engine *uc, int *regs, void **vals, int count);
  corresponding register.
 */
 UNICORN_EXPORT
-uc_err uc_reg_write_batch2(uc_engine *uc, int *regs, const void *const *vals,
-                           size_t *sizes, int count);
+uc_err uc_reg_write_batch2(uc_engine *uc, int const *regs,
+                           const void *const *vals, size_t *sizes, int count);
 
 /*
  Read multiple register values.
@@ -897,7 +898,7 @@ uc_err uc_reg_write_batch2(uc_engine *uc, int *regs, const void *const *vals,
  corresponding register.
 */
 UNICORN_EXPORT
-uc_err uc_reg_read_batch2(uc_engine *uc, int *regs, void *const *vals,
+uc_err uc_reg_read_batch2(uc_engine *uc, int const *regs, void *const *vals,
                           size_t *sizes, int count);
 
 /*
@@ -1278,8 +1279,8 @@ uc_err uc_context_reg_read2(uc_context *ctx, int regid, void *value,
    for detailed error).
 */
 UNICORN_EXPORT
-uc_err uc_context_reg_write_batch(uc_context *ctx, int *regs, void *const *vals,
-                                  int count);
+uc_err uc_context_reg_write_batch(uc_context *ctx, int const *regs,
+                                  void *const *vals, int count);
 
 /*
  Read multiple register values from a context.
@@ -1293,7 +1294,7 @@ uc_err uc_context_reg_write_batch(uc_context *ctx, int *regs, void *const *vals,
    for detailed error).
 */
 UNICORN_EXPORT
-uc_err uc_context_reg_read_batch(uc_context *ctx, int *regs, void **vals,
+uc_err uc_context_reg_read_batch(uc_context *ctx, int const *regs, void **vals,
                                  int count);
 
 /*
@@ -1310,7 +1311,7 @@ uc_err uc_context_reg_read_batch(uc_context *ctx, int *regs, void **vals,
  corresponding register.
 */
 UNICORN_EXPORT
-uc_err uc_context_reg_write_batch2(uc_context *ctx, int *regs,
+uc_err uc_context_reg_write_batch2(uc_context *ctx, int const *regs,
                                    const void *const *vals, size_t *sizes,
                                    int count);
 
@@ -1329,8 +1330,8 @@ uc_err uc_context_reg_write_batch2(uc_context *ctx, int *regs,
  corresponding register.
 */
 UNICORN_EXPORT
-uc_err uc_context_reg_read_batch2(uc_context *ctx, int *regs, void *const *vals,
-                                  size_t *sizes, int count);
+uc_err uc_context_reg_read_batch2(uc_context *ctx, int const *regs,
+                                  void *const *vals, size_t *sizes, int count);
 
 /*
  Restore the current CPU context from a saved copy.

--- a/uc.c
+++ b/uc.c
@@ -572,7 +572,7 @@ uc_err uc_close(uc_engine *uc)
 }
 
 UNICORN_EXPORT
-uc_err uc_reg_read_batch(uc_engine *uc, int *regs, void **vals, int count)
+uc_err uc_reg_read_batch(uc_engine *uc, int const *regs, void **vals, int count)
 {
     UC_INIT(uc);
     reg_read_t reg_read = uc->reg_read;
@@ -596,7 +596,7 @@ uc_err uc_reg_read_batch(uc_engine *uc, int *regs, void **vals, int count)
 }
 
 UNICORN_EXPORT
-uc_err uc_reg_write_batch(uc_engine *uc, int *regs, void *const *vals,
+uc_err uc_reg_write_batch(uc_engine *uc, int const *regs, void *const *vals,
                           int count)
 {
     UC_INIT(uc);
@@ -627,7 +627,7 @@ uc_err uc_reg_write_batch(uc_engine *uc, int *regs, void *const *vals,
 }
 
 UNICORN_EXPORT
-uc_err uc_reg_read_batch2(uc_engine *uc, int *regs, void *const *vals,
+uc_err uc_reg_read_batch2(uc_engine *uc, int const *regs, void *const *vals,
                           size_t *sizes, int count)
 {
     UC_INIT(uc);
@@ -651,8 +651,8 @@ uc_err uc_reg_read_batch2(uc_engine *uc, int *regs, void *const *vals,
 }
 
 UNICORN_EXPORT
-uc_err uc_reg_write_batch2(uc_engine *uc, int *regs, const void *const *vals,
-                           size_t *sizes, int count)
+uc_err uc_reg_write_batch2(uc_engine *uc, int const *regs,
+                           const void *const *vals, size_t *sizes, int count)
 {
     UC_INIT(uc);
     reg_write_t reg_write = uc->reg_write;
@@ -2344,8 +2344,8 @@ uc_err uc_context_reg_read2(uc_context *ctx, int regid, void *value,
 }
 
 UNICORN_EXPORT
-uc_err uc_context_reg_write_batch(uc_context *ctx, int *regs, void *const *vals,
-                                  int count)
+uc_err uc_context_reg_write_batch(uc_context *ctx, int const *regs,
+                                  void *const *vals, int count)
 {
     reg_write_t reg_write = find_context_reg_rw(ctx->arch, ctx->mode).write;
     void *env = ctx->data;
@@ -2367,7 +2367,7 @@ uc_err uc_context_reg_write_batch(uc_context *ctx, int *regs, void *const *vals,
 }
 
 UNICORN_EXPORT
-uc_err uc_context_reg_read_batch(uc_context *ctx, int *regs, void **vals,
+uc_err uc_context_reg_read_batch(uc_context *ctx, int const *regs, void **vals,
                                  int count)
 {
     reg_read_t reg_read = find_context_reg_rw(ctx->arch, ctx->mode).read;
@@ -2389,7 +2389,7 @@ uc_err uc_context_reg_read_batch(uc_context *ctx, int *regs, void **vals,
 }
 
 UNICORN_EXPORT
-uc_err uc_context_reg_write_batch2(uc_context *ctx, int *regs,
+uc_err uc_context_reg_write_batch2(uc_context *ctx, int const *regs,
                                    const void *const *vals, size_t *sizes,
                                    int count)
 {
@@ -2412,8 +2412,8 @@ uc_err uc_context_reg_write_batch2(uc_context *ctx, int *regs,
 }
 
 UNICORN_EXPORT
-uc_err uc_context_reg_read_batch2(uc_context *ctx, int *regs, void *const *vals,
-                                  size_t *sizes, int count)
+uc_err uc_context_reg_read_batch2(uc_context *ctx, int const *regs,
+                                  void *const *vals, size_t *sizes, int count)
 {
     reg_read_t reg_read = find_context_reg_rw(ctx->arch, ctx->mode).read;
     void *env = ctx->data;


### PR DESCRIPTION
This PR just marks some parameters that are pointers as const pointers - I noticed that clang-tidy was warning me that these could be marked as const, and it makes sense to me.