### PR TITLE
Remove ninja installation from macos runners

### DIFF
--- a/.github/workflows/Crate-publishing.yml
+++ b/.github/workflows/Crate-publishing.yml
@@ -47,12 +47,6 @@ jobs:
         run: |
           choco install ninja
 
-      - name: "🛠️ macOS build dependencies"
-        if: contains(matrix.config.os, 'macOS')
-        shell: bash
-        run: |
-          brew install ninja
-
       - name: "🚧 Cargo test"
         if: "!startsWith(github.ref, 'refs/tags')"
         run: |

--- a/.github/workflows/Nuget-publishing.yml
+++ b/.github/workflows/Nuget-publishing.yml
@@ -159,7 +159,6 @@ jobs:
         if: contains(matrix.config.name, 'macos-x64')
         shell: bash
         run: |
-          brew install ninja
           ninja --version
           cmake --version
           mkdir build

--- a/.github/workflows/build-uc2.yml
+++ b/.github/workflows/build-uc2.yml
@@ -294,7 +294,6 @@ jobs:
         if: contains(matrix.config.name, 'macos')
         shell: bash
         run: |
-          brew install ninja
           ninja --version
           cmake --version
           mkdir build
@@ -314,7 +313,6 @@ jobs:
         if: contains(matrix.config.name, 'android')
         shell: bash
         run: |
-          brew install ninja
           mkdir build
           mkdir instdir
           cmake . -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake" \


### PR DESCRIPTION
Remove the following warning in GitHub Actions with macOS runners:

> ninja 1.13.1 is already installed and up-to-date. To reinstall 1.13.1, run: brew reinstall ninja 