### PR TITLE
bindings: ruby: fix version identifier to 2.1.3

### DIFF
--- a/bindings/ruby/Makefile
+++ b/bindings/ruby/Makefile
@@ -5,7 +5,7 @@
 # Use bundle install && rake to install gem and test
 install: gen_const
 	cd unicorn_gem && rake build
-	cd unicorn_gem && gem install --local pkg/unicorn-engine-2.1.1.gem
+	cd unicorn_gem && gem install --local pkg/unicorn-engine-2.1.3.gem
 
 gen_const:
 	cd .. && python3 const_generator.py ruby

--- a/bindings/ruby/unicorn_gem/lib/unicorn_engine/version.rb
+++ b/bindings/ruby/unicorn_gem/lib/unicorn_engine/version.rb
@@ -1,3 +1,3 @@
 module Unicorn
-  VERSION = "2.1.1"
+  VERSION = "2.1.3"
 end


### PR DESCRIPTION
It seems when bumping 2.1.2 and 2.1.3 some places have been forgotten. This actually results in a 2.1.1 gem file when building distro packages as a result.