### PR TITLE
Added CFG check and standalone flag for .NET binding

### DIFF
--- a/bindings/dotnet/UnicornEngine/Unicorn.fs
+++ b/bindings/dotnet/UnicornEngine/Unicorn.fs
@@ -71,6 +71,10 @@ and Unicorn(arch: Int32, mode: Int32, binding: IBinding) =
         mem.ToPointer()
 
     do
+        // check for cfg
+        if OperatingSystem.IsWindows() then
+            WinNativeImport.CheckCFG();
+
         // initialize event list
         _eventMemMap
         |> Seq.map(fun kv -> kv.Key)

--- a/bindings/dotnet/UnicornEngine/UnicornEngine.fsproj
+++ b/bindings/dotnet/UnicornEngine/UnicornEngine.fsproj
@@ -10,6 +10,7 @@
     <ProjectGuid>0c21f1c1-2725-4a46-9022-1905f85822a5</ProjectGuid>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+	<OtherFlags>--standalone</OtherFlags>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -21,6 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="WinNativeImport.fs" />
     <Compile Include="Const\Arm.fs" />
     <Compile Include="Const\Arm64.fs" />
     <Compile Include="Const\Common.fs" />

--- a/bindings/dotnet/UnicornEngine/WinNativeImport.fs
+++ b/bindings/dotnet/UnicornEngine/WinNativeImport.fs
@@ -1,0 +1,17 @@
+﻿namespace UnicornEngine
+
+open System
+open System.Runtime.InteropServices
+
+module private WinNativeImport =
+    module private Imports =
+        [<DllImport("kernel32.dll")>] extern bool GetProcessMitigationPolicy(IntPtr hProcess, uint32 MitigationPolicy, uint32& Buffer, UIntPtr Length)
+
+     let public CheckCFG() =
+        let CurrentProcess = IntPtr(-1)
+        let CFGFlag = 7u
+        let mutable Flags = 0u
+        let BufferSize = UIntPtr(uint32 sizeof<uint32>)
+        if Imports.GetProcessMitigationPolicy(CurrentProcess, CFGFlag, &Flags, BufferSize) then
+            if (Flags &&& 0x1u) <> 0u then
+                raise <| ApplicationException("Control Flow Guard (CFG) is enabled. Unicorn cannot run with CFG enabled.")


### PR DESCRIPTION
Added CFG check on instance creation since unicorn doesn't support it and added "--standalone" flag to make it easier to work with the library.