### PR TITLE
Make Unicorn struct clone-able

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 
 [dependencies]
 unicorn-engine-sys = { version = "2.1.3", path = "sys", features = [], default-features = false }
+perfect-derive = "0.1.5"
 
 [build-dependencies]
 bindgen = "0.71.1"

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 
 [dependencies]
 unicorn-engine-sys = { version = "2.1.3", path = "sys", features = [], default-features = false }
-perfect-derive = "0.1.5"
 
 [build-dependencies]
 bindgen = "0.71.1"

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -44,6 +44,7 @@ extern crate alloc;
 
 use alloc::{boxed::Box, rc::Rc, vec::Vec};
 use core::{cell::UnsafeCell, ffi::c_void, ptr};
+use perfect_derive::perfect_derive;
 
 #[macro_use]
 pub mod unicorn_const;
@@ -158,6 +159,9 @@ impl<D> Drop for UnicornInner<'_, D> {
 }
 
 /// A Unicorn emulator instance.
+///
+/// You could clone this instance cheaply, since it has an `Rc` inside.
+#[perfect_derive(Clone)]
 pub struct Unicorn<'a, D: 'a> {
     inner: Rc<UnsafeCell<UnicornInner<'a, D>>>,
 }

--- a/bindings/rust/src/lib.rs
+++ b/bindings/rust/src/lib.rs
@@ -44,7 +44,6 @@ extern crate alloc;
 
 use alloc::{boxed::Box, rc::Rc, vec::Vec};
 use core::{cell::UnsafeCell, ffi::c_void, ptr};
-use perfect_derive::perfect_derive;
 
 #[macro_use]
 pub mod unicorn_const;
@@ -161,7 +160,6 @@ impl<D> Drop for UnicornInner<'_, D> {
 /// A Unicorn emulator instance.
 ///
 /// You could clone this instance cheaply, since it has an `Rc` inside.
-#[perfect_derive(Clone)]
 pub struct Unicorn<'a, D: 'a> {
     inner: Rc<UnsafeCell<UnicornInner<'a, D>>>,
 }
@@ -240,6 +238,14 @@ where
 impl<D> core::fmt::Debug for Unicorn<'_, D> {
     fn fmt(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(formatter, "Unicorn {{ uc: {:p} }}", self.get_handle())
+    }
+}
+
+impl<D> Clone for Unicorn<'_, D> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Rc::clone(&self.inner),
+        }
     }
 }
 


### PR DESCRIPTION
In some situations, we hold a mutable reference to the user-defined data stored in `Unicorn` struct by `get_data_mut`, and we also need to call some mutable method like `reg_write` at the same time. However, currently Rust does not support inter-procedure field-granularity borrow checker (see [this blog](https://smallcultfollowing.com/babysteps/blog/2025/02/25/view-types-redux/) for more details), as a result, this makes it impossible to do this.

Since the `Unicorn` struct holds an `Rc` of `UnicornInner`, we can just cheaply clone the `Unicorn` to get rid of this.

In this PR, I use `perfect_derive` instead of simple `derive`, since Rust's derive will require the generic parameter `D` also implement `Clone`, which is unnecessary (See [this blog](https://smallcultfollowing.com/babysteps/blog/2022/04/12/implied-bounds-and-perfect-derive/) for more details).