### PR TITLE
fix(python): catch `BaseException` in wrappers instead of `Exception`

### DIFF
--- a/bindings/python/unicorn/unicorn_py2.py
+++ b/bindings/python/unicorn/unicorn_py2.py
@@ -390,7 +390,7 @@ def _catch_hook_exception(func):
         """
         try:
             return func(self, *args, **kwargs)
-        except Exception as e:
+        except BaseException as e:
             # If multiple hooks raise exceptions, just use the first one
             if self._hook_exception is None:
                 self._hook_exception = e

--- a/bindings/python/unicorn/unicorn_py3/unicorn.py
+++ b/bindings/python/unicorn/unicorn_py3/unicorn.py
@@ -361,7 +361,7 @@ def uccallback(uc: Uc, functype: Type[_CFP]):
         def wrapper(handle: int, *args, **kwargs):
             try:
                 return func(uc, *args, **kwargs)
-            except Exception as e:
+            except BaseException as e:
                 # If multiple hooks raise exceptions, just use the first one
                 if uc._hook_exception is None:
                     uc._hook_exception = e


### PR DESCRIPTION
- Closes #2129

### Problem

The unicorn wrappers handling exceptions during hook handling catch `Exception`s and not `BaseException`s, thereby skipping any `KeyboardInterrupt`s. It would be nice if keyboard interrupts stopped emulation.

### Solution

Instead of catching `Exception` in the hook handling callbacks, we should catch `BaseException` as `KeyboardInterrupt` is derived from this ([docs](https://docs.python.org/3/library/exceptions.html#KeyboardInterrupt))

### Verification

I've built the bindings locally, and ran the same script posted in the given issue above ^^ below is a screenshot of the output for me:

![image](https://github.com/user-attachments/assets/51ac951c-7b36-48f7-a9b0-56110b504f6c)