### PR TITLE
ARM PAC FAQ fix: Read HCR_EL2 instead of clobbering with SCTLR_EL1

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -231,6 +231,9 @@ Taken from [#1789](https://github.com/unicorn-engine/unicorn/issues/1789).
     reg.crm = 0b0001;
     reg.op2 = 0b000;
 
+    err = uc_reg_read(uc, UC_ARM64_REG_CP_REG, &reg);
+    assert(err == UC_ERR_OK);
+
     // HCR.API
     reg.val |= (1ULL<<41);
 


### PR DESCRIPTION
The sample code for setting up PAC is missing the read register call for `HCR_EL2`.  This leads to clobbering `HCR_EL2` with whatever the bits in `SCTLR_EL1` were.

Fix by adding the missing register read call.