### PR TITLE
[ARM32] do not clear CPSR.E when updating flags

### DIFF
--- a/qemu/target/arm/internals.h
+++ b/qemu/target/arm/internals.h
@@ -1125,7 +1125,7 @@ static inline uint32_t aarch32_cpsr_valid_mask(uint64_t features,
         valid |= CPSR_Q; /* V5TE in reality*/
     }
     if ((features >> ARM_FEATURE_V6) & 1) {
-        valid |= CPSR_E | CPSR_GE;
+        valid |= CPSR_GE;
     }
     if ((features >> ARM_FEATURE_THUMB2) & 1) {
         valid |= CPSR_IT;

--- a/tests/unit/test_arm.c
+++ b/tests/unit/test_arm.c
@@ -960,29 +960,29 @@ static void test_arm_be_flags(void)
 {
     uc_engine *uc;
     /*
-  subs pc, lr, #4 //<------ mind the 's' == update flags
-	nop
-	nop
-	nop
-	*/
-	const uint8_t code[] = { 0xe2, 0x5e, 0xf0, 0x04, 0xe3, 0x20, 0xf0, 0x00, 0xe3, 0x20, 0xf0, 0x00, 0x20, 0xf0, 0x00 };
+    subs pc, lr, #4 //<------ mind the 's' == update flags
+    nop
+    nop
+    nop
+    */
+    const uint8_t code[] = { 0xe2, 0x5e, 0xf0, 0x04, 0xe3, 0x20, 0xf0, 0x00, 0xe3, 0x20, 0xf0, 0x00, 0x20, 0xf0, 0x00 };
     uint32_t reg;
 
     // Initialize emulator in ARM BE mode
     OK(uc_open(UC_ARCH_ARM, UC_MODE_ARM|UC_MODE_BIG_ENDIAN, &uc));
-	OK(uc_mem_map(uc, code_start, 4096, UC_PROT_ALL));
-	OK(uc_mem_write(uc, code_start, code, sizeof(code)));
-	
-	// Set LR
+    OK(uc_mem_map(uc, code_start, 4096, UC_PROT_ALL));
+    OK(uc_mem_write(uc, code_start, code, sizeof(code)));
+
+    // Set LR
     reg = code_start + 0x0c;
     OK(uc_reg_write(uc, UC_ARM_REG_LR, &reg));
 
-	// Run
-	OK(uc_emu_start(uc, code_start, code_start + sizeof(code), 0, 3));
+    // Run
+    OK(uc_emu_start(uc, code_start, code_start + sizeof(code), 0, 3));
 
-	// Check CPSR.E, should be set
-	OK(uc_reg_read(uc, UC_ARM_REG_CPSR, &reg));
-	TEST_CHECK((!!(reg&(1<<9)))==1);
+    // Check CPSR.E, should be set
+    OK(uc_reg_read(uc, UC_ARM_REG_CPSR, &reg));
+    TEST_CHECK((!!(reg&(1<<9)))==1);
 
     OK(uc_close(uc));
 }


### PR DESCRIPTION
Should fix #2157 . Please run all CI tests before merging. A unit test has been added for this.