### PR TITLE
read invalide address

### DIFF
--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -645,6 +645,9 @@ typedef enum uc_control_type {
     // Read/write: @args = (uint64_t ptr, int key, uint64_t diversifier,
     //                      bool *valid)
     UC_CTL_PAUTH_AUTH,
+    // read the invalid_addr after an error
+    // Read: @args = (uint64_t*)
+    UC_CTL_INVALID_ADDR,
 } uc_control_type;
 
 /*
@@ -734,6 +737,8 @@ See sample_ctl.c for a detailed example.
     uc_ctl(uc, UC_CTL_READ_WRITE(UC_CTL_PAUTH_STRIP, 3), (uint64_t)(ptr), (int)(key), (uint64_t *)(stripped_ptr))
 #define uc_ctl_pauth_auth(uc, ptr, key, diversifier, valid)                    \
     uc_ctl(uc, UC_CTL_READ_WRITE(UC_CTL_PAUTH_AUTH, 4), (uint64_t)(ptr), (int)(key), (uint64_t)(diversifier), (uint64_t *)(valid))
+#define uc_ctl_get_invalid_addr(uc, addr)                                    \
+    uc_ctl(uc, UC_CTL_READ(UC_CTL_INVALID_ADDR, 1), (addr))
 
 // Opaque storage for CPU context, used with uc_context_*()
 struct uc_context;

--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -193,7 +193,9 @@ typedef enum uc_err {
     UC_ERR_RESOURCE,        // Insufficient resource: uc_emu_start()
     UC_ERR_EXCEPTION,       // Unhandled CPU exception
     UC_ERR_OVERFLOW,        // Provided buffer is not large enough: uc_reg_*2()
-    UC_ERR_MMU_FAULT,       // The tlb_fill hook returned false (see tlb_fill hook)
+    UC_ERR_MMU_READ,        // The tlb_fill hook returned false for a read access (see tlb_fill hook)
+    UC_ERR_MMU_WRITE,       // The tlb_fill hook returned false for a write operation (see tlb_fill hook)
+    UC_ERR_MMU_FETCH,       // The tlb_fill hook returned false for a fetch (see tlb_fill hook)
 } uc_err;
 
 /*

--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -193,6 +193,7 @@ typedef enum uc_err {
     UC_ERR_RESOURCE,        // Insufficient resource: uc_emu_start()
     UC_ERR_EXCEPTION,       // Unhandled CPU exception
     UC_ERR_OVERFLOW,        // Provided buffer is not large enough: uc_reg_*2()
+    UC_ERR_MMU_FAULT,       // The tlb_fill hook returned false (see tlb_fill hook)
 } uc_err;
 
 /*

--- a/qemu/softmmu/unicorn_vtlb.c
+++ b/qemu/softmmu/unicorn_vtlb.c
@@ -9,7 +9,19 @@
 static void raise_mmu_exception(CPUState *cs, target_ulong address,
                                 int rw, uintptr_t retaddr)
 {
-    cs->uc->invalid_error = UC_ERR_MMU_FAULT;
+    switch (rw) {
+    case MMU_DATA_LOAD:
+        cs->uc->invalid_error = UC_ERR_MMU_READ;
+        break;
+    case MMU_DATA_STORE:
+        cs->uc->invalid_error = UC_ERR_MMU_WRITE;
+        break;
+    case MMU_INST_FETCH:
+        cs->uc->invalid_error = UC_ERR_MMU_FETCH;
+        break;
+    default:
+        cs->uc->invalid_error = UC_ERR_MMU_READ;
+    }
     cs->uc->invalid_addr = address;
     cpu_exit(cs->uc->cpu);
     cpu_loop_exit_restore(cs, retaddr);

--- a/qemu/softmmu/unicorn_vtlb.c
+++ b/qemu/softmmu/unicorn_vtlb.c
@@ -9,7 +9,7 @@
 static void raise_mmu_exception(CPUState *cs, target_ulong address,
                                 int rw, uintptr_t retaddr)
 {
-    cs->uc->invalid_error = UC_ERR_EXCEPTION;
+    cs->uc->invalid_error = UC_ERR_MMU_FAULT;
     cs->uc->invalid_addr = address;
     cpu_exit(cs->uc->cpu);
     cpu_loop_exit_restore(cs, retaddr);

--- a/uc.c
+++ b/uc.c
@@ -3041,6 +3041,14 @@ uc_err uc_ctl(uc_engine *uc, uc_control_type control, ...)
         restore_jit_state(uc);
         break;
     }
+    case UC_CTL_INVALID_ADDR:
+        if (rw == UC_CTL_IO_READ) {
+            uint64_t *invalid_addr = va_arg(args, uint64_t *);
+            *invalid_addr = uc->invalid_addr;
+        } else {
+            err = UC_ERR_ARG;
+        }
+        break;
 
     default:
         err = UC_ERR_ARG;

--- a/uc.c
+++ b/uc.c
@@ -191,6 +191,8 @@ const char *uc_strerror(uc_err code)
         return "Unhandled CPU exception (UC_ERR_EXCEPTION)";
     case UC_ERR_OVERFLOW:
         return "Provided buffer is too small (UC_ERR_OVERFLOW)";
+    case UC_ERR_MMU_FAULT:
+        return "The tlb_fill hook returned false (UC_ERR_MMU_FAULT)";
     }
 }
 

--- a/uc.c
+++ b/uc.c
@@ -191,8 +191,12 @@ const char *uc_strerror(uc_err code)
         return "Unhandled CPU exception (UC_ERR_EXCEPTION)";
     case UC_ERR_OVERFLOW:
         return "Provided buffer is too small (UC_ERR_OVERFLOW)";
-    case UC_ERR_MMU_FAULT:
-        return "The tlb_fill hook returned false (UC_ERR_MMU_FAULT)";
+    case UC_ERR_MMU_READ:
+        return "The tlb_fill hook returned false for a read (UC_ERR_MMU_READ)";
+    case UC_ERR_MMU_WRITE:
+        return "The tlb_fill hook returned false for a write (UC_ERR_MMU_WRITE)";
+    case UC_ERR_MMU_FETCH:
+        return "The tlb_fill hook returned false for a fetch (UC_ERR_MMU_FETCH)";
     }
 }
 


### PR DESCRIPTION
Add read access to the `invalid_addr` and use a different error code in mmu hook. This allows to handle page faults without need to extra save the address and the failure.