### PR TITLE
Fix `read_sprr_perm` for Apple real CPUs and GitHub Actions; enable Apple ARM64 wheel builds on PyPI. Fixes #2033.

### DIFF
--- a/.github/workflows/build-wheels-publish.yml
+++ b/.github/workflows/build-wheels-publish.yml
@@ -158,10 +158,7 @@ jobs:
           python2 -m pip install capstone==4.0.2 wheelhouse/*py2*.whl
           python2 -m unittest discover tests/regress "*.py"
 
-      # https://github.com/unicorn-engine/unicorn/issues/2033
-      # Skip macos arm64 wheels during release stage
       - uses: actions/upload-artifact@v4
-        if: ${{!( startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/tags/v') && contains(matrix.os, 'macos') && contains(matrix.arch, 'arm64') )}}
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ./wheelhouse/*.whl
@@ -281,7 +278,6 @@ jobs:
           output-dir: wheelhouse
 
       - uses: actions/upload-artifact@v4
-        if: ${{!( startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/tags/v') && contains(matrix.os, 'macos') && contains(matrix.arch, 'arm64') )}}
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ./wheelhouse/*.whl

--- a/qemu/configure
+++ b/qemu/configure
@@ -2152,38 +2152,12 @@ fi
 if [ "$darwin" = "yes" ] ; then
   cat > $TMPC << EOF
 #include <pthread.h>
-int main() { pthread_jit_write_protect_np(0); return 0;}
+int main() { pthread_jit_write_protect_supported_np(); return 0;}
 EOF
   if ! compile_prog ""; then
     have_pthread_jit_protect='no'
   else
     have_pthread_jit_protect='yes'
-  fi
-
-  if test "$have_pthread_jit_protect" = "yes" ; then
-    cat > $TMPC << EOF
-#include "stdint.h"
-int main() {
-    uint64_t v;
-
-    __asm__ __volatile__("isb sy\n"
-                          "mrs %0, S3_6_c15_c1_5\n"
-                          : "=r"(v)::"memory");
-    // In Apple Hypervisor virtualized environment (EL1), this value is not accessbile
-    // but pthread_jit_write_protect_np essentially is a no-op.
-    return 0;
-}
-EOF
-    if ! compile_prog ""; then
-      have_sprr_mrs='no'
-    else
-      $TMPE
-      if [ $? -eq 0 ]; then
-        have_sprr_mrs='yes'
-      else
-        have_sprr_mrs='no'
-      fi
-    fi
   fi
 fi
 
@@ -2563,10 +2537,6 @@ fi
 
 if test "$have_pthread_jit_protect" = "yes" ; then
   echo "HAVE_PTHREAD_JIT_PROTECT=y" >> $config_host_mak
-fi
-
-if test "$have_sprr_mrs" = "yes" ; then
-  echo "HAVE_SPRR_MRS=y" >> $config_host_mak
 fi
 
 # Hold two types of flag:

--- a/qemu/include/tcg/tcg-apple-jit.h
+++ b/qemu/include/tcg/tcg-apple-jit.h
@@ -39,10 +39,6 @@
 // On Github Action (Virtualized environment), this shall always returns 0
 static inline uint64_t read_sprr_perm(void)
 {
-    if (!pthread_jit_write_protect_supported_np()) {
-        return 0;
-    }
-
     uint64_t v;
     __asm__ __volatile__("isb sy\n"
                          "mrs %0, S3_6_c15_c1_5\n"
@@ -52,6 +48,9 @@ static inline uint64_t read_sprr_perm(void)
 
 QEMU_UNUSED_FUNC static inline uint8_t thread_mask() 
 {
+    if (!pthread_jit_write_protect_supported_np()) {
+        return 0;
+    }
     uint64_t v = read_sprr_perm();
 
     if (v == 0) {
@@ -72,6 +71,9 @@ QEMU_UNUSED_FUNC static inline bool thread_executable()
 }
 
 static inline void assert_executable(bool executable) {
+    if (!pthread_jit_write_protect_supported_np()) {
+        return;
+    }
     uint64_t v = read_sprr_perm();
 
     if (!v) {

--- a/qemu/include/tcg/tcg-apple-jit.h
+++ b/qemu/include/tcg/tcg-apple-jit.h
@@ -30,28 +30,25 @@
 #include "stdbool.h"
 #include "qemu/compiler.h"
 
+#if defined(__APPLE__) && defined(HAVE_PTHREAD_JIT_PROTECT) && (defined(__arm__) || defined(__aarch64__))
+
 // Returns the S3_6_c15_c1_5 register's value
-// Taken from 
+// Taken from
 // https://stackoverflow.com/questions/70019553/lldb-how-to-read-the-permissions-of-a-memory-region-for-a-thread
 // https://blog.svenpeter.dev/posts/m1_sprr_gxf/
 // On Github Action (Virtualized environment), this shall always returns 0
-#if defined(HAVE_SPRR_MRS)
 static inline uint64_t read_sprr_perm(void)
 {
+    if (!pthread_jit_write_protect_supported_np()) {
+        return 0;
+    }
+
     uint64_t v;
     __asm__ __volatile__("isb sy\n"
                          "mrs %0, S3_6_c15_c1_5\n"
                          : "=r"(v)::"memory");
     return v;
 }
-#else
-static inline uint64_t read_sprr_perm(void)
-{
-    return 0;
-}
-#endif
-
-#if defined(__APPLE__) && defined(HAVE_SPRR_MRS) && defined(HAVE_PTHREAD_JIT_PROTECT) && (defined(__arm__) || defined(__aarch64__))
 
 QEMU_UNUSED_FUNC static inline uint8_t thread_mask() 
 {


### PR DESCRIPTION
The `read_sprr_perm` function now correctly works both on real Apple CPUs and in GitHub Actions virtualized environments by relying on `pthread_jit_write_protect_supported_np()`.
This ensures proper detection of JIT write protection status without depending on build-time msr register check.
As a result, building wheels for Apple ARM64 should now fully work fine.

Fixes:
- #2033

More context:
In `libsystem_pthread.dylib`, the function `_pthread_jit_write_protect_np` first checks whether JIT write protection is enabled by reading from a special memory location in the commpage: `0xfffffc10c`.
The same memory location is also checked by the `_pthread_jit_write_protect_supported_np` function.

In other words, whenever Apple code wants to access the `S3_6_c15_c1_5` system register using the `mrs` instruction, it first verifies that JIT write protection is supported by calling `_pthread_jit_write_protect_supported_np()`, which ensures the system is in a valid state for that operation.


<img width="537" height="102" alt="image" src="https://github.com/user-attachments/assets/12079dd4-088e-425b-8cd0-c7790a7aa0d3" />

<img width="565" height="252" alt="image" src="https://github.com/user-attachments/assets/c11b1539-fa13-4383-b9b4-539167c3b8d3" />

