### PR TITLE
bindings/python: sync version with core via CMakeLists.txt

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -7,6 +7,7 @@ import platform
 import shutil
 import subprocess
 import sys
+import re
 from setuptools import setup
 from setuptools.command.build_py import build_py
 from setuptools.command.sdist import sdist
@@ -14,6 +15,7 @@ from setuptools.command.sdist import sdist
 log = logging.getLogger(__name__)
 
 # are we building from the repository or from a source distribution?
+DEFAULT_VERSION = "2.1.4"
 ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
 LIBS_DIR = os.path.join(ROOT_DIR, 'unicorn', 'lib')
 HEADERS_DIR = os.path.join(ROOT_DIR, 'unicorn', 'include')
@@ -128,6 +130,24 @@ def build_libraries():
         shutil.copy(os.path.join(BUILD_DIR, LIBRARY_FILE), LIBS_DIR)
         shutil.copy(os.path.join(BUILD_DIR, STATIC_LIBRARY_FILE), LIBS_DIR)
 
+def get_version():
+    try:
+        # we follow the version in CMakeLists.txt, which is the source of truth for the version number
+        cmake_path = os.path.join(UC_DIR, 'CMakeLists.txt')
+        if os.path.exists(cmake_path):
+            with open(cmake_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+
+            major = re.search(r'set\(UNICORN_VERSION_MAJOR\s+(\d+)\)', content)
+            minor = re.search(r'set\(UNICORN_VERSION_MINOR\s+(\d+)\)', content)
+            patch = re.search(r'set\(UNICORN_VERSION_PATCH\s+(\d+)\)', content)
+
+            if major and minor and patch:
+                return "%s.%s.%s" % (major.group(1), minor.group(1), patch.group(1))
+    except Exception:
+        pass
+
+    return DEFAULT_VERSION
 
 class CustomSDist(sdist):
     def run(self):
@@ -147,6 +167,7 @@ class CustomBuild(build_py):
 
 
 setup(
+    version=get_version(),
     cmdclass={'build_py': CustomBuild, 'sdist': CustomSDist},
     has_ext_modules=lambda: True,  # It's not a Pure Python wheel,
     options={"bdist_wheel": {"py_limited_api": "cp37"}},  # to have ABI3 tagged wheel


### PR DESCRIPTION
Hello maintainers,

I encountered issues while compiling the Python RPM package for the distribution and attempting to compile it from source.

## errors

### from RPM compile 

We should notice that `Error: The version in the Python package metadata 0.0.0 normalizes to zero.`

<img width="1448" height="576" alt="c33714aefaf3e9307edf8c8618cff379" src="https://github.com/user-attachments/assets/e300f2e2-9074-49e0-be0f-361119f798be" />

### from Source compile

I use `setup.py` to compile a `tar.gz` file.

I discovered that the Unicorn version was set to `0.0.0` because the Python bindings did not determine their version during the package compilation process, unlike other language interfaces.

```bash
...
copying unicorn/tricore_const.py -> unicorn-0.0.0/unicorn
copying unicorn/unicorn.py -> unicorn-0.0.0/unicorn
copying unicorn/unicorn_const.py -> unicorn-0.0.0/unicorn
copying unicorn/unicorn_py2.py -> unicorn-0.0.0/unicorn
copying unicorn/x86_const.py -> unicorn-0.0.0/unicorn
copying unicorn.egg-info/PKG-INFO -> unicorn-0.0.0/unicorn.egg-info
copying unicorn.egg-info/SOURCES.txt -> unicorn-0.0.0/unicorn.egg-info
copying unicorn.egg-info/dependency_links.txt -> unicorn-0.0.0/unicorn.egg-info
copying unicorn.egg-info/requires.txt -> unicorn-0.0.0/unicorn.egg-info
copying unicorn.egg-info/top_level.txt -> unicorn-0.0.0/unicorn.egg-info
copying unicorn/unicorn_py3/__init__.py -> unicorn-0.0.0/unicorn/unicorn_py3
copying unicorn/unicorn_py3/unicorn.py -> unicorn-0.0.0/unicorn/unicorn_py3
copying unicorn/unicorn_py3/arch/__init__.py -> unicorn-0.0.0/unicorn/unicorn_py3/arch
copying unicorn/unicorn_py3/arch/arm.py -> unicorn-0.0.0/unicorn/unicorn_py3/arch
copying unicorn/unicorn_py3/arch/arm64.py -> unicorn-0.0.0/unicorn/unicorn_py3/arch
copying unicorn/unicorn_py3/arch/intel.py -> unicorn-0.0.0/unicorn/unicorn_py3/arch
copying unicorn/unicorn_py3/arch/types.py -> unicorn-0.0.0/unicorn/unicorn_py3/arch
copying unicorn.egg-info/SOURCES.txt -> unicorn-0.0.0/unicorn.egg-info
Writing unicorn-0.0.0/setup.cfg
creating dist
Creating tar archive
removing 'unicorn-0.0.0' (and everything under it)
```

## my change

I have implemented a function in `setup.py` to automatically retrieve the version, which depends on the top-level CMakeLists.txt. I believe this is a reasonable approach because the version-related variables in CMake are highly stable; my observations show that this section of the CMake code hasn't changed significantly since version `1.0.2-rc1`. Additionally, I have included a fallback var using a `DEFAULT_VERSION` variable to specify the version if needed.

:>