### PR TITLE
Add basic unit test coverage for ARM64 PAuth

### DIFF
--- a/tests/unit/test_arm64.c
+++ b/tests/unit/test_arm64.c
@@ -695,6 +695,109 @@ static void test_arm64_pc_guarantee(void)
     OK(uc_close(uc));
 }
 
+static uint64_t test_arm64_pauth_cp_reg_read(uc_engine *uc, const uint32_t cpregid[5])
+{
+    uc_arm64_cp_reg reg = {
+        .op0 = cpregid[0],
+        .op1 = cpregid[1],
+        .crn = cpregid[2],
+        .crm = cpregid[3],
+        .op2 = cpregid[4],
+        .val = 0,
+    };
+    OK(uc_reg_read(uc, UC_ARM64_REG_CP_REG, &reg));
+    return reg.val;
+}
+
+static void test_arm64_pauth_cp_reg_write(uc_engine *uc, const uint32_t cpregid[5], uint64_t value)
+{
+    uc_arm64_cp_reg reg = {
+        .op0 = cpregid[0],
+        .op1 = cpregid[1],
+        .crn = cpregid[2],
+        .crm = cpregid[3],
+        .op2 = cpregid[4],
+        .val = value,
+    };
+    OK(uc_reg_write(uc, UC_ARM64_REG_CP_REG, &reg));
+}
+
+static bool test_arm64_pauth_cp_reg_update(uc_engine *uc, const uint32_t cpregid[5], uint64_t clearmask, uint64_t setmask)
+{
+    uc_arm64_cp_reg reg = {
+        .op0 = cpregid[0],
+        .op1 = cpregid[1],
+        .crn = cpregid[2],
+        .crm = cpregid[3],
+        .op2 = cpregid[4],
+        .val = 0,
+    };
+    OK(uc_reg_read(uc, UC_ARM64_REG_CP_REG, &reg));
+    reg.val &= ~clearmask;
+    reg.val |= setmask;
+    OK(uc_reg_write(uc, UC_ARM64_REG_CP_REG, &reg));
+    OK(uc_reg_read(uc, UC_ARM64_REG_CP_REG, &reg));
+    return (((reg.val & setmask) == setmask) && ((reg.val & clearmask) == 0));
+}
+
+static void test_arm64_pauth(void)
+{
+    uc_engine *uc;
+    const char code_paciza_x1[] = "\xe1\x23\xc1\xda"; // paciza x1
+
+    // We expect a PAC added somewhere in pac_mask bits in order to make the
+    // test agnostic of TxSZ and TBI.
+
+    const uint64_t some_unsigned_pointer = 0x0000aaaabbbbccccULL;
+    const uint64_t pac_mask = 0xffff000000000000ULL & ~(1ULL << 55);
+
+    OK(uc_open(UC_ARCH_ARM64, UC_MODE_ARM, &uc));
+    OK(uc_ctl_set_cpu_model(uc, UC_CPU_ARM64_MAX));
+
+    // Check the CPU actually supports any form of PAuth, i.e. any APA or API
+    // bits are set.  At the time of writing, UC_CPU_ARM64_A72 does not support
+    // PAuth, but UC_CPU_ARM64_MAX does.  This is not required for the test,
+    // but helps with diagnostics when the selected CPU does not support PAuth.
+
+    const uint32_t ID_AA64ISAR1_EL1[5] = { 0b11, 0b000, 0b0000, 0b0110, 0b001 };
+    const uint64_t ID_AA64ISAR1_EL1_APA_API_MASK = (0b1111ULL << 4) | (0b1111ULL << 8);
+    uint64_t ID_AA64ISAR1_EL1_bits = test_arm64_pauth_cp_reg_read(uc, ID_AA64ISAR1_EL1);
+    TEST_CHECK((ID_AA64ISAR1_EL1_bits & ID_AA64ISAR1_EL1_APA_API_MASK) != 0);
+
+    // Minimal PAuth setup, enabling only IA and IB.  The test is agnostic to
+    // VA size and MTE config, so don't bother touching TCR_EL1 for now.
+
+    const uint32_t SCR_EL3[5] = { 0b11, 0b110, 0b0001, 0b0001, 0b000 };
+    const uint64_t SCR_EL3_NS_RW_API = 1ULL | (1ULL << 10) | (1ULL << 17);
+    TEST_CHECK(test_arm64_pauth_cp_reg_update(uc, SCR_EL3, 0, SCR_EL3_NS_RW_API));
+
+    const uint32_t HCR_EL2[5] = { 0b11, 0b100, 0b0001, 0b0001, 0b000 };
+    const uint64_t HCR_EL2_API = 1ULL << 41;
+    TEST_CHECK(test_arm64_pauth_cp_reg_update(uc, HCR_EL2, 0, HCR_EL2_API));
+
+    const uint32_t SCTLR_EL1[5] = { 0b11, 0b000, 0b0001, 0b0000, 0b000 };
+    const uint64_t SCTLR_EL1_EnIA_EnIB = (1ULL << 31) | (1ULL << 30);
+    TEST_CHECK(test_arm64_pauth_cp_reg_update(uc, SCTLR_EL1, 0, SCTLR_EL1_EnIA_EnIB));
+
+    const uint32_t APIAKeyLo_EL1[5] = { 0b11, 0b000, 0b0010, 0b0001, 0b000 };
+    const uint32_t APIAKeyHi_EL1[5] = { 0b11, 0b000, 0b0010, 0b0001, 0b001 };
+    test_arm64_pauth_cp_reg_write(uc, APIAKeyLo_EL1, 0xAAAAAAAAAAAAAAAAULL);
+    test_arm64_pauth_cp_reg_write(uc, APIAKeyHi_EL1, 0xBBBBBBBBBBBBBBBBULL);
+
+    // Verify that paciza signs a pointer.
+
+    uint64_t x1 = some_unsigned_pointer;
+    OK(uc_mem_map(uc, code_start, code_len, UC_PROT_ALL));
+    OK(uc_mem_write(uc, code_start, code_paciza_x1, sizeof(code_paciza_x1)));
+    OK(uc_reg_write(uc, UC_ARM64_REG_X1, &x1));
+    OK(uc_emu_start(uc, code_start, code_start + sizeof(code_paciza_x1) - 1, 0, 0));
+    OK(uc_reg_read(uc, UC_ARM64_REG_X1, &x1));
+    TEST_CHECK(x1 != some_unsigned_pointer);
+    TEST_CHECK((x1 & pac_mask) != 0);
+
+    OK(uc_close(uc));
+}
+
 TEST_LIST = {{"test_arm64_until", test_arm64_until},
              {"test_arm64_code_patching", test_arm64_code_patching},
              {"test_arm64_code_patching_count", test_arm64_code_patching_count},
@@ -714,4 +817,5 @@ TEST_LIST = {{"test_arm64_until", test_arm64_until},
              {"test_arm64_mem_prot_regress", test_arm64_mem_prot_regress},
              {"test_arm64_mem_hook_read_write", test_arm64_mem_hook_read_write},
              {"test_arm64_pc_guarantee", test_arm64_pc_guarantee},
+             {"test_arm64_pauth", test_arm64_pauth},
              {NULL, NULL}};

--- a/tests/unit/test_arm64.c
+++ b/tests/unit/test_arm64.c
@@ -744,6 +744,11 @@ static void test_arm64_pauth(void)
 {
     uc_engine *uc;
     const char code_paciza_x1[] = "\xe1\x23\xc1\xda"; // paciza x1
+    const char code_autiza_x1[] = "\xe1\x33\xc1\xda"; // autiza x1
+    const char code_autizb_x1[] = "\xe1\x37\xc1\xda"; // autizb x1
+    const char code_autdza_x1[] = "\xe1\x3b\xc1\xda"; // autdza x1
+    const char code_autia_x1_x0[] = "\x01\x10\xc1\xda"; // autia x1, x0
+    const char code_xpaci_x1[] = "\xe1\x43\xc1\xda"; // xpaci x1
 
     // We expect a PAC added somewhere in pac_mask bits in order to make the
     // test agnostic of TxSZ and TBI.
@@ -753,6 +758,7 @@ static void test_arm64_pauth(void)
 
     OK(uc_open(UC_ARCH_ARM64, UC_MODE_ARM, &uc));
     OK(uc_ctl_set_cpu_model(uc, UC_CPU_ARM64_MAX));
+    OK(uc_mem_map(uc, code_start, code_len, UC_PROT_ALL));
 
     // Check the CPU actually supports any form of PAuth, i.e. any APA or API
     // bits are set.  At the time of writing, UC_CPU_ARM64_A72 does not support
@@ -781,19 +787,73 @@ static void test_arm64_pauth(void)
 
     const uint32_t APIAKeyLo_EL1[5] = { 0b11, 0b000, 0b0010, 0b0001, 0b000 };
     const uint32_t APIAKeyHi_EL1[5] = { 0b11, 0b000, 0b0010, 0b0001, 0b001 };
+    const uint32_t APIBKeyLo_EL1[5] = { 0b11, 0b000, 0b0010, 0b0001, 0b010 };
+    const uint32_t APIBKeyHi_EL1[5] = { 0b11, 0b000, 0b0010, 0b0001, 0b011 };
+    const uint32_t APDAKeyLo_EL1[5] = { 0b11, 0b000, 0b0010, 0b0010, 0b000 };
+    const uint32_t APDAKeyHi_EL1[5] = { 0b11, 0b000, 0b0010, 0b0010, 0b001 };
     test_arm64_pauth_cp_reg_write(uc, APIAKeyLo_EL1, 0xAAAAAAAAAAAAAAAAULL);
     test_arm64_pauth_cp_reg_write(uc, APIAKeyHi_EL1, 0xBBBBBBBBBBBBBBBBULL);
+    test_arm64_pauth_cp_reg_write(uc, APIBKeyLo_EL1, 0xCCCCCCCCCCCCCCCCULL); // != IA
+    test_arm64_pauth_cp_reg_write(uc, APIBKeyHi_EL1, 0xDDDDDDDDDDDDDDDDULL);
+    test_arm64_pauth_cp_reg_write(uc, APDAKeyLo_EL1, 0xAAAAAAAAAAAAAAAAULL); // == IA
+    test_arm64_pauth_cp_reg_write(uc, APDAKeyHi_EL1, 0xBBBBBBBBBBBBBBBBULL);
 
     // Verify that paciza signs a pointer.
 
-    uint64_t x1 = some_unsigned_pointer;
-    OK(uc_mem_map(uc, code_start, code_len, UC_PROT_ALL));
     OK(uc_mem_write(uc, code_start, code_paciza_x1, sizeof(code_paciza_x1)));
-    OK(uc_reg_write(uc, UC_ARM64_REG_X1, &x1));
+    OK(uc_reg_write(uc, UC_ARM64_REG_X1, &some_unsigned_pointer));
     OK(uc_emu_start(uc, code_start, code_start + sizeof(code_paciza_x1) - 1, 0, 0));
+    uint64_t signed_pointer = 0;
+    OK(uc_reg_read(uc, UC_ARM64_REG_X1, &signed_pointer));
+    TEST_CHECK(signed_pointer != some_unsigned_pointer);
+    TEST_CHECK((signed_pointer & pac_mask) != 0);
+
+    // Verify that xpaci results in original pointer.
+
+    OK(uc_mem_write(uc, code_start, code_xpaci_x1, sizeof(code_xpaci_x1)));
+    OK(uc_emu_start(uc, code_start, code_start + sizeof(code_xpaci_x1) - 1, 0, 0));
+    uint64_t stripped_pointer = 0;
+    OK(uc_reg_read(uc, UC_ARM64_REG_X1, &stripped_pointer));
+    TEST_CHECK(stripped_pointer == some_unsigned_pointer);
+
+    // Verify autia behaviour
+
+    uint64_t x0 = 1337;
+    uint64_t x1 = 0;
+    OK(uc_mem_write(uc, code_start, code_autiza_x1, sizeof(code_autiza_x1)));
+    OK(uc_reg_write(uc, UC_ARM64_REG_X1, &some_unsigned_pointer));
+    OK(uc_emu_start(uc, code_start, code_start + sizeof(code_autiza_x1) - 1, 0, 0));
     OK(uc_reg_read(uc, UC_ARM64_REG_X1, &x1));
-    TEST_CHECK(x1 != some_unsigned_pointer);
-    TEST_CHECK((x1 & pac_mask) != 0);
+    TEST_CHECK((x1 & pac_mask) != 0); // unsigned pointer is invalid
+
+    x1 = 0;
+    OK(uc_mem_write(uc, code_start, code_autiza_x1, sizeof(code_autiza_x1)));
+    OK(uc_reg_write(uc, UC_ARM64_REG_X1, &signed_pointer));
+    OK(uc_emu_start(uc, code_start, code_start + sizeof(code_autiza_x1) - 1, 0, 0));
+    OK(uc_reg_read(uc, UC_ARM64_REG_X1, &x1));
+    TEST_CHECK((x1 & pac_mask) == 0); // signed pointer is valid
+
+    x1 = 0;
+    OK(uc_mem_write(uc, code_start, code_autia_x1_x0, sizeof(code_autia_x1_x0)));
+    OK(uc_reg_write(uc, UC_ARM64_REG_X1, &signed_pointer));
+    OK(uc_reg_write(uc, UC_ARM64_REG_X0, &x0));
+    OK(uc_emu_start(uc, code_start, code_start + sizeof(code_autia_x1_x0) - 1, 0, 0));
+    OK(uc_reg_read(uc, UC_ARM64_REG_X1, &x1));
+    TEST_CHECK((x1 & pac_mask) != 0); // wrong diversifier is invalid
+
+    x1 = 0;
+    OK(uc_mem_write(uc, code_start, code_autizb_x1, sizeof(code_autizb_x1)));
+    OK(uc_reg_write(uc, UC_ARM64_REG_X1, &signed_pointer));
+    OK(uc_emu_start(uc, code_start, code_start + sizeof(code_autizb_x1) - 1, 0, 0));
+    OK(uc_reg_read(uc, UC_ARM64_REG_X1, &x1));
+    TEST_CHECK((x1 & pac_mask) != 0); // wrong but enabled key is invalid
+
+    x1 = 0;
+    OK(uc_mem_write(uc, code_start, code_autdza_x1, sizeof(code_autdza_x1)));
+    OK(uc_reg_write(uc, UC_ARM64_REG_X1, &signed_pointer));
+    OK(uc_emu_start(uc, code_start, code_start + sizeof(code_autdza_x1) - 1, 0, 0));
+    OK(uc_reg_read(uc, UC_ARM64_REG_X1, &x1));
+    TEST_CHECK((x1 & pac_mask) != 0); // disabled but same value key is invalid
 
     OK(uc_close(uc));
 }


### PR DESCRIPTION
Add unit test coverage for basic PAuth functionality.

Intended to make sure PAuth works correctly in all builds, including Windows and alpine, in order to help diagnose the unexpected test failures in #2262.