### PR TITLE
AARCH64: Fix unmapped memory errors when Top Byte Ignore Addresses are 

### DIFF
--- a/qemu/accel/tcg/cputlb.c
+++ b/qemu/accel/tcg/cputlb.c
@@ -1556,11 +1556,12 @@ load_helper(CPUArchState *env, target_ulong addr, TCGMemOpIdx oi,
                     if (uc->stop_request)
                         break;
                 }
-
+#ifdef TARGET_ARM64
                 if (!handled) {
                     addr = addr & ARM64_TBI_MASK;
                     handled = 1;
                 }
+#endif
             }
         } else {
             error_code = uc->invalid_error;
@@ -2118,7 +2119,9 @@ store_helper(CPUArchState *env, target_ulong addr, uint64_t val,
     struct uc_struct *uc = env->uc;
     HOOK_FOREACH_VAR_DECLARE;
     uintptr_t mmu_idx = get_mmuidx(oi);
+#ifdef TARGET_ARM64
     addr = addr & ARM64_TBI_MASK;
+#endif
     uintptr_t index = tlb_index(env, mmu_idx, addr);
     CPUTLBEntry *entry = tlb_entry(env, mmu_idx, addr);
     target_ulong tlb_addr = tlb_addr_write(entry);

--- a/qemu/accel/tcg/cputlb.c
+++ b/qemu/accel/tcg/cputlb.c
@@ -61,6 +61,7 @@
     } while (0)
 #endif
 
+#define ARM64_TBI_MASK 0xFFFFFFFFFFFFFF
 /* run_on_cpu_data.target_ptr should always be big enough for a
  * target_ulong even on 32 bit builds */
 QEMU_BUILD_BUG_ON(sizeof(target_ulong) > sizeof(run_on_cpu_data));
@@ -1555,6 +1556,11 @@ load_helper(CPUArchState *env, target_ulong addr, TCGMemOpIdx oi,
                     if (uc->stop_request)
                         break;
                 }
+
+                if (!handled) {
+                    addr = addr & ARM64_TBI_MASK;
+                    handled = 1;
+                }
             }
         } else {
             error_code = uc->invalid_error;
@@ -2112,6 +2118,7 @@ store_helper(CPUArchState *env, target_ulong addr, uint64_t val,
     struct uc_struct *uc = env->uc;
     HOOK_FOREACH_VAR_DECLARE;
     uintptr_t mmu_idx = get_mmuidx(oi);
+    addr = addr & ARM64_TBI_MASK;
     uintptr_t index = tlb_index(env, mmu_idx, addr);
     CPUTLBEntry *entry = tlb_entry(env, mmu_idx, addr);
     target_ulong tlb_addr = tlb_addr_write(entry);


### PR DESCRIPTION
This MR is far from complete; I honestly need some advise on how to implement this feature properly. I am not familiar enough with QEMU.

# Problem

AArch64 uses since ARM v8.0 a feature called "Top Byte Ignore" which ensures that of an `uint64_t` the top most byte is not regarded as a address. This is being used in later ARM processor versions for the [Memory Tagging Extensions (MTE)](https://developer.arm.com/documentation/108035/0100/Introduction-to-the-Memory-Tagging-Extension) and Pointer Authentication (PAC) hardware mitigations., which are used in recent software to dramtically increase memory safety for legacy C software. In the next Release 2.20 we will have [Qemu 5.1.0](#2143) which [implements MTE](https://www.qemu.org/2020/08/11/qemu-5-1-0/).

Why does this cause problems with the current unicorn implementation? The entire hooking and memory mapping systems do not regard this specific ARM/AArch64 feature and evaluate the TBI addresses as-is. As these are not mapped, because the are entirely unknown to the mapping, 

I stumbled upon this when I fought with a memory allocator which started using addresses like `0x2000007FFFFFF32ae` which threw an unmapped memory exception. I tried hooking this high address range, but none of the hooks hit. After some ARM research it became apparent that is TBI.

# Provisionary Solution

This at least works for my current use case: simply using a bit mask on the address to ensure that it is evaluated as if the highest bit does not exist. This does then not intefer with the memory mapping.

# Points to discuss

I'am willing to work on this further, but need some direction on:

- is this the correct position to handle this in QEMU?
- are these checks sufficient or do we need to consider additional API points

I will add a simple test once I have figured out working with TBI Pointers in C++.