### PR TITLE
build: fix __int128_t redefinition with Clang on MSYS2

### DIFF
--- a/qemu/include/qemu/int128.h
+++ b/qemu/include/qemu/int128.h
@@ -146,7 +146,7 @@ static inline Int128 bswap128(Int128 a)
 #else /* !CONFIG_INT128 */
 
 typedef struct Int128 Int128;
-#if !(defined(_MSC_VER) && defined(__clang__))
+#if !defined(__clang__)
 typedef Int128 __int128_t;
 #endif
 


### PR DESCRIPTION
Fixes a build failure on Windows when using the MSYS2 clang64 toolchain.

The compiler already defines `__int128_t` which caused a typedef redefinition error. This PR updates the preprocessor directive in `qemu/include/qemu/int128.h` to avoid this redefinition for all Clang compilers.

```sh
 unicorn/qemu/include/qemu/int128.h:150:16: error: typedef redefinition with different types ('Int128' (aka 'struct Int128') vs '__int128')
  150 | typedef Int128 __int128_t;
      |                ^
1 error generated.
```