### PR TITLE
Update to zig 0.14.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ rust_build
 [Oo]bj/
 packages/
 cmocka/
+.zig-cache/
 zig-cache/
 zig-out/
 .cache

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,11 @@
 .{
-    .name = "unicorn",
+    .name = .unicorn,
     .version = "2.1.3",
-    .paths = .{""},
+    .fingerprint = 0x58fbd83f9276a14b, // Changing this has security and trust implications.
+    .minimum_zig_version = "0.14.0",
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "bindings/",
+    },
 }


### PR DESCRIPTION
I have just edited build.zig.zon,
and added .zig-cache to .gitignore

Discussion:
if you have unicorn installed system wide and tried to build the project, it will
panic about not finding the unicorn/build dir.

if you haven't unicorn installed system wide it will panic about not finding the unicorn library instead of building it


its seems that you could force it to build by running `zig build cmake`
but it will error with 
```shell
error: unsupported linker arg: --dependency-file=CMakeFiles/unicorn.dir/link.d
```

I prefer dropping down cmake and use the zig build system it seems that someone have ported unicorn to it. [here](https://github.com/vesim987/unizorn/blob/master/build.zig)