### PR TITLE
Fix JAVA binding compilation

### DIFF
--- a/bindings/java/src/test/java/tests/TestSamples.java
+++ b/bindings/java/src/test/java/tests/TestSamples.java
@@ -236,7 +236,7 @@ public class TestSamples implements UnicornConst {
                 ">>> A6 = 0x0		>>> D6 = 0x0\n" +
                 ">>> A7 = 0x0		>>> D7 = 0x0\n" +
                 ">>> PC = 0x10002\n" +
-                ">>> SR = 0x0\n",
+                ">>> SR = 0x8\n",
             outContent.toString());
     }
 

--- a/bindings/java/unicorn_Unicorn.c
+++ b/bindings/java/unicorn_Unicorn.c
@@ -760,7 +760,7 @@ JNIEXPORT void JNICALL Java_unicorn_Unicorn__1mem_1read(JNIEnv *env,
 {
     jlong size = (*env)->GetArrayLength(env, dest);
     jbyte *arr = (*env)->GetByteArrayElements(env, dest, NULL);
-    uc_err err = uc_mem_read((uc_engine *)uc, address, arr, *size);
+    uc_err err = uc_mem_read((uc_engine *)uc, address, arr, (uint64_t)size);
     (*env)->ReleaseByteArrayElements(env, dest, arr, 0);
     if (err != UC_ERR_OK) {
         throwUnicornException(env, err);


### PR DESCRIPTION
Apparently, the pointer there is a leftover from the previous implementation. Fails to build on OSX.

A side note: the Java regression test fails for the m68k engine, so another PR created #2267, SR register bug that has been fixed in #2161 and as a result the test needs fixing in turn.