### PR TITLE
PPC: Re-enable timebase (TB) registers with 512MHz frequency

### DIFF
--- a/qemu/target/ppc/translate_init.inc.c
+++ b/qemu/target/ppc/translate_init.inc.c
@@ -205,7 +205,6 @@ static void spr_write_decr(DisasContext *ctx, int sprn, int gprn)
 
 /* SPR common to all non-embedded PowerPC, except 601 */
 /* Time base */
-#if 0
 static void spr_read_tbl(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
@@ -218,11 +217,7 @@ static void spr_read_tbl(DisasContext *ctx, int gprn, int sprn)
         gen_stop_exception(ctx);
     }
 }
-#else
-#define spr_read_tbl spr_read_generic
-#endif
 
-#if 0
 static void spr_read_tbu(DisasContext *ctx, int gprn, int sprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
@@ -235,9 +230,6 @@ static void spr_read_tbu(DisasContext *ctx, int gprn, int sprn)
         gen_stop_exception(ctx);
     }
 }
-#else
-#define spr_read_tbu spr_read_generic
-#endif
 
 #if 0
 // ATTRIBUTE_UNUSED
@@ -255,7 +247,6 @@ static void spr_read_atbu(DisasContext *ctx, int gprn, int sprn)
 }
 #endif
 
-#if 0
 static void spr_write_tbl(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
@@ -268,12 +259,7 @@ static void spr_write_tbl(DisasContext *ctx, int sprn, int gprn)
         gen_stop_exception(ctx);
     }
 }
-#else
-#define spr_write_tbl spr_write_generic
-#endif
 
-
-#if 0
 static void spr_write_tbu(DisasContext *ctx, int sprn, int gprn)
 {
     TCGContext *tcg_ctx = ctx->uc->tcg_ctx;
@@ -286,9 +272,6 @@ static void spr_write_tbu(DisasContext *ctx, int sprn, int gprn)
         gen_stop_exception(ctx);
     }
 }
-#else
-#define spr_write_tbu spr_write_generic
-#endif
 
 #if 0
 // ATTRIBUTE_UNUSED
@@ -10158,6 +10141,10 @@ static void ppc_cpu_reset(CPUState *dev)
     s->exception_index = POWERPC_EXCP_NONE;
     env->error_code = 0;
     ppc_irq_reset(cpu);
+
+    if (!env->tb_env) {
+        cpu_ppc_tb_init(env, 512000000);
+    }
 
     /* tininess for underflow is detected before rounding */
     set_float_detect_tininess(float_tininess_before_rounding,


### PR DESCRIPTION
Hi,   
I'm building a [user-space AIX emulator](https://github.com/Theldus/aix-user) and noticed that AIX's libc implementation of `clock_gettime(CLOCK_MONOTONIC)` uses the PowerPC mftb/mftbu instructions to read the timebase for monotonic timing.

Currently, these registers always return 0 because PR #1910 stubbed them out to prevent crashes from uninitialized tb_env. This causes CLOCK_MONOTONIC to always return zero'ed values.

This PR fixes this by initializing tb_env during CPU reset with cpu_ppc_tb_init() and re-enabling timebase read/write functions (spr_read_tbl/tbu).

Tested with: AIX binaries + `test_ppc`.