### PR TITLE
Shall we not check stop_request in hook loops?

### DIFF
--- a/qemu/accel/tcg/cputlb.c
+++ b/qemu/accel/tcg/cputlb.c
@@ -1529,10 +1529,6 @@ load_helper(CPUArchState *env, target_ulong addr, TCGMemOpIdx oi,
                                            ((uc_cb_eventmem_t)hook->callback)(uc, UC_MEM_FETCH_UNMAPPED, paddr, size, 0, hook->user_data));
                     if (handled)
                         break;
-
-                    // the last callback may already asked to stop emulation
-                    if (uc->stop_request)
-                        break;
                 }
             } else {
                 // data reading
@@ -1549,10 +1545,6 @@ load_helper(CPUArchState *env, target_ulong addr, TCGMemOpIdx oi,
                     JIT_CALLBACK_GUARD_VAR(handled, 
                                            ((uc_cb_eventmem_t)hook->callback)(uc, UC_MEM_READ_UNMAPPED, paddr, size, 0, hook->user_data));
                     if (handled)
-                        break;
-
-                    // the last callback may already asked to stop emulation
-                    if (uc->stop_request)
                         break;
                 }
             }
@@ -1615,9 +1607,6 @@ load_helper(CPUArchState *env, target_ulong addr, TCGMemOpIdx oi,
                 synced = true;
             }
             JIT_CALLBACK_GUARD(((uc_cb_hookmem_t)hook->callback)(env->uc, UC_MEM_READ, paddr, size, 0, hook->user_data));
-            // the last callback may already asked to stop emulation
-            if (uc->stop_request)
-                break;
         }
 
         /* Unicorn: Previous callbacks may invalidate TLB, reload everything.
@@ -1649,10 +1638,6 @@ load_helper(CPUArchState *env, target_ulong addr, TCGMemOpIdx oi,
                 JIT_CALLBACK_GUARD_VAR(handled, 
                                        ((uc_cb_eventmem_t)hook->callback)(uc, UC_MEM_READ_PROT, paddr, size, 0, hook->user_data));
                 if (handled)
-                    break;
-
-                // the last callback may already asked to stop emulation
-                if (uc->stop_request)
                     break;
             }
 
@@ -1699,10 +1684,6 @@ load_helper(CPUArchState *env, target_ulong addr, TCGMemOpIdx oi,
                 JIT_CALLBACK_GUARD_VAR(handled,
                                        ((uc_cb_eventmem_t)hook->callback)(uc, UC_MEM_FETCH_PROT, paddr, size, 0, hook->user_data));
                 if (handled)
-                    break;
-
-                // the last callback may already asked to stop emulation
-                if (uc->stop_request)
                     break;
             }
 
@@ -1811,9 +1792,6 @@ _out:
                     synced = true;
                 }
                 JIT_CALLBACK_GUARD(((uc_cb_hookmem_t)hook->callback)(env->uc, UC_MEM_READ_AFTER, paddr, size, res, hook->user_data));
-                // the last callback may already asked to stop emulation
-                if (uc->stop_request)
-                    break;
             }
         }
     }
@@ -2159,9 +2137,6 @@ store_helper(CPUArchState *env, target_ulong addr, uint64_t val,
                 synced = true;
             }
             JIT_CALLBACK_GUARD(((uc_cb_hookmem_t)hook->callback)(uc, UC_MEM_WRITE, paddr, size, val, hook->user_data));
-            // the last callback may already asked to stop emulation
-            if (uc->stop_request)
-                break;
         }
     }
 
@@ -2180,10 +2155,6 @@ store_helper(CPUArchState *env, target_ulong addr, uint64_t val,
             JIT_CALLBACK_GUARD_VAR(handled,
                                    ((uc_cb_eventmem_t)hook->callback)(uc, UC_MEM_WRITE_UNMAPPED, paddr, size, val, hook->user_data));
             if (handled)
-                break;
-
-            // the last callback may already asked to stop emulation
-            if (uc->stop_request)
                 break;
         }
 
@@ -2233,10 +2204,6 @@ store_helper(CPUArchState *env, target_ulong addr, uint64_t val,
             JIT_CALLBACK_GUARD_VAR(handled,
                                    ((uc_cb_eventmem_t)hook->callback)(uc, UC_MEM_WRITE_PROT, paddr, size, val, hook->user_data));
             if (handled)
-                break;
-
-            // the last callback may already asked to stop emulation
-            if (uc->stop_request)
                 break;
         }
 

--- a/qemu/target/i386/misc_helper.c
+++ b/qemu/target/i386/misc_helper.c
@@ -130,10 +130,6 @@ void helper_cpuid(CPUX86State *env)
             }
             JIT_CALLBACK_GUARD_VAR(skip_cpuid, ((uc_cb_insn_cpuid_t)hook->callback)(env->uc, hook->user_data));
         }
-
-        // the last callback may already asked to stop emulation
-        if (env->uc->stop_request)
-            break;
     }
 
     if (!skip_cpuid) {
@@ -242,10 +238,6 @@ void helper_rdtsc(CPUX86State *env)
             }
             JIT_CALLBACK_GUARD_VAR(skip_rdtsc, ((uc_cb_insn_cpuid_t)hook->callback)(env->uc, hook->user_data));
         }
-
-        // the last callback may already asked to stop emulation
-        if (env->uc->stop_request)
-            break;
     }
 
     if (!skip_rdtsc) {
@@ -286,10 +278,6 @@ void helper_rdtscp(CPUX86State *env)
             }
             JIT_CALLBACK_GUARD_VAR(skip_rdtscp, ((uc_cb_insn_cpuid_t)hook->callback)(env->uc, hook->user_data));
         }
-
-        // the last callback may already asked to stop emulation
-        if (env->uc->stop_request)
-            break;
     }
 
     if (!skip_rdtscp) {

--- a/qemu/target/i386/seg_helper.c
+++ b/qemu/target/i386/seg_helper.c
@@ -990,10 +990,6 @@ void helper_syscall(CPUX86State *env, int next_eip_addend)
             }
             JIT_CALLBACK_GUARD(((uc_cb_insn_syscall_t)hook->callback)(env->uc, hook->user_data));
         }
-
-        // the last callback may already asked to stop emulation
-        if (env->uc->stop_request)
-            break;
     }
 
     env->eip += next_eip_addend;
@@ -2374,10 +2370,6 @@ void helper_sysenter(CPUX86State *env, int next_eip_addend)
             }
             JIT_CALLBACK_GUARD(((uc_cb_insn_syscall_t)hook->callback)(env->uc, hook->user_data));
         }
-
-        // the last callback may already asked to stop emulation
-        if (env->uc->stop_request)
-            break;
     }
 
     env->eip += next_eip_addend;


### PR DESCRIPTION
`uc->stop_request` is set by `uc_emu_stop()`. Currently, there is a check for this flag in hook loops: if the flag is true after a hook, then the loop is break out. This behavior is undocumented, and to be more specific, the behavior is:

If user called `uc_emu_stop()` in a hook callback, then:

* The following callbacks with the same type at the same moment will be skipped
* For instructions executed later until the TB end, all types of hook will only execute the first callback.

This behavior is strange, and makes users lose control of instructions executed before TB ends.

Since users have called emu stop, and a TB will not be so large, not checking the `stop_request` may not involve much overhead?