### PR TITLE
Hooks: Add warning about ARM IT blocks with UC_HOOK_CODE

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -34,6 +34,9 @@ You might also use it to trace the execution with a disassembly, in a similar wa
 
 If you want to inject behaviour you might use this hook to modify the registers - including modifying the program counter, to jump to a different place.
 
+> [!WARNING]  
+> **ARM only:** Changes to the program counter are ignored when the callback is invoked inside an *If-Then (IT)* block.
+
 
 ## UC_HOOK_MEM_READ, UC_HOOK_MEM_WRITE, UC_HOOK_READ_MEM_AFTER
 


### PR DESCRIPTION
The `Hooks.md` currently mentions this about `UC_HOOK_CODE`:
https://github.com/unicorn-engine/unicorn/blob/c24c9ebe773ce6fbecb0e39f68ffb23b7326b17f/docs/Hooks.md?plain=1#L35

So in my application, which emulates a Cortex M7, I ended up using this hook to modify the program counter during execution.

For some reason the changes to the program counter were sometimes ignored. After a lot of debugging I stumbled across this piece of code:
https://github.com/unicorn-engine/unicorn/blob/c24c9ebe773ce6fbecb0e39f68ffb23b7326b17f/uc.c#L2153-L2160

This was the reason for the ignored PC changes in my case. I created a simple test case to reproduce this:
<details>

<summary>Expand test case</summary>

```c
static void test_arm_modify_pc_callback(uc_engine *uc, uint64_t address,
                                        uint32_t size, void *user_data)
{
    uint64_t *expected_pc = (uint64_t *)user_data;

    if (*expected_pc != 0) {
        TEST_CHECK(*expected_pc == address);
        exit(0);
    }

    // Modify PC wile in itt block
    if (address == code_start + 4) {
        uint32_t pc = code_start + 4 + 1;
        uc_reg_write(uc, UC_ARM_REG_PC, &pc);
        *expected_pc = pc - 1;
    }
}

static void test_arm_it_modify_pc(void)
{
    char code[] =
        "\x05\xbf" // ittet   eq
        "\x00\x18" // addeq   r0, r0, r0
        "\x01\x18" // addeq   r1, r0, r0
        "\x02\x18" // addne   r2, r0, r0
        "\x03\x18" // addeq   r3, r0, r0
        "\xf9\xe7" // b code_start
        "\xf8\xe7" // b code_start
        ;
    uc_engine *uc;
    uc_hook hook;
    uint64_t expected_pc = 0;

    uc_common_setup(&uc, UC_ARCH_ARM, UC_MODE_THUMB, code, sizeof(code) - 1,
                UC_CPU_ARM_CORTEX_M7);

    OK(uc_hook_add(uc, &hook, UC_HOOK_CODE, test_arm_modify_pc_callback,
                   &expected_pc, 1, 0));

    OK(uc_emu_start(uc, code_start | 1, code_start + sizeof(code) - 1, 0, 0));

    OK(uc_close(uc));
}
```
</details>

In order to avoid anyone from running into the same issue this PR adds a warning to the hooks documentation.

Some potential "fixes" I could think of:
- Allowing emulation to exit from within an IT block.
  I don't know enough about qemu/unicorn to know what is preventing it from doing that in the first place.
- Only invoking the callback once per IT block. Maybe with the size of the entire block?