### PR TITLE
py3: export UC_MMIO_{READ|WRITE}_TYPE

### DIFF
--- a/bindings/python/unicorn/unicorn_py3/unicorn.py
+++ b/bindings/python/unicorn/unicorn_py3/unicorn.py
@@ -1576,4 +1576,4 @@ UC_MMIO_READ_TYPE = Callable[[Uc, int, int, Any], int]
 UC_MMIO_WRITE_TYPE = Callable[[Uc, int, int, int, Any], None]
 
 
-__all__ = ['Uc', 'UcContext', 'ucsubclass', 'UcError', 'uc_version', 'version_bind', 'uc_arch_supported', 'debug']
+__all__ = ['Uc', 'UcContext', 'ucsubclass', 'UcError', 'uc_version', 'version_bind', 'uc_arch_supported', 'debug', 'UC_MMIO_READ_TYPE', 'UC_MMIO_WRITE_TYPE']


### PR DESCRIPTION
fix a script importing:
from unicorn.unicorn import UC_MMIO_READ_TYPE, UC_MMIO_WRITE_TYPE