### PR TITLE
Added CFG Check and standalone flag for .NET binding

### DIFF
--- a/bindings/dotnet/UnicornEngine/Unicorn.fs
+++ b/bindings/dotnet/UnicornEngine/Unicorn.fs
@@ -20,7 +20,6 @@ and SyscallHook = delegate of Unicorn * Object -> unit
 
 // the managed unicorn engine
 and Unicorn(arch: Int32, mode: Int32, binding: IBinding) =
-
     // hook callback list
     let _codeHooks = new List<(CodeHook * (UIntPtr * Object * Object))>()
     let _blockHooks = new List<(BlockHook * (UIntPtr * Object * Object))>()
@@ -71,6 +70,9 @@ and Unicorn(arch: Int32, mode: Int32, binding: IBinding) =
         mem.ToPointer()
 
     do
+        if OperatingSystem.IsWindows() then
+            WinNativeImport.CheckCFG();
+            
         // initialize event list
         _eventMemMap
         |> Seq.map(fun kv -> kv.Key)

--- a/bindings/dotnet/UnicornEngine/UnicornEngine.fsproj
+++ b/bindings/dotnet/UnicornEngine/UnicornEngine.fsproj
@@ -10,6 +10,7 @@
     <ProjectGuid>0c21f1c1-2725-4a46-9022-1905f85822a5</ProjectGuid>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+	<OtherFlags>--standalone</OtherFlags>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -21,6 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="WinNativeImport.fs" />
     <Compile Include="Const\Arm.fs" />
     <Compile Include="Const\Arm64.fs" />
     <Compile Include="Const\Common.fs" />

--- a/bindings/dotnet/UnicornEngine/WinNativeImport.fs
+++ b/bindings/dotnet/UnicornEngine/WinNativeImport.fs
@@ -1,0 +1,17 @@
+﻿namespace UnicornEngine
+
+open System
+open System.Runtime.InteropServices
+
+module private WinNativeImport =
+    module private Imports =
+        [<DllImport("kernel32.dll")>] extern bool GetProcessMitigationPolicy(IntPtr hProcess, uint32 MitigationPolicy, uint32& Buffer, UIntPtr Length)
+
+     let public CheckCFG() =
+        let CurrentProcess = IntPtr(-1)
+        let CFGFlag = 7u
+        let mutable Flags = 0u
+        let BufferSize = UIntPtr(uint32 sizeof<uint32>)
+        if Imports.GetProcessMitigationPolicy(CurrentProcess, CFGFlag, &Flags, BufferSize) then
+            if (Flags &&& 0x1u) <> 0u then
+                raise <| ApplicationException("Control Flow Guard (CFG) is enabled. Unicorn cannot run with CFG enabled.")


### PR DESCRIPTION
Added code for CFG check (windows) for the .NET binding since unicorn doesn't support CFG. and added the standalone flag to make it easier to build and work with the library.