### PR TITLE
Drop stdbool

### DIFF
--- a/include/unicorn/platform.h
+++ b/include/unicorn/platform.h
@@ -50,8 +50,13 @@ typedef unsigned char bool;
 #endif // (_MSC_VER < MSC_VER_VS2013) || defined(_KERNEL_MODE)
 
 #else
-// not MSVC -> C99 is supported
+#if __STDC_VERSION__ >= 199901L
+// C99 is supported
 #include <stdbool.h>
+#else
+typedef unsigned char bool;
+#define false 0
+#define true 1
 #endif // !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
        // && (defined (WIN32) || defined (WIN64) || defined (_WIN32) || defined
        // (_WIN64))

--- a/include/unicorn/platform.h
+++ b/include/unicorn/platform.h
@@ -50,7 +50,8 @@ typedef unsigned char bool;
 #endif // (_MSC_VER < MSC_VER_VS2013) || defined(_KERNEL_MODE)
 
 #else
-#if __STDC_VERSION__ >= 199901L
+// Clang 5 doesn't have stdbool.h in manylinux image
+#if __STDC_VERSION__ >= 199901L && __clang_major__ > 5
 // C99 is supported
 #include <stdbool.h>
 #else

--- a/include/unicorn/platform.h
+++ b/include/unicorn/platform.h
@@ -57,6 +57,7 @@ typedef unsigned char bool;
 typedef unsigned char bool;
 #define false 0
 #define true 1
+#endif // __STDC_VERSION__
 #endif // !defined(__CYGWIN__) && !defined(__MINGW32__) && !defined(__MINGW64__)
        // && (defined (WIN32) || defined (WIN64) || defined (_WIN32) || defined
        // (_WIN64))


### PR DESCRIPTION
This allows unicorn-engine-sys to build in manylinux image, which only has libclang7.