### PR TITLE
Correctly restore skip_sync_pc_on_exit

### DIFF
--- a/qemu/accel/tcg/tcg-runtime.c
+++ b/qemu/accel/tcg/tcg-runtime.c
@@ -179,9 +179,9 @@ void HELPER(check_exit_request)(void *p, uint32_t in_delay_slot) {
         uc->cpu->tcg_exit_req = 0;
 
         if (uc->skip_sync_pc_on_exit) {
+            uc->skip_sync_pc_on_exit = false;
             cpu_loop_exit(uc->cpu);
         } else {
-            uc->skip_sync_pc_on_exit = false;
             cpu_loop_exit_restore(uc->cpu, GETPC());
         }
     }


### PR DESCRIPTION
Currently, once users have modified PC register via `uc_reg_write`, [this line](https://github.com/unicorn-engine/unicorn/blob/cad506442abf4cfeec2f7cbda5bd7a2f57bf9b78/uc.c#L711) will modify `uc->skip_sync_pc_on_exit` to be true. However, this value is never restored to false due to a typo in `qemu/accel/tcg/tcg-runtime.c`.

With this value being `true`, all followed memory hooks introduced in [this commit](https://github.com/unicorn-engine/unicorn/commit/b999f507b984930dec9e994e26f7c91c36a42a07) are never syncing PC, thus leading to wrong PC value got in memory hooks.

However, I'm sorry that I could not give a minimal reproducing example, since the testcase I used is far too large and complicated. Anyway, the typo is apparent and I think this patch should work.