### PR TITLE
fix(ppc): avoid using static TCG variables

### DIFF
--- a/qemu/include/tcg/tcg.h
+++ b/qemu/include/tcg/tcg.h
@@ -720,7 +720,7 @@ struct TCGContext {
     void *tb_ret_addr;
 
     /* target/riscv/translate.c */
-    TCGv cpu_gpr[32], cpu_pc; // also target/mips/translate.c
+    TCGv cpu_gpr[32], cpu_pc; // also target/mips/translate.c, target/ppc/translate.c
     TCGv_i64 cpu_fpr[32]; /* assume F and D extensions */
     TCGv load_res;
     TCGv load_val;
@@ -803,6 +803,22 @@ struct TCGContext {
     // Used to store the start of current instrution.
     uint64_t pc_start;
 
+    // target/ppc/translate.c
+    TCGv cpu_gprh[32];
+    TCGv_i32 cpu_crf[8];
+    TCGv cpu_nip;
+    TCGv cpu_msr;
+    TCGv cpu_ctr;
+    TCGv cpu_lr;
+#if defined(TARGET_PPC64)
+    TCGv cpu_cfar;
+#endif
+    TCGv cpu_xer, cpu_so, cpu_ov, cpu_ca, cpu_ov32, cpu_ca32;
+    TCGv cpu_reserve;
+    TCGv cpu_reserve_val;
+    TCGv cpu_fpscr;
+    TCGv_i32 cpu_access_type;
+
     // target/s390x/translate.c
     TCGv_i64 psw_addr;
     TCGv_i64 psw_mask;
@@ -813,6 +829,9 @@ struct TCGContext {
     TCGv_i64 cc_dst;
     TCGv_i64 cc_vr;
 
+    char ppc_cpu_reg_names[10 * 3 + 22 * 4   /* GPR */
+                           + 10 * 4 + 22 * 5 /* SPE GPRh */
+                           + 8 * 5           /* CRF */];
     char s390x_cpu_reg_names[16][4]; // renamed from original cpu_reg_names[][] to avoid name clash with m68k
     TCGv_i64 regs[16];
 };

--- a/qemu/target/ppc/helper_regs.h
+++ b/qemu/target/ppc/helper_regs.h
@@ -90,8 +90,9 @@ static inline void hreg_compute_hflags(CPUPPCState *env)
 
     /* We 'forget' FE0 & FE1: we'll never generate imprecise exceptions */
     hflags_mask = (1 << MSR_VR) | (1 << MSR_AP) | (1 << MSR_SA) |
-        (1 << MSR_PR) | (1 << MSR_FP) | (1 << MSR_SE) | (1 << MSR_BE) |
-        (1 << MSR_LE) | (1 << MSR_VSX) | (1 << MSR_IR) | (1 << MSR_DR);
+                  (1 << MSR_PR) | (1 << MSR_FP) | (1 << MSR_SE) |
+                  (1 << MSR_BE) | (1 << MSR_LE) | (1 << MSR_VSX) |
+                  (1 << MSR_IR) | (1 << MSR_DR);
     hflags_mask |= (1ULL << MSR_CM) | (1ULL << MSR_SF) | MSR_HVB;
     hreg_compute_mem_idx(env);
     env->hflags = env->msr & hflags_mask;

--- a/qemu/target/ppc/translate/dfp-impl.inc.c
+++ b/qemu/target/ppc/translate/dfp-impl.inc.c
@@ -41,7 +41,7 @@ static void gen_##name(DisasContext *ctx)         \
     gen_update_nip(ctx, ctx->base.pc_next - 4);            \
     ra = gen_fprp_ptr(tcg_ctx, rA(ctx->opcode));           \
     rb = gen_fprp_ptr(tcg_ctx, rB(ctx->opcode));           \
-    gen_helper_##name(tcg_ctx, cpu_crf[crfD(ctx->opcode)], \
+    gen_helper_##name(tcg_ctx, tcg_ctx->cpu_crf[crfD(ctx->opcode)], \
                       tcg_ctx->cpu_env, ra, rb);           \
     tcg_temp_free_ptr(tcg_ctx, ra);                        \
     tcg_temp_free_ptr(tcg_ctx, rb);                        \
@@ -60,7 +60,7 @@ static void gen_##name(DisasContext *ctx)         \
     gen_update_nip(ctx, ctx->base.pc_next - 4);            \
     uim = tcg_const_i32(tcg_ctx, UIMM5(ctx->opcode));      \
     rb = gen_fprp_ptr(tcg_ctx, rB(ctx->opcode));           \
-    gen_helper_##name(tcg_ctx, cpu_crf[crfD(ctx->opcode)], \
+    gen_helper_##name(tcg_ctx, tcg_ctx->cpu_crf[crfD(ctx->opcode)], \
                       tcg_ctx->cpu_env, uim, rb);          \
     tcg_temp_free_i32(tcg_ctx, uim);                       \
     tcg_temp_free_ptr(tcg_ctx, rb);                        \
@@ -79,7 +79,7 @@ static void gen_##name(DisasContext *ctx)         \
     gen_update_nip(ctx, ctx->base.pc_next - 4);   \
     ra = gen_fprp_ptr(tcg_ctx, rA(ctx->opcode));           \
     dcm = tcg_const_i32(tcg_ctx, DCM(ctx->opcode));        \
-    gen_helper_##name(tcg_ctx, cpu_crf[crfD(ctx->opcode)], \
+    gen_helper_##name(tcg_ctx, tcg_ctx->cpu_crf[crfD(ctx->opcode)], \
                       tcg_ctx->cpu_env, ra, dcm);          \
     tcg_temp_free_ptr(tcg_ctx, ra);                        \
     tcg_temp_free_i32(tcg_ctx, dcm);                       \

--- a/qemu/target/ppc/translate/spe-impl.inc.c
+++ b/qemu/target/ppc/translate/spe-impl.inc.c
@@ -19,26 +19,26 @@ static inline void gen_evmra(DisasContext *ctx)
     TCGv_i64 tmp = tcg_temp_new_i64(tcg_ctx);
 
     /* tmp := rA_lo + rA_hi << 32 */
-    tcg_gen_concat_tl_i64(tcg_ctx, tmp, cpu_gpr[rA(ctx->opcode)],
-                          cpu_gprh[rA(ctx->opcode)]);
+    tcg_gen_concat_tl_i64(tcg_ctx, tmp, tcg_ctx->cpu_gpr[rA(ctx->opcode)],
+                          tcg_ctx->cpu_gprh[rA(ctx->opcode)]);
 
     /* spe_acc := tmp */
     tcg_gen_st_i64(tcg_ctx, tmp, tcg_ctx->cpu_env, offsetof(CPUPPCState, spe_acc));
     tcg_temp_free_i64(tcg_ctx, tmp);
 
     /* rD := rA */
-    tcg_gen_mov_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gpr[rA(ctx->opcode)]);
-    tcg_gen_mov_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], cpu_gprh[rA(ctx->opcode)]);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gpr[rA(ctx->opcode)]);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], tcg_ctx->cpu_gprh[rA(ctx->opcode)]);
 }
 
 static inline void gen_load_gpr64(TCGContext *tcg_ctx, TCGv_i64 t, int reg)
 {
-    tcg_gen_concat_tl_i64(tcg_ctx, t, cpu_gpr[reg], cpu_gprh[reg]);
+    tcg_gen_concat_tl_i64(tcg_ctx, t, tcg_ctx->cpu_gpr[reg], tcg_ctx->cpu_gprh[reg]);
 }
 
 static inline void gen_store_gpr64(TCGContext *tcg_ctx, int reg, TCGv_i64 t)
 {
-    tcg_gen_extr_i64_tl(tcg_ctx, cpu_gpr[reg], cpu_gprh[reg], t);
+    tcg_gen_extr_i64_tl(tcg_ctx, tcg_ctx->cpu_gpr[reg], tcg_ctx->cpu_gprh[reg], t);
 }
 
 #define GEN_SPE(name0, name1, opc2, opc3, inval0, inval1, type)         \
@@ -65,10 +65,10 @@ static inline void gen_##name(DisasContext *ctx)                              \
         gen_exception(ctx, POWERPC_EXCP_SPEU);                                \
         return;                                                               \
     }                                                                         \
-    tcg_op(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gpr[rA(ctx->opcode)],                \
-           cpu_gpr[rB(ctx->opcode)]);                                         \
-    tcg_op(tcg_ctx, cpu_gprh[rD(ctx->opcode)], cpu_gprh[rA(ctx->opcode)],              \
-           cpu_gprh[rB(ctx->opcode)]);                                        \
+    tcg_op(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gpr[rA(ctx->opcode)],                \
+           tcg_ctx->cpu_gpr[rB(ctx->opcode)]);                                         \
+    tcg_op(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], tcg_ctx->cpu_gprh[rA(ctx->opcode)],              \
+           tcg_ctx->cpu_gprh[rB(ctx->opcode)]);                                        \
 }
 
 GEN_SPEOP_LOGIC2(evand, tcg_gen_and_tl);
@@ -92,13 +92,13 @@ static inline void gen_##name(DisasContext *ctx)                              \
     }                                                                         \
     t0 = tcg_temp_new_i32(tcg_ctx);                                                  \
                                                                               \
-    tcg_gen_trunc_tl_i32(tcg_ctx, t0, cpu_gpr[rA(ctx->opcode)]);                       \
+    tcg_gen_trunc_tl_i32(tcg_ctx, t0, tcg_ctx->cpu_gpr[rA(ctx->opcode)]);                       \
     tcg_opi(tcg_ctx, t0, t0, rB(ctx->opcode));                                         \
-    tcg_gen_extu_i32_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], t0);                        \
+    tcg_gen_extu_i32_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], t0);                        \
                                                                               \
-    tcg_gen_trunc_tl_i32(tcg_ctx, t0, cpu_gprh[rA(ctx->opcode)]);                      \
+    tcg_gen_trunc_tl_i32(tcg_ctx, t0, tcg_ctx->cpu_gprh[rA(ctx->opcode)]);                      \
     tcg_opi(tcg_ctx, t0, t0, rB(ctx->opcode));                                         \
-    tcg_gen_extu_i32_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], t0);                       \
+    tcg_gen_extu_i32_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], t0);                       \
                                                                               \
     tcg_temp_free_i32(tcg_ctx, t0);                                                    \
 }
@@ -119,13 +119,13 @@ static inline void gen_##name(DisasContext *ctx)                              \
     }                                                                         \
     t0 = tcg_temp_new_i32(tcg_ctx);                                                  \
                                                                               \
-    tcg_gen_trunc_tl_i32(tcg_ctx, t0, cpu_gpr[rA(ctx->opcode)]);                       \
+    tcg_gen_trunc_tl_i32(tcg_ctx, t0, tcg_ctx->cpu_gpr[rA(ctx->opcode)]);                       \
     tcg_op(tcg_ctx, t0, t0);                                                           \
-    tcg_gen_extu_i32_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], t0);                        \
+    tcg_gen_extu_i32_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], t0);                        \
                                                                               \
-    tcg_gen_trunc_tl_i32(tcg_ctx, t0, cpu_gprh[rA(ctx->opcode)]);                      \
+    tcg_gen_trunc_tl_i32(tcg_ctx, t0, tcg_ctx->cpu_gprh[rA(ctx->opcode)]);                      \
     tcg_op(tcg_ctx, t0, t0);                                                           \
-    tcg_gen_extu_i32_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], t0);                       \
+    tcg_gen_extu_i32_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], t0);                       \
                                                                               \
     tcg_temp_free_i32(tcg_ctx, t0);                                                    \
 }
@@ -155,15 +155,15 @@ static inline void gen_##name(DisasContext *ctx)                              \
     t0 = tcg_temp_new_i32(tcg_ctx);                                                  \
     t1 = tcg_temp_new_i32(tcg_ctx);                                                  \
                                                                               \
-    tcg_gen_trunc_tl_i32(tcg_ctx, t0, cpu_gpr[rA(ctx->opcode)]);                       \
-    tcg_gen_trunc_tl_i32(tcg_ctx, t1, cpu_gpr[rB(ctx->opcode)]);                       \
+    tcg_gen_trunc_tl_i32(tcg_ctx, t0, tcg_ctx->cpu_gpr[rA(ctx->opcode)]);                       \
+    tcg_gen_trunc_tl_i32(tcg_ctx, t1, tcg_ctx->cpu_gpr[rB(ctx->opcode)]);                       \
     tcg_op(tcg_ctx, t0, t0, t1);                                                       \
-    tcg_gen_extu_i32_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], t0);                        \
+    tcg_gen_extu_i32_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], t0);                        \
                                                                               \
-    tcg_gen_trunc_tl_i32(tcg_ctx, t0, cpu_gprh[rA(ctx->opcode)]);                      \
-    tcg_gen_trunc_tl_i32(tcg_ctx, t1, cpu_gprh[rB(ctx->opcode)]);                      \
+    tcg_gen_trunc_tl_i32(tcg_ctx, t0, tcg_ctx->cpu_gprh[rA(ctx->opcode)]);                      \
+    tcg_gen_trunc_tl_i32(tcg_ctx, t1, tcg_ctx->cpu_gprh[rB(ctx->opcode)]);                      \
     tcg_op(tcg_ctx, t0, t0, t1);                                                       \
-    tcg_gen_extu_i32_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], t0);                       \
+    tcg_gen_extu_i32_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], t0);                       \
                                                                               \
     tcg_temp_free_i32(tcg_ctx, t0);                                                    \
     tcg_temp_free_i32(tcg_ctx, t1);                                                    \
@@ -235,8 +235,8 @@ static inline void gen_evmergehi(DisasContext *ctx)
         gen_exception(ctx, POWERPC_EXCP_SPEU);
         return;
     }
-    tcg_gen_mov_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gprh[rB(ctx->opcode)]);
-    tcg_gen_mov_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], cpu_gprh[rA(ctx->opcode)]);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gprh[rB(ctx->opcode)]);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], tcg_ctx->cpu_gprh[rA(ctx->opcode)]);
 }
 GEN_SPEOP_ARITH2(evaddw, tcg_gen_add_i32);
 static inline void gen_op_evsubf(TCGContext *tcg_ctx, TCGv_i32 ret, TCGv_i32 arg1, TCGv_i32 arg2)
@@ -257,13 +257,13 @@ static inline void gen_##name(DisasContext *ctx)                              \
     }                                                                         \
     t0 = tcg_temp_new_i32(tcg_ctx);                                                  \
                                                                               \
-    tcg_gen_trunc_tl_i32(tcg_ctx, t0, cpu_gpr[rB(ctx->opcode)]);                       \
+    tcg_gen_trunc_tl_i32(tcg_ctx, t0, tcg_ctx->cpu_gpr[rB(ctx->opcode)]);                       \
     tcg_op(tcg_ctx, t0, t0, rA(ctx->opcode));                                          \
-    tcg_gen_extu_i32_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], t0);                        \
+    tcg_gen_extu_i32_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], t0);                        \
                                                                               \
-    tcg_gen_trunc_tl_i32(tcg_ctx, t0, cpu_gprh[rB(ctx->opcode)]);                      \
+    tcg_gen_trunc_tl_i32(tcg_ctx, t0, tcg_ctx->cpu_gprh[rB(ctx->opcode)]);                      \
     tcg_op(tcg_ctx, t0, t0, rA(ctx->opcode));                                          \
-    tcg_gen_extu_i32_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], t0);                       \
+    tcg_gen_extu_i32_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], t0);                       \
                                                                               \
     tcg_temp_free_i32(tcg_ctx, t0);                                                    \
 }
@@ -284,26 +284,26 @@ static inline void gen_##name(DisasContext *ctx)                              \
     TCGLabel *l3 = gen_new_label(tcg_ctx);                                           \
     TCGLabel *l4 = gen_new_label(tcg_ctx);                                           \
                                                                               \
-    tcg_gen_ext32s_tl(tcg_ctx, cpu_gpr[rA(ctx->opcode)], cpu_gpr[rA(ctx->opcode)]);    \
-    tcg_gen_ext32s_tl(tcg_ctx, cpu_gpr[rB(ctx->opcode)], cpu_gpr[rB(ctx->opcode)]);    \
-    tcg_gen_ext32s_tl(tcg_ctx, cpu_gprh[rA(ctx->opcode)], cpu_gprh[rA(ctx->opcode)]);  \
-    tcg_gen_ext32s_tl(tcg_ctx, cpu_gprh[rB(ctx->opcode)], cpu_gprh[rB(ctx->opcode)]);  \
+    tcg_gen_ext32s_tl(tcg_ctx, tcg_ctx->cpu_gpr[rA(ctx->opcode)], tcg_ctx->cpu_gpr[rA(ctx->opcode)]);    \
+    tcg_gen_ext32s_tl(tcg_ctx, tcg_ctx->cpu_gpr[rB(ctx->opcode)], tcg_ctx->cpu_gpr[rB(ctx->opcode)]);    \
+    tcg_gen_ext32s_tl(tcg_ctx, tcg_ctx->cpu_gprh[rA(ctx->opcode)], tcg_ctx->cpu_gprh[rA(ctx->opcode)]);  \
+    tcg_gen_ext32s_tl(tcg_ctx, tcg_ctx->cpu_gprh[rB(ctx->opcode)], tcg_ctx->cpu_gprh[rB(ctx->opcode)]);  \
                                                                               \
-    tcg_gen_brcond_tl(tcg_ctx, tcg_cond, cpu_gpr[rA(ctx->opcode)],                     \
-                       cpu_gpr[rB(ctx->opcode)], l1);                         \
-    tcg_gen_movi_i32(tcg_ctx, cpu_crf[crfD(ctx->opcode)], 0);                          \
+    tcg_gen_brcond_tl(tcg_ctx, tcg_cond, tcg_ctx->cpu_gpr[rA(ctx->opcode)],                     \
+                       tcg_ctx->cpu_gpr[rB(ctx->opcode)], l1);                         \
+    tcg_gen_movi_i32(tcg_ctx, tcg_ctx->cpu_crf[crfD(ctx->opcode)], 0);                          \
     tcg_gen_br(tcg_ctx, l2);                                                           \
     gen_set_label(tcg_ctx, l1);                                                        \
-    tcg_gen_movi_i32(tcg_ctx, cpu_crf[crfD(ctx->opcode)],                              \
+    tcg_gen_movi_i32(tcg_ctx, tcg_ctx->cpu_crf[crfD(ctx->opcode)],                              \
                      CRF_CL | CRF_CH_OR_CL | CRF_CH_AND_CL);                  \
     gen_set_label(tcg_ctx, l2);                                                        \
-    tcg_gen_brcond_tl(tcg_ctx, tcg_cond, cpu_gprh[rA(ctx->opcode)],                    \
-                       cpu_gprh[rB(ctx->opcode)], l3);                        \
-    tcg_gen_andi_i32(tcg_ctx, cpu_crf[crfD(ctx->opcode)], cpu_crf[crfD(ctx->opcode)],  \
+    tcg_gen_brcond_tl(tcg_ctx, tcg_cond, tcg_ctx->cpu_gprh[rA(ctx->opcode)],                    \
+                       tcg_ctx->cpu_gprh[rB(ctx->opcode)], l3);                        \
+    tcg_gen_andi_i32(tcg_ctx, tcg_ctx->cpu_crf[crfD(ctx->opcode)], tcg_ctx->cpu_crf[crfD(ctx->opcode)],  \
                      ~(CRF_CH | CRF_CH_AND_CL));                              \
     tcg_gen_br(tcg_ctx, l4);                                                           \
     gen_set_label(tcg_ctx, l3);                                                        \
-    tcg_gen_ori_i32(tcg_ctx, cpu_crf[crfD(ctx->opcode)], cpu_crf[crfD(ctx->opcode)],   \
+    tcg_gen_ori_i32(tcg_ctx, tcg_ctx->cpu_crf[crfD(ctx->opcode)], tcg_ctx->cpu_crf[crfD(ctx->opcode)],   \
                     CRF_CH | CRF_CH_OR_CL);                                   \
     gen_set_label(tcg_ctx, l4);                                                        \
 }
@@ -318,8 +318,8 @@ static inline void gen_brinc(DisasContext *ctx)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     /* Note: brinc is usable even if SPE is disabled */
-    gen_helper_brinc(tcg_ctx, cpu_gpr[rD(ctx->opcode)],
-                     cpu_gpr[rA(ctx->opcode)], cpu_gpr[rB(ctx->opcode)]);
+    gen_helper_brinc(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)],
+                     tcg_ctx->cpu_gpr[rA(ctx->opcode)], tcg_ctx->cpu_gpr[rB(ctx->opcode)]);
 }
 
 static inline void gen_evmergelo(DisasContext *ctx)
@@ -329,8 +329,8 @@ static inline void gen_evmergelo(DisasContext *ctx)
         gen_exception(ctx, POWERPC_EXCP_SPEU);
         return;
     }
-    tcg_gen_mov_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], cpu_gpr[rA(ctx->opcode)]);
-    tcg_gen_mov_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gpr[rB(ctx->opcode)]);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], tcg_ctx->cpu_gpr[rA(ctx->opcode)]);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gpr[rB(ctx->opcode)]);
 }
 
 static inline void gen_evmergehilo(DisasContext *ctx)
@@ -340,8 +340,8 @@ static inline void gen_evmergehilo(DisasContext *ctx)
         gen_exception(ctx, POWERPC_EXCP_SPEU);
         return;
     }
-    tcg_gen_mov_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gpr[rB(ctx->opcode)]);
-    tcg_gen_mov_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], cpu_gprh[rA(ctx->opcode)]);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gpr[rB(ctx->opcode)]);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], tcg_ctx->cpu_gprh[rA(ctx->opcode)]);
 }
 
 static inline void gen_evmergelohi(DisasContext *ctx)
@@ -353,13 +353,13 @@ static inline void gen_evmergelohi(DisasContext *ctx)
     }
     if (rD(ctx->opcode) == rA(ctx->opcode)) {
         TCGv tmp = tcg_temp_new(tcg_ctx);
-        tcg_gen_mov_tl(tcg_ctx, tmp, cpu_gpr[rA(ctx->opcode)]);
-        tcg_gen_mov_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gprh[rB(ctx->opcode)]);
-        tcg_gen_mov_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], tmp);
+        tcg_gen_mov_tl(tcg_ctx, tmp, tcg_ctx->cpu_gpr[rA(ctx->opcode)]);
+        tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gprh[rB(ctx->opcode)]);
+        tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], tmp);
         tcg_temp_free(tcg_ctx, tmp);
     } else {
-        tcg_gen_mov_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gprh[rB(ctx->opcode)]);
-        tcg_gen_mov_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], cpu_gpr[rA(ctx->opcode)]);
+        tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gprh[rB(ctx->opcode)]);
+        tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], tcg_ctx->cpu_gpr[rA(ctx->opcode)]);
     }
 }
 
@@ -368,8 +368,8 @@ static inline void gen_evsplati(DisasContext *ctx)
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     uint64_t imm = ((int32_t)(rA(ctx->opcode) << 27)) >> 27;
 
-    tcg_gen_movi_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], imm);
-    tcg_gen_movi_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], imm);
+    tcg_gen_movi_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], imm);
+    tcg_gen_movi_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], imm);
 }
 
 static inline void gen_evsplatfi(DisasContext *ctx)
@@ -377,8 +377,8 @@ static inline void gen_evsplatfi(DisasContext *ctx)
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     uint64_t imm = rA(ctx->opcode) << 27;
 
-    tcg_gen_movi_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], imm);
-    tcg_gen_movi_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], imm);
+    tcg_gen_movi_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], imm);
+    tcg_gen_movi_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], imm);
 }
 
 static inline void gen_evsel(DisasContext *ctx)
@@ -390,19 +390,19 @@ static inline void gen_evsel(DisasContext *ctx)
     TCGLabel *l4 = gen_new_label(tcg_ctx);
     TCGv_i32 t0 = tcg_temp_local_new_i32(tcg_ctx);
 
-    tcg_gen_andi_i32(tcg_ctx, t0, cpu_crf[ctx->opcode & 0x07], 1 << 3);
+    tcg_gen_andi_i32(tcg_ctx, t0, tcg_ctx->cpu_crf[ctx->opcode & 0x07], 1 << 3);
     tcg_gen_brcondi_i32(tcg_ctx, TCG_COND_EQ, t0, 0, l1);
-    tcg_gen_mov_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], cpu_gprh[rA(ctx->opcode)]);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], tcg_ctx->cpu_gprh[rA(ctx->opcode)]);
     tcg_gen_br(tcg_ctx, l2);
     gen_set_label(tcg_ctx, l1);
-    tcg_gen_mov_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], cpu_gprh[rB(ctx->opcode)]);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], tcg_ctx->cpu_gprh[rB(ctx->opcode)]);
     gen_set_label(tcg_ctx, l2);
-    tcg_gen_andi_i32(tcg_ctx, t0, cpu_crf[ctx->opcode & 0x07], 1 << 2);
+    tcg_gen_andi_i32(tcg_ctx, t0, tcg_ctx->cpu_crf[ctx->opcode & 0x07], 1 << 2);
     tcg_gen_brcondi_i32(tcg_ctx, TCG_COND_EQ, t0, 0, l3);
-    tcg_gen_mov_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gpr[rA(ctx->opcode)]);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gpr[rA(ctx->opcode)]);
     tcg_gen_br(tcg_ctx, l4);
     gen_set_label(tcg_ctx, l3);
-    tcg_gen_mov_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gpr[rB(ctx->opcode)]);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gpr[rB(ctx->opcode)]);
     gen_set_label(tcg_ctx, l4);
     tcg_temp_free_i32(tcg_ctx, t0);
 }
@@ -443,9 +443,9 @@ static inline void gen_evmwumi(DisasContext *ctx)
     t1 = tcg_temp_new_i64(tcg_ctx);
 
     /* t0 := rA; t1 := rB */
-    tcg_gen_extu_tl_i64(tcg_ctx, t0, cpu_gpr[rA(ctx->opcode)]);
+    tcg_gen_extu_tl_i64(tcg_ctx, t0, tcg_ctx->cpu_gpr[rA(ctx->opcode)]);
     tcg_gen_ext32u_i64(tcg_ctx, t0, t0);
-    tcg_gen_extu_tl_i64(tcg_ctx, t1, cpu_gpr[rB(ctx->opcode)]);
+    tcg_gen_extu_tl_i64(tcg_ctx, t1, tcg_ctx->cpu_gpr[rB(ctx->opcode)]);
     tcg_gen_ext32u_i64(tcg_ctx, t1, t1);
 
     tcg_gen_mul_i64(tcg_ctx, t0, t0, t1);  /* t0 := rA * rB */
@@ -525,9 +525,9 @@ static inline void gen_evmwsmi(DisasContext *ctx)
     t1 = tcg_temp_new_i64(tcg_ctx);
 
     /* t0 := rA; t1 := rB */
-    tcg_gen_extu_tl_i64(tcg_ctx, t0, cpu_gpr[rA(ctx->opcode)]);
+    tcg_gen_extu_tl_i64(tcg_ctx, t0, tcg_ctx->cpu_gpr[rA(ctx->opcode)]);
     tcg_gen_ext32s_i64(tcg_ctx, t0, t0);
-    tcg_gen_extu_tl_i64(tcg_ctx, t1, cpu_gpr[rB(ctx->opcode)]);
+    tcg_gen_extu_tl_i64(tcg_ctx, t1, tcg_ctx->cpu_gpr[rB(ctx->opcode)]);
     tcg_gen_ext32s_i64(tcg_ctx, t1, t1);
 
     tcg_gen_mul_i64(tcg_ctx, t0, t0, t1);  /* t0 := rA * rB */
@@ -623,7 +623,7 @@ static inline void gen_addr_spe_imm_index(DisasContext *ctx, TCGv EA, int sh)
     if (rA(ctx->opcode) == 0) {
         tcg_gen_movi_tl(tcg_ctx, EA, uimm << sh);
     } else {
-        tcg_gen_addi_tl(tcg_ctx, EA, cpu_gpr[rA(ctx->opcode)], uimm << sh);
+        tcg_gen_addi_tl(tcg_ctx, EA, tcg_ctx->cpu_gpr[rA(ctx->opcode)], uimm << sh);
         if (NARROW_MODE(ctx)) {
             tcg_gen_ext32u_tl(tcg_ctx, EA, EA);
         }
@@ -641,9 +641,10 @@ static inline void gen_op_evldd(DisasContext *ctx, TCGv addr)
 
 static inline void gen_op_evldw(DisasContext *ctx, TCGv addr)
 {
-    gen_qemu_ld32u(ctx, cpu_gprh[rD(ctx->opcode)], addr);
+    TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
+    gen_qemu_ld32u(ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], addr);
     gen_addr_add(ctx, addr, addr, 4);
-    gen_qemu_ld32u(ctx, cpu_gpr[rD(ctx->opcode)], addr);
+    gen_qemu_ld32u(ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], addr);
 }
 
 static inline void gen_op_evldh(DisasContext *ctx, TCGv addr)
@@ -651,16 +652,16 @@ static inline void gen_op_evldh(DisasContext *ctx, TCGv addr)
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv t0 = tcg_temp_new(tcg_ctx);
     gen_qemu_ld16u(ctx, t0, addr);
-    tcg_gen_shli_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], t0, 16);
+    tcg_gen_shli_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], t0, 16);
     gen_addr_add(ctx, addr, addr, 2);
     gen_qemu_ld16u(ctx, t0, addr);
-    tcg_gen_or_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], cpu_gprh[rD(ctx->opcode)], t0);
+    tcg_gen_or_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], tcg_ctx->cpu_gprh[rD(ctx->opcode)], t0);
     gen_addr_add(ctx, addr, addr, 2);
     gen_qemu_ld16u(ctx, t0, addr);
-    tcg_gen_shli_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], t0, 16);
+    tcg_gen_shli_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], t0, 16);
     gen_addr_add(ctx, addr, addr, 2);
     gen_qemu_ld16u(ctx, t0, addr);
-    tcg_gen_or_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gpr[rD(ctx->opcode)], t0);
+    tcg_gen_or_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gpr[rD(ctx->opcode)], t0);
     tcg_temp_free(tcg_ctx, t0);
 }
 
@@ -670,8 +671,8 @@ static inline void gen_op_evlhhesplat(DisasContext *ctx, TCGv addr)
     TCGv t0 = tcg_temp_new(tcg_ctx);
     gen_qemu_ld16u(ctx, t0, addr);
     tcg_gen_shli_tl(tcg_ctx, t0, t0, 16);
-    tcg_gen_mov_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], t0);
-    tcg_gen_mov_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], t0);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], t0);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], t0);
     tcg_temp_free(tcg_ctx, t0);
 }
 
@@ -680,8 +681,8 @@ static inline void gen_op_evlhhousplat(DisasContext *ctx, TCGv addr)
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv t0 = tcg_temp_new(tcg_ctx);
     gen_qemu_ld16u(ctx, t0, addr);
-    tcg_gen_mov_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], t0);
-    tcg_gen_mov_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], t0);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], t0);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], t0);
     tcg_temp_free(tcg_ctx, t0);
 }
 
@@ -690,8 +691,8 @@ static inline void gen_op_evlhhossplat(DisasContext *ctx, TCGv addr)
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv t0 = tcg_temp_new(tcg_ctx);
     gen_qemu_ld16s(ctx, t0, addr);
-    tcg_gen_mov_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], t0);
-    tcg_gen_mov_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], t0);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], t0);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], t0);
     tcg_temp_free(tcg_ctx, t0);
 }
 
@@ -700,25 +701,27 @@ static inline void gen_op_evlwhe(DisasContext *ctx, TCGv addr)
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv t0 = tcg_temp_new(tcg_ctx);
     gen_qemu_ld16u(ctx, t0, addr);
-    tcg_gen_shli_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], t0, 16);
+    tcg_gen_shli_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], t0, 16);
     gen_addr_add(ctx, addr, addr, 2);
     gen_qemu_ld16u(ctx, t0, addr);
-    tcg_gen_shli_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], t0, 16);
+    tcg_gen_shli_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], t0, 16);
     tcg_temp_free(tcg_ctx, t0);
 }
 
 static inline void gen_op_evlwhou(DisasContext *ctx, TCGv addr)
 {
-    gen_qemu_ld16u(ctx, cpu_gprh[rD(ctx->opcode)], addr);
+    TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
+    gen_qemu_ld16u(ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], addr);
     gen_addr_add(ctx, addr, addr, 2);
-    gen_qemu_ld16u(ctx, cpu_gpr[rD(ctx->opcode)], addr);
+    gen_qemu_ld16u(ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], addr);
 }
 
 static inline void gen_op_evlwhos(DisasContext *ctx, TCGv addr)
 {
-    gen_qemu_ld16s(ctx, cpu_gprh[rD(ctx->opcode)], addr);
+    TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
+    gen_qemu_ld16s(ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], addr);
     gen_addr_add(ctx, addr, addr, 2);
-    gen_qemu_ld16s(ctx, cpu_gpr[rD(ctx->opcode)], addr);
+    gen_qemu_ld16s(ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], addr);
 }
 
 static inline void gen_op_evlwwsplat(DisasContext *ctx, TCGv addr)
@@ -726,8 +729,8 @@ static inline void gen_op_evlwwsplat(DisasContext *ctx, TCGv addr)
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv t0 = tcg_temp_new(tcg_ctx);
     gen_qemu_ld32u(ctx, t0, addr);
-    tcg_gen_mov_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], t0);
-    tcg_gen_mov_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], t0);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], t0);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], t0);
     tcg_temp_free(tcg_ctx, t0);
 }
 
@@ -736,12 +739,12 @@ static inline void gen_op_evlwhsplat(DisasContext *ctx, TCGv addr)
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv t0 = tcg_temp_new(tcg_ctx);
     gen_qemu_ld16u(ctx, t0, addr);
-    tcg_gen_shli_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], t0, 16);
-    tcg_gen_or_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], cpu_gprh[rD(ctx->opcode)], t0);
+    tcg_gen_shli_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], t0, 16);
+    tcg_gen_or_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], tcg_ctx->cpu_gprh[rD(ctx->opcode)], t0);
     gen_addr_add(ctx, addr, addr, 2);
     gen_qemu_ld16u(ctx, t0, addr);
-    tcg_gen_shli_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], t0, 16);
-    tcg_gen_or_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gprh[rD(ctx->opcode)], t0);
+    tcg_gen_shli_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], t0, 16);
+    tcg_gen_or_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gprh[rD(ctx->opcode)], t0);
     tcg_temp_free(tcg_ctx, t0);
 }
 
@@ -756,54 +759,58 @@ static inline void gen_op_evstdd(DisasContext *ctx, TCGv addr)
 
 static inline void gen_op_evstdw(DisasContext *ctx, TCGv addr)
 {
-    gen_qemu_st32(ctx, cpu_gprh[rS(ctx->opcode)], addr);
+    TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
+    gen_qemu_st32(ctx, tcg_ctx->cpu_gprh[rS(ctx->opcode)], addr);
     gen_addr_add(ctx, addr, addr, 4);
-    gen_qemu_st32(ctx, cpu_gpr[rS(ctx->opcode)], addr);
+    gen_qemu_st32(ctx, tcg_ctx->cpu_gpr[rS(ctx->opcode)], addr);
 }
 
 static inline void gen_op_evstdh(DisasContext *ctx, TCGv addr)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv t0 = tcg_temp_new(tcg_ctx);
-    tcg_gen_shri_tl(tcg_ctx, t0, cpu_gprh[rS(ctx->opcode)], 16);
+    tcg_gen_shri_tl(tcg_ctx, t0, tcg_ctx->cpu_gprh[rS(ctx->opcode)], 16);
     gen_qemu_st16(ctx, t0, addr);
     gen_addr_add(ctx, addr, addr, 2);
-    gen_qemu_st16(ctx, cpu_gprh[rS(ctx->opcode)], addr);
+    gen_qemu_st16(ctx, tcg_ctx->cpu_gprh[rS(ctx->opcode)], addr);
     gen_addr_add(ctx, addr, addr, 2);
-    tcg_gen_shri_tl(tcg_ctx, t0, cpu_gpr[rS(ctx->opcode)], 16);
+    tcg_gen_shri_tl(tcg_ctx, t0, tcg_ctx->cpu_gpr[rS(ctx->opcode)], 16);
     gen_qemu_st16(ctx, t0, addr);
     tcg_temp_free(tcg_ctx, t0);
     gen_addr_add(ctx, addr, addr, 2);
-    gen_qemu_st16(ctx, cpu_gpr[rS(ctx->opcode)], addr);
+    gen_qemu_st16(ctx, tcg_ctx->cpu_gpr[rS(ctx->opcode)], addr);
 }
 
 static inline void gen_op_evstwhe(DisasContext *ctx, TCGv addr)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv t0 = tcg_temp_new(tcg_ctx);
-    tcg_gen_shri_tl(tcg_ctx, t0, cpu_gprh[rS(ctx->opcode)], 16);
+    tcg_gen_shri_tl(tcg_ctx, t0, tcg_ctx->cpu_gprh[rS(ctx->opcode)], 16);
     gen_qemu_st16(ctx, t0, addr);
     gen_addr_add(ctx, addr, addr, 2);
-    tcg_gen_shri_tl(tcg_ctx, t0, cpu_gpr[rS(ctx->opcode)], 16);
+    tcg_gen_shri_tl(tcg_ctx, t0, tcg_ctx->cpu_gpr[rS(ctx->opcode)], 16);
     gen_qemu_st16(ctx, t0, addr);
     tcg_temp_free(tcg_ctx, t0);
 }
 
 static inline void gen_op_evstwho(DisasContext *ctx, TCGv addr)
 {
-    gen_qemu_st16(ctx, cpu_gprh[rS(ctx->opcode)], addr);
+    TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
+    gen_qemu_st16(ctx, tcg_ctx->cpu_gprh[rS(ctx->opcode)], addr);
     gen_addr_add(ctx, addr, addr, 2);
-    gen_qemu_st16(ctx, cpu_gpr[rS(ctx->opcode)], addr);
+    gen_qemu_st16(ctx, tcg_ctx->cpu_gpr[rS(ctx->opcode)], addr);
 }
 
 static inline void gen_op_evstwwe(DisasContext *ctx, TCGv addr)
 {
-    gen_qemu_st32(ctx, cpu_gprh[rS(ctx->opcode)], addr);
+    TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
+    gen_qemu_st32(ctx, tcg_ctx->cpu_gprh[rS(ctx->opcode)], addr);
 }
 
 static inline void gen_op_evstwwo(DisasContext *ctx, TCGv addr)
 {
-    gen_qemu_st32(ctx, cpu_gpr[rS(ctx->opcode)], addr);
+    TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
+    gen_qemu_st32(ctx, tcg_ctx->cpu_gpr[rS(ctx->opcode)], addr);
 }
 
 #define GEN_SPEOP_LDST(name, opc2, sh)                                        \
@@ -924,9 +931,9 @@ static inline void gen_##name(DisasContext *ctx)                              \
 {                                                                             \
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;                                   \
     TCGv_i32 t0 = tcg_temp_new_i32(tcg_ctx);                                         \
-    tcg_gen_trunc_tl_i32(tcg_ctx, t0, cpu_gpr[rB(ctx->opcode)]);                       \
+    tcg_gen_trunc_tl_i32(tcg_ctx, t0, tcg_ctx->cpu_gpr[rB(ctx->opcode)]);                       \
     gen_helper_##name(tcg_ctx, t0, tcg_ctx->cpu_env, t0);                                       \
-    tcg_gen_extu_i32_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], t0);                        \
+    tcg_gen_extu_i32_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], t0);                        \
     tcg_temp_free_i32(tcg_ctx, t0);                                                    \
 }
 #define GEN_SPEFPUOP_CONV_32_64(name)                                         \
@@ -937,7 +944,7 @@ static inline void gen_##name(DisasContext *ctx)                              \
     TCGv_i32 t1 = tcg_temp_new_i32(tcg_ctx);                                         \
     gen_load_gpr64(tcg_ctx, t0, rB(ctx->opcode));                                      \
     gen_helper_##name(tcg_ctx, t1, tcg_ctx->cpu_env, t0);                                       \
-    tcg_gen_extu_i32_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], t1);                        \
+    tcg_gen_extu_i32_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], t1);                        \
     tcg_temp_free_i64(tcg_ctx, t0);                                                    \
     tcg_temp_free_i32(tcg_ctx, t1);                                                    \
 }
@@ -947,7 +954,7 @@ static inline void gen_##name(DisasContext *ctx)                              \
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;                                   \
     TCGv_i64 t0 = tcg_temp_new_i64(tcg_ctx);                                         \
     TCGv_i32 t1 = tcg_temp_new_i32(tcg_ctx);                                         \
-    tcg_gen_trunc_tl_i32(tcg_ctx, t1, cpu_gpr[rB(ctx->opcode)]);                       \
+    tcg_gen_trunc_tl_i32(tcg_ctx, t1, tcg_ctx->cpu_gpr[rB(ctx->opcode)]);                       \
     gen_helper_##name(tcg_ctx, t0, tcg_ctx->cpu_env, t1);                                       \
     gen_store_gpr64(tcg_ctx, rD(ctx->opcode), t0);                                     \
     tcg_temp_free_i64(tcg_ctx, t0);                                                    \
@@ -974,10 +981,10 @@ static inline void gen_##name(DisasContext *ctx)                              \
     }                                                                         \
     t0 = tcg_temp_new_i32(tcg_ctx);                                                  \
     t1 = tcg_temp_new_i32(tcg_ctx);                                                  \
-    tcg_gen_trunc_tl_i32(tcg_ctx, t0, cpu_gpr[rA(ctx->opcode)]);                       \
-    tcg_gen_trunc_tl_i32(tcg_ctx, t1, cpu_gpr[rB(ctx->opcode)]);                       \
+    tcg_gen_trunc_tl_i32(tcg_ctx, t0, tcg_ctx->cpu_gpr[rA(ctx->opcode)]);                       \
+    tcg_gen_trunc_tl_i32(tcg_ctx, t1, tcg_ctx->cpu_gpr[rB(ctx->opcode)]);                       \
     gen_helper_##name(tcg_ctx, t0, tcg_ctx->cpu_env, t0, t1);                                   \
-    tcg_gen_extu_i32_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], t0);                        \
+    tcg_gen_extu_i32_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], t0);                        \
                                                                               \
     tcg_temp_free_i32(tcg_ctx, t0);                                                    \
     tcg_temp_free_i32(tcg_ctx, t1);                                                    \
@@ -1012,9 +1019,9 @@ static inline void gen_##name(DisasContext *ctx)                              \
     t0 = tcg_temp_new_i32(tcg_ctx);                                                  \
     t1 = tcg_temp_new_i32(tcg_ctx);                                                  \
                                                                               \
-    tcg_gen_trunc_tl_i32(tcg_ctx, t0, cpu_gpr[rA(ctx->opcode)]);                       \
-    tcg_gen_trunc_tl_i32(tcg_ctx, t1, cpu_gpr[rB(ctx->opcode)]);                       \
-    gen_helper_##name(tcg_ctx, cpu_crf[crfD(ctx->opcode)], tcg_ctx->cpu_env, t0, t1);           \
+    tcg_gen_trunc_tl_i32(tcg_ctx, t0, tcg_ctx->cpu_gpr[rA(ctx->opcode)]);                       \
+    tcg_gen_trunc_tl_i32(tcg_ctx, t1, tcg_ctx->cpu_gpr[rB(ctx->opcode)]);                       \
+    gen_helper_##name(tcg_ctx, tcg_ctx->cpu_crf[crfD(ctx->opcode)], tcg_ctx->cpu_env, t0, t1);           \
                                                                               \
     tcg_temp_free_i32(tcg_ctx, t0);                                                    \
     tcg_temp_free_i32(tcg_ctx, t1);                                                    \
@@ -1032,7 +1039,7 @@ static inline void gen_##name(DisasContext *ctx)                              \
     t1 = tcg_temp_new_i64(tcg_ctx);                                                  \
     gen_load_gpr64(tcg_ctx, t0, rA(ctx->opcode));                                      \
     gen_load_gpr64(tcg_ctx, t1, rB(ctx->opcode));                                      \
-    gen_helper_##name(tcg_ctx, cpu_crf[crfD(ctx->opcode)], tcg_ctx->cpu_env, t0, t1);           \
+    gen_helper_##name(tcg_ctx, tcg_ctx->cpu_crf[crfD(ctx->opcode)], tcg_ctx->cpu_env, t0, t1);           \
     tcg_temp_free_i64(tcg_ctx, t0);                                                    \
     tcg_temp_free_i64(tcg_ctx, t1);                                                    \
 }
@@ -1050,9 +1057,9 @@ static inline void gen_evfsabs(DisasContext *ctx)
         gen_exception(ctx, POWERPC_EXCP_SPEU);
         return;
     }
-    tcg_gen_andi_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gpr[rA(ctx->opcode)],
+    tcg_gen_andi_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gpr[rA(ctx->opcode)],
                     ~0x80000000);
-    tcg_gen_andi_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], cpu_gprh[rA(ctx->opcode)],
+    tcg_gen_andi_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], tcg_ctx->cpu_gprh[rA(ctx->opcode)],
                     ~0x80000000);
 }
 
@@ -1063,9 +1070,9 @@ static inline void gen_evfsnabs(DisasContext *ctx)
         gen_exception(ctx, POWERPC_EXCP_SPEU);
         return;
     }
-    tcg_gen_ori_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gpr[rA(ctx->opcode)],
+    tcg_gen_ori_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gpr[rA(ctx->opcode)],
                    0x80000000);
-    tcg_gen_ori_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], cpu_gprh[rA(ctx->opcode)],
+    tcg_gen_ori_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], tcg_ctx->cpu_gprh[rA(ctx->opcode)],
                    0x80000000);
 }
 
@@ -1076,9 +1083,9 @@ static inline void gen_evfsneg(DisasContext *ctx)
         gen_exception(ctx, POWERPC_EXCP_SPEU);
         return;
     }
-    tcg_gen_xori_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gpr[rA(ctx->opcode)],
+    tcg_gen_xori_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gpr[rA(ctx->opcode)],
                     0x80000000);
-    tcg_gen_xori_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], cpu_gprh[rA(ctx->opcode)],
+    tcg_gen_xori_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], tcg_ctx->cpu_gprh[rA(ctx->opcode)],
                     0x80000000);
 }
 
@@ -1131,7 +1138,7 @@ static inline void gen_efsabs(DisasContext *ctx)
         gen_exception(ctx, POWERPC_EXCP_SPEU);
         return;
     }
-    tcg_gen_andi_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gpr[rA(ctx->opcode)],
+    tcg_gen_andi_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gpr[rA(ctx->opcode)],
                     (target_long)~0x80000000LL);
 }
 
@@ -1142,7 +1149,7 @@ static inline void gen_efsnabs(DisasContext *ctx)
         gen_exception(ctx, POWERPC_EXCP_SPEU);
         return;
     }
-    tcg_gen_ori_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gpr[rA(ctx->opcode)],
+    tcg_gen_ori_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gpr[rA(ctx->opcode)],
                    0x80000000);
 }
 
@@ -1153,7 +1160,7 @@ static inline void gen_efsneg(DisasContext *ctx)
         gen_exception(ctx, POWERPC_EXCP_SPEU);
         return;
     }
-    tcg_gen_xori_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gpr[rA(ctx->opcode)],
+    tcg_gen_xori_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gpr[rA(ctx->opcode)],
                     0x80000000);
 }
 
@@ -1207,8 +1214,8 @@ static inline void gen_efdabs(DisasContext *ctx)
         gen_exception(ctx, POWERPC_EXCP_SPEU);
         return;
     }
-    tcg_gen_mov_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gpr[rA(ctx->opcode)]);
-    tcg_gen_andi_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], cpu_gprh[rA(ctx->opcode)],
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gpr[rA(ctx->opcode)]);
+    tcg_gen_andi_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], tcg_ctx->cpu_gprh[rA(ctx->opcode)],
                     ~0x80000000);
 }
 
@@ -1219,8 +1226,8 @@ static inline void gen_efdnabs(DisasContext *ctx)
         gen_exception(ctx, POWERPC_EXCP_SPEU);
         return;
     }
-    tcg_gen_mov_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gpr[rA(ctx->opcode)]);
-    tcg_gen_ori_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], cpu_gprh[rA(ctx->opcode)],
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gpr[rA(ctx->opcode)]);
+    tcg_gen_ori_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], tcg_ctx->cpu_gprh[rA(ctx->opcode)],
                    0x80000000);
 }
 
@@ -1231,8 +1238,8 @@ static inline void gen_efdneg(DisasContext *ctx)
         gen_exception(ctx, POWERPC_EXCP_SPEU);
         return;
     }
-    tcg_gen_mov_tl(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gpr[rA(ctx->opcode)]);
-    tcg_gen_xori_tl(tcg_ctx, cpu_gprh[rD(ctx->opcode)], cpu_gprh[rA(ctx->opcode)],
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gpr[rA(ctx->opcode)]);
+    tcg_gen_xori_tl(tcg_ctx, tcg_ctx->cpu_gprh[rD(ctx->opcode)], tcg_ctx->cpu_gprh[rA(ctx->opcode)],
                     0x80000000);
 }
 

--- a/qemu/target/ppc/translate/vmx-impl.inc.c
+++ b/qemu/target/ppc/translate/vmx-impl.inc.c
@@ -411,7 +411,7 @@ static void glue(gen_, name)(DisasContext *ctx)                         \
         return;                                                         \
     }                                                                   \
     rb = gen_avr_ptr(tcg_ctx, rB(ctx->opcode));                         \
-    gen_helper_##name(tcg_ctx, cpu_gpr[rD(ctx->opcode)], cpu_gpr[rA(ctx->opcode)], rb); \
+    gen_helper_##name(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], tcg_ctx->cpu_gpr[rA(ctx->opcode)], rb); \
     tcg_temp_free_ptr(tcg_ctx, rb);                                     \
 }
 
@@ -1134,7 +1134,7 @@ static void glue(gen_, name)(DisasContext *ctx)                         \
             return;                                                     \
         }                                                               \
         rb = gen_avr_ptr(tcg_ctx, rB(ctx->opcode));                     \
-        gen_helper_##name(tcg_ctx, cpu_gpr[rD(ctx->opcode)], rb);       \
+        gen_helper_##name(tcg_ctx, tcg_ctx->cpu_gpr[rD(ctx->opcode)], rb);       \
         tcg_temp_free_ptr(tcg_ctx, rb);                                 \
     }
 GEN_VXFORM_NOA(vupkhsb, 7, 8);
@@ -1401,7 +1401,7 @@ static void gen_##op(DisasContext *ctx)             \
                                                     \
     ps = tcg_const_i32(tcg_ctx, (ctx->opcode & 0x200) != 0); \
                                                     \
-    gen_helper_##op(tcg_ctx, cpu_crf[6], rd, ra, rb, ps);    \
+    gen_helper_##op(tcg_ctx, tcg_ctx->cpu_crf[6], rd, ra, rb, ps);    \
                                                     \
     tcg_temp_free_ptr(tcg_ctx, ra);                 \
     tcg_temp_free_ptr(tcg_ctx, rb);                 \
@@ -1426,7 +1426,7 @@ static void gen_##op(DisasContext *ctx)             \
                                                     \
     ps = tcg_const_i32(tcg_ctx, (ctx->opcode & 0x200) != 0); \
                                                     \
-    gen_helper_##op(tcg_ctx, cpu_crf[6], rd, rb, ps);        \
+    gen_helper_##op(tcg_ctx, tcg_ctx->cpu_crf[6], rd, rb, ps);        \
                                                     \
     tcg_temp_free_ptr(tcg_ctx, rb);                 \
     tcg_temp_free_ptr(tcg_ctx, rd);                 \

--- a/qemu/target/ppc/translate/vsx-impl.inc.c
+++ b/qemu/target/ppc/translate/vsx-impl.inc.c
@@ -375,7 +375,7 @@ static void gen_##name(DisasContext *ctx)                          \
     xt = gen_vsr_ptr(tcg_ctx, xT(ctx->opcode));                             \
     gen_set_access_type(ctx, ACCESS_INT);                          \
     gen_addr_register(ctx, EA);                                    \
-    gen_helper_##name(tcg_ctx, tcg_ctx->cpu_env, EA, xt, cpu_gpr[rB(ctx->opcode)]);  \
+    gen_helper_##name(tcg_ctx, tcg_ctx->cpu_env, EA, xt, tcg_ctx->cpu_gpr[rB(ctx->opcode)]);  \
     tcg_temp_free(tcg_ctx, EA);                                             \
     tcg_temp_free_ptr(tcg_ctx, xt);                                         \
 }
@@ -608,7 +608,7 @@ static void gen_mfvsrwz(DisasContext *ctx)
     TCGv_i64 xsh = tcg_temp_new_i64(tcg_ctx);
     get_cpu_vsrh(tcg_ctx, xsh, xS(ctx->opcode));
     tcg_gen_ext32u_i64(tcg_ctx, tmp, xsh);
-    tcg_gen_trunc_i64_tl(tcg_ctx, cpu_gpr[rA(ctx->opcode)], tmp);
+    tcg_gen_trunc_i64_tl(tcg_ctx, tcg_ctx->cpu_gpr[rA(ctx->opcode)], tmp);
     tcg_temp_free_i64(tcg_ctx, tmp);
     tcg_temp_free_i64(tcg_ctx, xsh);
 }
@@ -629,7 +629,7 @@ static void gen_mtvsrwa(DisasContext *ctx)
     }
     TCGv_i64 tmp = tcg_temp_new_i64(tcg_ctx);
     TCGv_i64 xsh = tcg_temp_new_i64(tcg_ctx);
-    tcg_gen_extu_tl_i64(tcg_ctx, tmp, cpu_gpr[rA(ctx->opcode)]);
+    tcg_gen_extu_tl_i64(tcg_ctx, tmp, tcg_ctx->cpu_gpr[rA(ctx->opcode)]);
     tcg_gen_ext32s_i64(tcg_ctx, xsh, tmp);
     set_cpu_vsrh(tcg_ctx, xT(ctx->opcode), xsh);
     tcg_temp_free_i64(tcg_ctx, tmp);
@@ -652,7 +652,7 @@ static void gen_mtvsrwz(DisasContext *ctx)
     }
     TCGv_i64 tmp = tcg_temp_new_i64(tcg_ctx);
     TCGv_i64 xsh = tcg_temp_new_i64(tcg_ctx);
-    tcg_gen_extu_tl_i64(tcg_ctx, tmp, cpu_gpr[rA(ctx->opcode)]);
+    tcg_gen_extu_tl_i64(tcg_ctx, tmp, tcg_ctx->cpu_gpr[rA(ctx->opcode)]);
     tcg_gen_ext32u_i64(tcg_ctx, xsh, tmp);
     set_cpu_vsrh(tcg_ctx, xT(ctx->opcode), xsh);
     tcg_temp_free_i64(tcg_ctx, tmp);
@@ -677,7 +677,7 @@ static void gen_mfvsrd(DisasContext *ctx)
     }
     t0 = tcg_temp_new_i64(tcg_ctx);
     get_cpu_vsrh(tcg_ctx, t0, xS(ctx->opcode));
-    tcg_gen_mov_i64(tcg_ctx, cpu_gpr[rA(ctx->opcode)], t0);
+    tcg_gen_mov_i64(tcg_ctx, tcg_ctx->cpu_gpr[rA(ctx->opcode)], t0);
     tcg_temp_free_i64(tcg_ctx, t0);
 }
 
@@ -697,7 +697,7 @@ static void gen_mtvsrd(DisasContext *ctx)
         }
     }
     t0 = tcg_temp_new_i64(tcg_ctx);
-    tcg_gen_mov_i64(tcg_ctx, t0, cpu_gpr[rA(ctx->opcode)]);
+    tcg_gen_mov_i64(tcg_ctx, t0, tcg_ctx->cpu_gpr[rA(ctx->opcode)]);
     set_cpu_vsrh(tcg_ctx, xT(ctx->opcode), t0);
     tcg_temp_free_i64(tcg_ctx, t0);
 }
@@ -719,7 +719,7 @@ static void gen_mfvsrld(DisasContext *ctx)
     }
     t0 = tcg_temp_new_i64(tcg_ctx);
     get_cpu_vsrl(tcg_ctx, t0, xS(ctx->opcode));
-    tcg_gen_mov_i64(tcg_ctx, cpu_gpr[rA(ctx->opcode)], t0);
+    tcg_gen_mov_i64(tcg_ctx, tcg_ctx->cpu_gpr[rA(ctx->opcode)], t0);
     tcg_temp_free_i64(tcg_ctx, t0);
 }
 
@@ -743,11 +743,11 @@ static void gen_mtvsrdd(DisasContext *ctx)
     if (!rA(ctx->opcode)) {
         tcg_gen_movi_i64(tcg_ctx, t0, 0);
     } else {
-        tcg_gen_mov_i64(tcg_ctx, t0, cpu_gpr[rA(ctx->opcode)]);
+        tcg_gen_mov_i64(tcg_ctx, t0, tcg_ctx->cpu_gpr[rA(ctx->opcode)]);
     }
     set_cpu_vsrh(tcg_ctx, xT(ctx->opcode), t0);
 
-    tcg_gen_mov_i64(tcg_ctx, t0, cpu_gpr[rB(ctx->opcode)]);
+    tcg_gen_mov_i64(tcg_ctx, t0, tcg_ctx->cpu_gpr[rB(ctx->opcode)]);
     set_cpu_vsrl(tcg_ctx, xT(ctx->opcode), t0);
     tcg_temp_free_i64(tcg_ctx, t0);
 }
@@ -769,8 +769,8 @@ static void gen_mtvsrws(DisasContext *ctx)
     }
 
     t0 = tcg_temp_new_i64(tcg_ctx);
-    tcg_gen_deposit_i64(tcg_ctx, t0, cpu_gpr[rA(ctx->opcode)],
-                        cpu_gpr[rA(ctx->opcode)], 32, 32);
+    tcg_gen_deposit_i64(tcg_ctx, t0, tcg_ctx->cpu_gpr[rA(ctx->opcode)],
+                        tcg_ctx->cpu_gpr[rA(ctx->opcode)], 32, 32);
     set_cpu_vsrl(tcg_ctx, xT(ctx->opcode), t0);
     set_cpu_vsrh(tcg_ctx, xT(ctx->opcode), t0);
     tcg_temp_free_i64(tcg_ctx, t0);
@@ -1009,7 +1009,7 @@ static void gen_##name(DisasContext *ctx)                                     \
     xa = gen_vsr_ptr(tcg_ctx, xA(ctx->opcode));                                        \
     xb = gen_vsr_ptr(tcg_ctx, xB(ctx->opcode));                                        \
     if ((ctx->opcode >> (31 - 21)) & 1) {                                     \
-        gen_helper_##name(tcg_ctx, cpu_crf[6], tcg_ctx->cpu_env, xt, xa, xb);                   \
+        gen_helper_##name(tcg_ctx, tcg_ctx->cpu_crf[6], tcg_ctx->cpu_env, xt, xa, xb);                   \
     } else {                                                                  \
         ignored = tcg_temp_new_i32(tcg_ctx);                                         \
         gen_helper_##name(tcg_ctx, ignored, tcg_ctx->cpu_env, xt, xa, xb);                      \
@@ -1735,7 +1735,7 @@ VSX_EXTRACT_INSERT(xxinsertw)
 static void gen_xsxexpdp(DisasContext *ctx)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    TCGv rt = cpu_gpr[rD(ctx->opcode)];
+    TCGv rt = tcg_ctx->cpu_gpr[rD(ctx->opcode)];
     TCGv_i64 t0;
     if (unlikely(!ctx->vsx_enabled)) {
         gen_exception(ctx, POWERPC_EXCP_VSXU);
@@ -1777,8 +1777,8 @@ static void gen_xsiexpdp(DisasContext *ctx)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv_i64 xth;
-    TCGv ra = cpu_gpr[rA(ctx->opcode)];
-    TCGv rb = cpu_gpr[rB(ctx->opcode)];
+    TCGv ra = tcg_ctx->cpu_gpr[rA(ctx->opcode)];
+    TCGv rb = tcg_ctx->cpu_gpr[rB(ctx->opcode)];
     TCGv_i64 t0;
 
     if (unlikely(!ctx->vsx_enabled)) {
@@ -1840,7 +1840,7 @@ static void gen_xsiexpqp(DisasContext *ctx)
 static void gen_xsxsigdp(DisasContext *ctx)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    TCGv rt = cpu_gpr[rD(ctx->opcode)];
+    TCGv rt = tcg_ctx->cpu_gpr[rD(ctx->opcode)];
     TCGv_i64 t0, t1, zr, nan, exp;
 
     if (unlikely(!ctx->vsx_enabled)) {

--- a/qemu/target/ppc/translate_init.inc.c
+++ b/qemu/target/ppc/translate_init.inc.c
@@ -44,13 +44,14 @@ static void spr_load_dump_spr(TCGContext *tcg_ctx, int sprn)
 static void spr_read_generic(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_load_spr(tcg_ctx, cpu_gpr[gprn], sprn);
+    gen_load_spr(tcg_ctx, tcg_ctx->cpu_gpr[gprn], sprn);
     spr_load_dump_spr(tcg_ctx, sprn);
 }
 
 static void spr_store_dump_spr(int sprn)
 {
 #ifdef PPC_DUMP_SPR_ACCESSES
+    TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv_i32 t0 = tcg_const_i32(tcg_ctx, sprn);
     gen_helper_store_dump_spr(tcg_ctx, tcg_ctx->cpu_env, t0);
     tcg_temp_free_i32(tcg_ctx, t0);
@@ -60,7 +61,7 @@ static void spr_store_dump_spr(int sprn)
 static void spr_write_generic(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_store_spr(tcg_ctx, sprn, cpu_gpr[gprn]);
+    gen_store_spr(tcg_ctx, sprn, tcg_ctx->cpu_gpr[gprn]);
     spr_store_dump_spr(sprn);
 }
 
@@ -69,7 +70,7 @@ static void spr_write_generic32(DisasContext *ctx, int sprn, int gprn)
 #ifdef TARGET_PPC64
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv t0 = tcg_temp_new(tcg_ctx);
-    tcg_gen_ext32u_tl(tcg_ctx, t0, cpu_gpr[gprn]);
+    tcg_gen_ext32u_tl(tcg_ctx, t0, tcg_ctx->cpu_gpr[gprn]);
     gen_store_spr(tcg_ctx, sprn, t0);
     tcg_temp_free(tcg_ctx, t0);
     spr_store_dump_spr(sprn);
@@ -84,7 +85,7 @@ static void spr_write_clear(DisasContext *ctx, int sprn, int gprn)
     TCGv t0 = tcg_temp_new(tcg_ctx);
     TCGv t1 = tcg_temp_new(tcg_ctx);
     gen_load_spr(tcg_ctx, t0, sprn);
-    tcg_gen_neg_tl(tcg_ctx, t1, cpu_gpr[gprn]);
+    tcg_gen_neg_tl(tcg_ctx, t1, tcg_ctx->cpu_gpr[gprn]);
     tcg_gen_and_tl(tcg_ctx, t0, t0, t1);
     gen_store_spr(tcg_ctx, sprn, t0);
     tcg_temp_free(tcg_ctx, t0);
@@ -99,26 +100,27 @@ static void spr_access_nop(DisasContext *ctx, int sprn, int gprn)
 /* XER */
 static void spr_read_xer(DisasContext *ctx, int gprn, int sprn)
 {
-    gen_read_xer(ctx, cpu_gpr[gprn]);
+    TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
+    gen_read_xer(ctx, tcg_ctx->cpu_gpr[gprn]);
 }
 
 static void spr_write_xer(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_write_xer(tcg_ctx, cpu_gpr[gprn]);
+    gen_write_xer(tcg_ctx, tcg_ctx->cpu_gpr[gprn]);
 }
 
 /* LR */
 static void spr_read_lr(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    tcg_gen_mov_tl(tcg_ctx, cpu_gpr[gprn], cpu_lr);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_lr);
 }
 
 static void spr_write_lr(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    tcg_gen_mov_tl(tcg_ctx, cpu_lr, cpu_gpr[gprn]);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_lr, tcg_ctx->cpu_gpr[gprn]);
 }
 
 /* CFAR */
@@ -126,13 +128,13 @@ static void spr_write_lr(DisasContext *ctx, int sprn, int gprn)
 static void spr_read_cfar(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    tcg_gen_mov_tl(tcg_ctx, cpu_gpr[gprn], cpu_cfar);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_cfar);
 }
 
 static void spr_write_cfar(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    tcg_gen_mov_tl(tcg_ctx, cpu_cfar, cpu_gpr[gprn]);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_cfar, tcg_ctx->cpu_gpr[gprn]);
 }
 #endif
 
@@ -140,13 +142,13 @@ static void spr_write_cfar(DisasContext *ctx, int sprn, int gprn)
 static void spr_read_ctr(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    tcg_gen_mov_tl(tcg_ctx, cpu_gpr[gprn], cpu_ctr);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_ctr);
 }
 
 static void spr_write_ctr(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    tcg_gen_mov_tl(tcg_ctx, cpu_ctr, cpu_gpr[gprn]);
+    tcg_gen_mov_tl(tcg_ctx, tcg_ctx->cpu_ctr, tcg_ctx->cpu_gpr[gprn]);
 }
 
 /* User read access to SPR */
@@ -158,14 +160,14 @@ static void spr_write_ctr(DisasContext *ctx, int sprn, int gprn)
 static void spr_read_ureg(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_load_spr(tcg_ctx, cpu_gpr[gprn], sprn + 0x10);
+    gen_load_spr(tcg_ctx, tcg_ctx->cpu_gpr[gprn], sprn + 0x10);
 }
 
 #if defined(TARGET_PPC64)
 static void spr_write_ureg(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_store_spr(tcg_ctx, sprn + 0x10, cpu_gpr[gprn]);
+    gen_store_spr(tcg_ctx, sprn + 0x10, tcg_ctx->cpu_gpr[gprn]);
 }
 #endif
 
@@ -178,7 +180,7 @@ static void spr_read_decr(DisasContext *ctx, int gprn, int sprn)
     if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT) {
         gen_io_start(tcg_ctx);
     }
-    gen_helper_load_decr(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env);
+    gen_helper_load_decr(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env);
     if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT) {
         gen_stop_exception(ctx);
     }
@@ -194,7 +196,7 @@ static void spr_write_decr(DisasContext *ctx, int sprn, int gprn)
     if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT) {
         gen_io_start(tcg_ctx);
     }
-    gen_helper_store_decr(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_decr(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
     if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT) {
         gen_stop_exception(ctx);
     }
@@ -212,7 +214,7 @@ static void spr_read_tbl(DisasContext *ctx, int gprn, int sprn)
     if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT) {
         gen_io_start(tcg_ctx);
     }
-    gen_helper_load_tbl(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env);
+    gen_helper_load_tbl(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env);
     if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT) {
         gen_io_end(tcg_ctx);
         gen_stop_exception(ctx);
@@ -229,7 +231,7 @@ static void spr_read_tbu(DisasContext *ctx, int gprn, int sprn)
     if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT) {
         gen_io_start(tcg_ctx);
     }
-    gen_helper_load_tbu(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env);
+    gen_helper_load_tbu(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env);
     if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT) {
         gen_io_end(tcg_ctx);
         gen_stop_exception(ctx);
@@ -244,14 +246,14 @@ static void spr_read_tbu(DisasContext *ctx, int gprn, int sprn)
 static void spr_read_atbl(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_load_atbl(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env);
+    gen_helper_load_atbl(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env);
 }
 
 // ATTRIBUTE_UNUSED
 static void spr_read_atbu(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_load_atbu(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env);
+    gen_helper_load_atbu(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env);
 }
 #endif
 
@@ -262,7 +264,7 @@ static void spr_write_tbl(DisasContext *ctx, int sprn, int gprn)
     if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT) {
         gen_io_start(tcg_ctx);
     }
-    gen_helper_store_tbl(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_tbl(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
     if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT) {
         gen_io_end(tcg_ctx);
         gen_stop_exception(ctx);
@@ -280,7 +282,7 @@ static void spr_write_tbu(DisasContext *ctx, int sprn, int gprn)
     if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT) {
         gen_io_start(tcg_ctx);
     }
-    gen_helper_store_tbu(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_tbu(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
     if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT) {
         gen_io_end(tcg_ctx);
         gen_stop_exception(ctx);
@@ -295,14 +297,14 @@ static void spr_write_tbu(DisasContext *ctx, int sprn, int gprn)
 static void spr_write_atbl(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_store_atbl(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_atbl(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 }
 
 // ATTRIBUTE_UNUSED
 static void spr_write_atbu(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_store_atbu(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_atbu(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 }
 #endif
 
@@ -311,13 +313,13 @@ static void spr_write_atbu(DisasContext *ctx, int sprn, int gprn)
 static void spr_read_purr(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_load_purr(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env);
+    gen_helper_load_purr(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env);
 }
 
 static void spr_write_purr(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_store_purr(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_purr(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 }
 
 /* HDECR */
@@ -327,7 +329,7 @@ static void spr_read_hdecr(DisasContext *ctx, int gprn, int sprn)
     if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT) {
         gen_io_start(tcg_ctx);
     }
-    gen_helper_load_hdecr(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env);
+    gen_helper_load_hdecr(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env);
     if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT) {
         gen_io_end(tcg_ctx);
         gen_stop_exception(ctx);
@@ -340,7 +342,7 @@ static void spr_write_hdecr(DisasContext *ctx, int sprn, int gprn)
     if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT) {
         gen_io_start(tcg_ctx);
     }
-    gen_helper_store_hdecr(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_hdecr(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
     if (tb_cflags(ctx->base.tb) & CF_USE_ICOUNT) {
         gen_io_end(tcg_ctx);
         gen_stop_exception(ctx);
@@ -350,19 +352,19 @@ static void spr_write_hdecr(DisasContext *ctx, int sprn, int gprn)
 static void spr_read_vtb(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_load_vtb(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env);
+    gen_helper_load_vtb(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env);
 }
 
 static void spr_write_vtb(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_store_vtb(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_vtb(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 }
 
 static void spr_write_tbu40(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_store_tbu40(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_tbu40(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 }
 
 #endif
@@ -372,7 +374,7 @@ static void spr_write_tbu40(DisasContext *ctx, int sprn, int gprn)
 static void spr_read_ibat(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    tcg_gen_ld_tl(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env,
+    tcg_gen_ld_tl(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env,
                   offsetof(CPUPPCState,
                            IBAT[sprn & 1][(sprn - SPR_IBAT0U) / 2]));
 }
@@ -380,7 +382,7 @@ static void spr_read_ibat(DisasContext *ctx, int gprn, int sprn)
 static void spr_read_ibat_h(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    tcg_gen_ld_tl(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env,
+    tcg_gen_ld_tl(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env,
                   offsetof(CPUPPCState,
                            IBAT[sprn & 1][((sprn - SPR_IBAT4U) / 2) + 4]));
 }
@@ -389,7 +391,7 @@ static void spr_write_ibatu(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv_i32 t0 = tcg_const_i32(tcg_ctx, (sprn - SPR_IBAT0U) / 2);
-    gen_helper_store_ibatu(tcg_ctx, tcg_ctx->cpu_env, t0, cpu_gpr[gprn]);
+    gen_helper_store_ibatu(tcg_ctx, tcg_ctx->cpu_env, t0, tcg_ctx->cpu_gpr[gprn]);
     tcg_temp_free_i32(tcg_ctx, t0);
 }
 
@@ -397,7 +399,7 @@ static void spr_write_ibatu_h(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv_i32 t0 = tcg_const_i32(tcg_ctx, ((sprn - SPR_IBAT4U) / 2) + 4);
-    gen_helper_store_ibatu(tcg_ctx, tcg_ctx->cpu_env, t0, cpu_gpr[gprn]);
+    gen_helper_store_ibatu(tcg_ctx, tcg_ctx->cpu_env, t0, tcg_ctx->cpu_gpr[gprn]);
     tcg_temp_free_i32(tcg_ctx, t0);
 }
 
@@ -405,7 +407,7 @@ static void spr_write_ibatl(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv_i32 t0 = tcg_const_i32(tcg_ctx, (sprn - SPR_IBAT0L) / 2);
-    gen_helper_store_ibatl(tcg_ctx, tcg_ctx->cpu_env, t0, cpu_gpr[gprn]);
+    gen_helper_store_ibatl(tcg_ctx, tcg_ctx->cpu_env, t0, tcg_ctx->cpu_gpr[gprn]);
     tcg_temp_free_i32(tcg_ctx, t0);
 }
 
@@ -413,7 +415,7 @@ static void spr_write_ibatl_h(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv_i32 t0 = tcg_const_i32(tcg_ctx, ((sprn - SPR_IBAT4L) / 2) + 4);
-    gen_helper_store_ibatl(tcg_ctx, tcg_ctx->cpu_env, t0, cpu_gpr[gprn]);
+    gen_helper_store_ibatl(tcg_ctx, tcg_ctx->cpu_env, t0, tcg_ctx->cpu_gpr[gprn]);
     tcg_temp_free_i32(tcg_ctx, t0);
 }
 
@@ -422,7 +424,7 @@ static void spr_write_ibatl_h(DisasContext *ctx, int sprn, int gprn)
 static void spr_read_dbat(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    tcg_gen_ld_tl(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env,
+    tcg_gen_ld_tl(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env,
                   offsetof(CPUPPCState,
                            DBAT[sprn & 1][(sprn - SPR_DBAT0U) / 2]));
 }
@@ -430,7 +432,7 @@ static void spr_read_dbat(DisasContext *ctx, int gprn, int sprn)
 static void spr_read_dbat_h(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    tcg_gen_ld_tl(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env,
+    tcg_gen_ld_tl(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env,
                   offsetof(CPUPPCState,
                            DBAT[sprn & 1][((sprn - SPR_DBAT4U) / 2) + 4]));
 }
@@ -439,7 +441,7 @@ static void spr_write_dbatu(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv_i32 t0 = tcg_const_i32(tcg_ctx, (sprn - SPR_DBAT0U) / 2);
-    gen_helper_store_dbatu(tcg_ctx, tcg_ctx->cpu_env, t0, cpu_gpr[gprn]);
+    gen_helper_store_dbatu(tcg_ctx, tcg_ctx->cpu_env, t0, tcg_ctx->cpu_gpr[gprn]);
     tcg_temp_free_i32(tcg_ctx, t0);
 }
 
@@ -447,7 +449,7 @@ static void spr_write_dbatu_h(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv_i32 t0 = tcg_const_i32(tcg_ctx, ((sprn - SPR_DBAT4U) / 2) + 4);
-    gen_helper_store_dbatu(tcg_ctx, tcg_ctx->cpu_env, t0, cpu_gpr[gprn]);
+    gen_helper_store_dbatu(tcg_ctx, tcg_ctx->cpu_env, t0, tcg_ctx->cpu_gpr[gprn]);
     tcg_temp_free_i32(tcg_ctx, t0);
 }
 
@@ -455,7 +457,7 @@ static void spr_write_dbatl(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv_i32 t0 = tcg_const_i32(tcg_ctx, (sprn - SPR_DBAT0L) / 2);
-    gen_helper_store_dbatl(tcg_ctx, tcg_ctx->cpu_env, t0, cpu_gpr[gprn]);
+    gen_helper_store_dbatl(tcg_ctx, tcg_ctx->cpu_env, t0, tcg_ctx->cpu_gpr[gprn]);
     tcg_temp_free_i32(tcg_ctx, t0);
 }
 
@@ -463,7 +465,7 @@ static void spr_write_dbatl_h(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv_i32 t0 = tcg_const_i32(tcg_ctx, ((sprn - SPR_DBAT4L) / 2) + 4);
-    gen_helper_store_dbatl(tcg_ctx, tcg_ctx->cpu_env, t0, cpu_gpr[gprn]);
+    gen_helper_store_dbatl(tcg_ctx, tcg_ctx->cpu_env, t0, tcg_ctx->cpu_gpr[gprn]);
     tcg_temp_free_i32(tcg_ctx, t0);
 }
 
@@ -471,7 +473,7 @@ static void spr_write_dbatl_h(DisasContext *ctx, int sprn, int gprn)
 static void spr_write_sdr1(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_store_sdr1(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_sdr1(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 }
 
 #if defined(TARGET_PPC64)
@@ -480,52 +482,52 @@ static void spr_write_sdr1(DisasContext *ctx, int sprn, int gprn)
 static void spr_write_pidr(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_store_pidr(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_pidr(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 }
 
 static void spr_write_lpidr(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_store_lpidr(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_lpidr(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 }
 
 static void spr_read_hior(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    tcg_gen_ld_tl(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env, offsetof(CPUPPCState, excp_prefix));
+    tcg_gen_ld_tl(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env, offsetof(CPUPPCState, excp_prefix));
 }
 
 static void spr_write_hior(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv t0 = tcg_temp_new(tcg_ctx);
-    tcg_gen_andi_tl(tcg_ctx, t0, cpu_gpr[gprn], 0x3FFFFF00000ULL);
+    tcg_gen_andi_tl(tcg_ctx, t0, tcg_ctx->cpu_gpr[gprn], 0x3FFFFF00000ULL);
     tcg_gen_st_tl(tcg_ctx, t0, tcg_ctx->cpu_env, offsetof(CPUPPCState, excp_prefix));
     tcg_temp_free(tcg_ctx, t0);
 }
 static void spr_write_ptcr(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_store_ptcr(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_ptcr(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 }
 
 static void spr_write_pcr(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_store_pcr(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_pcr(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 }
 
 /* DPDES */
 static void spr_read_dpdes(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_load_dpdes(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env);
+    gen_helper_load_dpdes(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env);
 }
 
 static void spr_write_dpdes(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_store_dpdes(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_dpdes(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 }
 #endif
 
@@ -534,31 +536,31 @@ static void spr_write_dpdes(DisasContext *ctx, int sprn, int gprn)
 static void spr_read_601_rtcl(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_load_601_rtcl(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env);
+    gen_helper_load_601_rtcl(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env);
 }
 
 static void spr_read_601_rtcu(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_load_601_rtcu(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env);
+    gen_helper_load_601_rtcu(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env);
 }
 
 static void spr_write_601_rtcu(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_store_601_rtcu(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_601_rtcu(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 }
 
 static void spr_write_601_rtcl(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_store_601_rtcl(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_601_rtcl(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 }
 
 static void spr_write_hid0_601(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_store_hid0_601(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_hid0_601(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
     /* Must stop the translation as endianness may have changed */
     gen_stop_exception(ctx);
 }
@@ -567,7 +569,7 @@ static void spr_write_hid0_601(DisasContext *ctx, int sprn, int gprn)
 static void spr_read_601_ubat(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    tcg_gen_ld_tl(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env,
+    tcg_gen_ld_tl(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env,
                   offsetof(CPUPPCState,
                            IBAT[sprn & 1][(sprn - SPR_IBAT0U) / 2]));
 }
@@ -576,7 +578,7 @@ static void spr_write_601_ubatu(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv_i32 t0 = tcg_const_i32(tcg_ctx, (sprn - SPR_IBAT0U) / 2);
-    gen_helper_store_601_batl(tcg_ctx, tcg_ctx->cpu_env, t0, cpu_gpr[gprn]);
+    gen_helper_store_601_batl(tcg_ctx, tcg_ctx->cpu_env, t0, tcg_ctx->cpu_gpr[gprn]);
     tcg_temp_free_i32(tcg_ctx, t0);
 }
 
@@ -584,7 +586,7 @@ static void spr_write_601_ubatl(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv_i32 t0 = tcg_const_i32(tcg_ctx, (sprn - SPR_IBAT0U) / 2);
-    gen_helper_store_601_batu(tcg_ctx, tcg_ctx->cpu_env, t0, cpu_gpr[gprn]);
+    gen_helper_store_601_batu(tcg_ctx, tcg_ctx->cpu_env, t0, tcg_ctx->cpu_gpr[gprn]);
     tcg_temp_free_i32(tcg_ctx, t0);
 }
 
@@ -593,9 +595,9 @@ static void spr_read_40x_pit(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
 #ifdef UNICORN_ARCH_POSTFIX
-    glue(gen_helper_load_40x_pit, UNICORN_ARCH_POSTFIX)(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env);
+    glue(gen_helper_load_40x_pit, UNICORN_ARCH_POSTFIX)(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env);
 #else
-    gen_helper_load_40x_pit(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env);
+    gen_helper_load_40x_pit(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env);
 #endif
 }
 
@@ -603,20 +605,20 @@ static void spr_write_40x_pit(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
 #ifdef UNICORN_ARCH_POSTFIX
-    glue(gen_helper_store_40x_pit, UNICORN_ARCH_POSTFIX)(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    glue(gen_helper_store_40x_pit, UNICORN_ARCH_POSTFIX)(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 #else
-    gen_helper_store_40x_pit(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_40x_pit(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 #endif
 }
 
 static void spr_write_40x_dbcr0(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_store_spr(tcg_ctx, sprn, cpu_gpr[gprn]);
+    gen_store_spr(tcg_ctx, sprn, tcg_ctx->cpu_gpr[gprn]);
 #ifdef UNICORN_ARCH_POSTFIX
-    glue(gen_helper_store_40x_dbcr0, UNICORN_ARCH_POSTFIX)(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    glue(gen_helper_store_40x_dbcr0, UNICORN_ARCH_POSTFIX)(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 #else
-    gen_helper_store_40x_dbcr0(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_40x_dbcr0(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 #endif
     /* We must stop translation as we may have rebooted */
     gen_stop_exception(ctx);
@@ -626,22 +628,22 @@ static void spr_write_40x_sler(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
 #ifdef UNICORN_ARCH_POSTFIX
-    glue(gen_helper_store_40x_sler, UNICORN_ARCH_POSTFIX)(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    glue(gen_helper_store_40x_sler, UNICORN_ARCH_POSTFIX)(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 #else
-    gen_helper_store_40x_sler(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_40x_sler(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 #endif
 }
 
 static void spr_write_booke_tcr(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_store_booke_tcr(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_booke_tcr(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 }
 
 static void spr_write_booke_tsr(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_store_booke_tsr(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_booke_tsr(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 }
 
 /* PowerPC 403 specific registers */
@@ -649,7 +651,7 @@ static void spr_write_booke_tsr(DisasContext *ctx, int sprn, int gprn)
 static void spr_read_403_pbr(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    tcg_gen_ld_tl(tcg_ctx, cpu_gpr[gprn], tcg_ctx->cpu_env,
+    tcg_gen_ld_tl(tcg_ctx, tcg_ctx->cpu_gpr[gprn], tcg_ctx->cpu_env,
                   offsetof(CPUPPCState, pb[sprn - SPR_403_PBL1]));
 }
 
@@ -657,7 +659,7 @@ static void spr_write_403_pbr(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv_i32 t0 = tcg_const_i32(tcg_ctx, sprn - SPR_403_PBL1);
-    gen_helper_store_403_pbr(tcg_ctx, tcg_ctx->cpu_env, t0, cpu_gpr[gprn]);
+    gen_helper_store_403_pbr(tcg_ctx, tcg_ctx->cpu_env, t0, tcg_ctx->cpu_gpr[gprn]);
     tcg_temp_free_i32(tcg_ctx, t0);
 }
 
@@ -665,7 +667,7 @@ static void spr_write_pir(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv t0 = tcg_temp_new(tcg_ctx);
-    tcg_gen_andi_tl(tcg_ctx, t0, cpu_gpr[gprn], 0xF);
+    tcg_gen_andi_tl(tcg_ctx, t0, tcg_ctx->cpu_gpr[gprn], 0xF);
     gen_store_spr(tcg_ctx, SPR_PIR, t0);
     tcg_temp_free(tcg_ctx, t0);
 }
@@ -676,7 +678,7 @@ static void spr_read_spefscr(DisasContext *ctx, int gprn, int sprn)
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv_i32 t0 = tcg_temp_new_i32(tcg_ctx);
     tcg_gen_ld_i32(tcg_ctx, t0, tcg_ctx->cpu_env, offsetof(CPUPPCState, spe_fscr));
-    tcg_gen_extu_i32_tl(tcg_ctx, cpu_gpr[gprn], t0);
+    tcg_gen_extu_i32_tl(tcg_ctx, tcg_ctx->cpu_gpr[gprn], t0);
     tcg_temp_free_i32(tcg_ctx, t0);
 }
 
@@ -684,7 +686,7 @@ static void spr_write_spefscr(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv_i32 t0 = tcg_temp_new_i32(tcg_ctx);
-    tcg_gen_trunc_tl_i32(tcg_ctx, t0, cpu_gpr[gprn]);
+    tcg_gen_trunc_tl_i32(tcg_ctx, t0, tcg_ctx->cpu_gpr[gprn]);
     tcg_gen_st_i32(tcg_ctx, t0, tcg_ctx->cpu_env, offsetof(CPUPPCState, spe_fscr));
     tcg_temp_free_i32(tcg_ctx, t0);
 }
@@ -695,7 +697,7 @@ static void spr_write_excp_prefix(DisasContext *ctx, int sprn, int gprn)
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv t0 = tcg_temp_new(tcg_ctx);
     tcg_gen_ld_tl(tcg_ctx, t0, tcg_ctx->cpu_env, offsetof(CPUPPCState, ivpr_mask));
-    tcg_gen_and_tl(tcg_ctx, t0, t0, cpu_gpr[gprn]);
+    tcg_gen_and_tl(tcg_ctx, t0, t0, tcg_ctx->cpu_gpr[gprn]);
     tcg_gen_st_tl(tcg_ctx, t0, tcg_ctx->cpu_env, offsetof(CPUPPCState, excp_prefix));
     gen_store_spr(tcg_ctx, sprn, t0);
     tcg_temp_free(tcg_ctx, t0);
@@ -721,7 +723,7 @@ static void spr_write_excp_vector(DisasContext *ctx, int sprn, int gprn)
 
     TCGv t0 = tcg_temp_new(tcg_ctx);
     tcg_gen_ld_tl(tcg_ctx, t0, tcg_ctx->cpu_env, offsetof(CPUPPCState, ivor_mask));
-    tcg_gen_and_tl(tcg_ctx, t0, t0, cpu_gpr[gprn]);
+    tcg_gen_and_tl(tcg_ctx, t0, t0, tcg_ctx->cpu_gpr[gprn]);
     tcg_gen_st_tl(tcg_ctx, t0, tcg_ctx->cpu_env, offsetof(CPUPPCState, excp_vectors[sprn_offs]));
     gen_store_spr(tcg_ctx, sprn, t0);
     tcg_temp_free(tcg_ctx, t0);
@@ -1226,7 +1228,7 @@ static void spr_write_amr(DisasContext *ctx, int sprn, int gprn)
     }
 
     /* Mask new bits into t2 */
-    tcg_gen_and_tl(tcg_ctx, t2, t1, cpu_gpr[gprn]);
+    tcg_gen_and_tl(tcg_ctx, t2, t1, tcg_ctx->cpu_gpr[gprn]);
 
     /* Load AMR and clear new bits in t0 */
     gen_load_spr(tcg_ctx, t0, SPR_AMR);
@@ -1258,7 +1260,7 @@ static void spr_write_uamor(DisasContext *ctx, int sprn, int gprn)
     gen_load_spr(tcg_ctx, t1, SPR_AMOR);
 
     /* Mask new bits into t2 */
-    tcg_gen_and_tl(tcg_ctx, t2, t1, cpu_gpr[gprn]);
+    tcg_gen_and_tl(tcg_ctx, t2, t1, tcg_ctx->cpu_gpr[gprn]);
 
     /* Load AMR and clear new bits in t0 */
     gen_load_spr(tcg_ctx, t0, SPR_UAMOR);
@@ -1290,7 +1292,7 @@ static void spr_write_iamr(DisasContext *ctx, int sprn, int gprn)
     gen_load_spr(tcg_ctx, t1, SPR_AMOR);
 
     /* Mask new bits into t2 */
-    tcg_gen_and_tl(tcg_ctx, t2, t1, cpu_gpr[gprn]);
+    tcg_gen_and_tl(tcg_ctx, t2, t1, tcg_ctx->cpu_gpr[gprn]);
 
     /* Load AMR and clear new bits in t0 */
     gen_load_spr(tcg_ctx, t0, SPR_IAMR);
@@ -1350,7 +1352,7 @@ static void spr_read_thrm(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     gen_helper_fixup_thrm(tcg_ctx, tcg_ctx->cpu_env);
-    gen_load_spr(tcg_ctx, cpu_gpr[gprn], sprn);
+    gen_load_spr(tcg_ctx, tcg_ctx->cpu_gpr[gprn], sprn);
     spr_load_dump_spr(tcg_ctx, sprn);
 }
 
@@ -1720,7 +1722,7 @@ static void spr_write_e500_l1csr0(DisasContext *ctx, int sprn, int gprn)
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv t0 = tcg_temp_new(tcg_ctx);
 
-    tcg_gen_andi_tl(tcg_ctx, t0, cpu_gpr[gprn], L1CSR0_DCE | L1CSR0_CPE);
+    tcg_gen_andi_tl(tcg_ctx, t0, tcg_ctx->cpu_gpr[gprn], L1CSR0_DCE | L1CSR0_CPE);
     gen_store_spr(tcg_ctx, sprn, t0);
     tcg_temp_free(tcg_ctx, t0);
 }
@@ -1730,7 +1732,7 @@ static void spr_write_e500_l1csr1(DisasContext *ctx, int sprn, int gprn)
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv t0 = tcg_temp_new(tcg_ctx);
 
-    tcg_gen_andi_tl(tcg_ctx, t0, cpu_gpr[gprn], L1CSR1_ICE | L1CSR1_CPE);
+    tcg_gen_andi_tl(tcg_ctx, t0, tcg_ctx->cpu_gpr[gprn], L1CSR1_ICE | L1CSR1_CPE);
     gen_store_spr(tcg_ctx, sprn, t0);
     tcg_temp_free(tcg_ctx, t0);
 }
@@ -1738,27 +1740,27 @@ static void spr_write_e500_l1csr1(DisasContext *ctx, int sprn, int gprn)
 static void spr_write_booke206_mmucsr0(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_booke206_tlbflush(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_booke206_tlbflush(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 }
 
 static void spr_write_booke_pid(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
     TCGv_i32 t0 = tcg_const_i32(tcg_ctx, sprn);
-    gen_helper_booke_setpid(tcg_ctx, tcg_ctx->cpu_env, t0, cpu_gpr[gprn]);
+    gen_helper_booke_setpid(tcg_ctx, tcg_ctx->cpu_env, t0, tcg_ctx->cpu_gpr[gprn]);
     tcg_temp_free_i32(tcg_ctx, t0);
 }
 
 static void spr_write_eplc(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_booke_set_eplc(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_booke_set_eplc(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 }
 
 static void spr_write_epsc(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
-    gen_helper_booke_set_epsc(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_booke_set_epsc(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 }
 
 static void gen_spr_usprg3(CPUPPCState *env)
@@ -4752,9 +4754,9 @@ static void spr_write_mas73(DisasContext *ctx, int sprn, int gprn)
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
 
     TCGv val = tcg_temp_new(tcg_ctx);
-    tcg_gen_ext32u_tl(tcg_ctx, val, cpu_gpr[gprn]);
+    tcg_gen_ext32u_tl(tcg_ctx, val, tcg_ctx->cpu_gpr[gprn]);
     gen_store_spr(tcg_ctx, SPR_BOOKE_MAS3, val);
-    tcg_gen_shri_tl(tcg_ctx, val, cpu_gpr[gprn], 32);
+    tcg_gen_shri_tl(tcg_ctx, val, tcg_ctx->cpu_gpr[gprn], 32);
     gen_store_spr(tcg_ctx, SPR_BOOKE_MAS7, val);
     tcg_temp_free(tcg_ctx, val);
 }
@@ -4768,7 +4770,7 @@ static void spr_read_mas73(DisasContext *ctx, int gprn, int sprn)
     gen_load_spr(tcg_ctx, mas7, SPR_BOOKE_MAS7);
     tcg_gen_shli_tl(tcg_ctx, mas7, mas7, 32);
     gen_load_spr(tcg_ctx, mas3, SPR_BOOKE_MAS3);
-    tcg_gen_or_tl(tcg_ctx, cpu_gpr[gprn], mas3, mas7);
+    tcg_gen_or_tl(tcg_ctx, tcg_ctx->cpu_gpr[gprn], mas3, mas7);
     tcg_temp_free(tcg_ctx, mas3);
     tcg_temp_free(tcg_ctx, mas7);
 }
@@ -7424,7 +7426,7 @@ static void spr_read_prev_upper32(DisasContext *ctx, int gprn, int sprn)
 
     gen_load_spr(tcg_ctx, spr, sprn - 1);
     tcg_gen_shri_tl(tcg_ctx, spr_up, spr, 32);
-    tcg_gen_ext32u_tl(tcg_ctx, cpu_gpr[gprn], spr_up);
+    tcg_gen_ext32u_tl(tcg_ctx, tcg_ctx->cpu_gpr[gprn], spr_up);
 
     tcg_temp_free(tcg_ctx, spr);
     tcg_temp_free(tcg_ctx, spr_up);
@@ -7436,7 +7438,7 @@ static void spr_write_prev_upper32(DisasContext *ctx, int sprn, int gprn)
     TCGv spr = tcg_temp_new(tcg_ctx);
 
     gen_load_spr(tcg_ctx, spr, sprn - 1);
-    tcg_gen_deposit_tl(tcg_ctx, spr, spr, cpu_gpr[gprn], 32, 32);
+    tcg_gen_deposit_tl(tcg_ctx, spr, spr, tcg_ctx->cpu_gpr[gprn], 32, 32);
     gen_store_spr(tcg_ctx, sprn - 1, spr);
 
     tcg_temp_free(tcg_ctx, spr);
@@ -7747,7 +7749,7 @@ static void spr_write_hmer(DisasContext *ctx, int sprn, int gprn)
     TCGv hmer = tcg_temp_new(tcg_ctx);
 
     gen_load_spr(tcg_ctx, hmer, sprn);
-    tcg_gen_and_tl(tcg_ctx, hmer, cpu_gpr[gprn], hmer);
+    tcg_gen_and_tl(tcg_ctx, hmer, tcg_ctx->cpu_gpr[gprn], hmer);
     gen_store_spr(tcg_ctx, sprn, hmer);
     spr_store_dump_spr(sprn);
     tcg_temp_free(tcg_ctx, hmer);
@@ -7757,7 +7759,7 @@ static void spr_write_lpcr(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
 
-    gen_helper_store_lpcr(tcg_ctx, tcg_ctx->cpu_env, cpu_gpr[gprn]);
+    gen_helper_store_lpcr(tcg_ctx, tcg_ctx->cpu_env, tcg_ctx->cpu_gpr[gprn]);
 }
 
 static void gen_spr_970_lpar(CPUPPCState *env)

--- a/qemu/target/ppc/unicorn.c
+++ b/qemu/target/ppc/unicorn.c
@@ -108,15 +108,9 @@ static void ppc_release(void *ctx)
         g_free(fast->table);
     }
 
-    for (i = 0; i < 32; i++) {
-        g_free(tcg_ctx->cpu_gpr[i]);
-    }
-    //    g_free(tcg_ctx->cpu_PC);
     g_free(tcg_ctx->btarget);
     g_free(tcg_ctx->bcond);
     g_free(tcg_ctx->cpu_dspctrl);
-
-    //    g_free(tcg_ctx->tb_ctx.tbs);
 
     if (env->nb_tlb != 0) {
         switch (env->tlb_type) {


### PR DESCRIPTION
### Problem

A lot of variables in `qemu/target/ppc/translate.c` use global TCG variables, which is unexpected as these variables should be a part of the instance-specific TCG context.

### Solution

In this PR, I've moved these global PPC TCG variables to the TCGContext struct. 