### PR TITLE
fix incorrect ret of trampoline `closure` in `alloc_code_gen_buffer`

### DIFF
--- a/qemu/accel/tcg/translate-all.c
+++ b/qemu/accel/tcg/translate-all.c
@@ -980,8 +980,8 @@ static inline void *alloc_code_gen_buffer(struct uc_struct *uc)
 
     // mov edx, [ecx] ; restore edx
     // mov ecx, [ecx+4] ; restore ecx
-    // ret
-    const char tramp2[] = "\x8b\x11\x8b\x49\x04\xc3";
+    // ret 4
+    const char tramp2[] = "\x8b\x11\x8b\x49\x04\xc2\x04\x00";
     memcpy(ptr, (void*)tramp2, sizeof(tramp2) - 1);
 
     memcpy(data + 0x8,  (void*)&uc, 4);


### PR DESCRIPTION
In x86 windows (NOT x64), the second argument of `AddVectoredExceptionHandler` is a function pointer that uses stdcall calling conv:

```c
// from winnt.h
#define NTAPI __stdcall
...
...
typedef LONG (NTAPI *PVECTORED_EXCEPTION_HANDLER)(
    struct _EXCEPTION_POINTERS *ExceptionInfo
    );
```

The trampoline `closure`, which is passed to `AddVectoredExceptionHandler`, is responsible to clean up args on stack. So the last instruction of `closure` should be `ret 4` instead of just `ret`, otherwise it would cause stack unbalance and you may get crash randomly.
