### PR TITLE
arm: Add missing hflag update after writing xpsr

### DIFF
--- a/qemu/target/arm/unicorn_arm.c
+++ b/qemu/target/arm/unicorn_arm.c
@@ -154,6 +154,7 @@ static void v7m_msr_xpsr(CPUARMState *env, uint32_t mask, uint32_t reg,
     }
 
     xpsr_write(env, val, xpsrmask);
+    arm_rebuild_hflags(env);
 }
 
 static uc_err read_cp_reg(CPUARMState *env, uc_arm_cp_reg *cp)

--- a/tests/unit/test_arm.c
+++ b/tests/unit/test_arm.c
@@ -286,8 +286,8 @@ static void test_arm_m_exc_return(void)
     int r_sp = 0x8000;
     uc_hook hook;
 
-    uc_common_setup(&uc, UC_ARCH_ARM, UC_MODE_THUMB | UC_MODE_MCLASS, code,
-                    sizeof(code) - 1, UC_CPU_ARM_CORTEX_A15);
+    uc_common_setup(&uc, UC_ARCH_ARM, UC_MODE_THUMB, code,
+                    sizeof(code) - 1, UC_CPU_ARM_CORTEX_M7);
     OK(uc_mem_map(uc, r_sp - 0x1000, 0x1000, UC_PROT_ALL));
     OK(uc_hook_add(uc, &hook, UC_HOOK_INTR,
                    test_arm_m_exc_return_hook_interrupt, NULL, 0, 0));


### PR DESCRIPTION
This adds a missing hflag update after updating the xpsr.
Currently when using an Arm Cortex-M CPU, which does not feature `ARM_FEATURE_M_SECURITY`, the `EXC_RETURN` interrupt is not triggered.
After some debugging it turns out the `v7m_handler_mode` condition here is never true:
https://github.com/unicorn-engine/unicorn/blob/c24c9ebe773ce6fbecb0e39f68ffb23b7326b17f/qemu/target/arm/translate.c#L827-L830
`v7m_handler_mode` is evaluated based on the `HANDLER` flag which is set when rebuilding hflags:
https://github.com/unicorn-engine/unicorn/blob/c24c9ebe773ce6fbecb0e39f68ffb23b7326b17f/qemu/target/arm/helper.c#L11592-L11594
Since setting IPSR using `uc_reg_write` does not rebuild hflags, qemu doesn't realize that it's currently in an exception and returning from an exception causes a hard fault.
This fixes this by rebuilding hflags after updating xPSR.
This doesn't matter for processors with the security feature since the condition is always true in that case. I've updated the test to catch this.