### PR TITLE
Fixed tcg temp alloc without free in mips tcg translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Unicorn Engine
 [![pypi downloads](https://pepy.tech/badge/unicorn)](https://pepy.tech/project/unicorn)
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/unicorn.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:unicorn)
 
+**LOOKING FOR CONTRIBUTORS!** See [this](https://github.com/unicorn-engine/unicorn/issues/2237).
+==============
 
 <p align="center">
 <img width="250" src="docs/unicorn-logo.png">

--- a/bindings/java/src/test/java/tests/TestSamples.java
+++ b/bindings/java/src/test/java/tests/TestSamples.java
@@ -236,7 +236,7 @@ public class TestSamples implements UnicornConst {
                 ">>> A6 = 0x0		>>> D6 = 0x0\n" +
                 ">>> A7 = 0x0		>>> D7 = 0x0\n" +
                 ">>> PC = 0x10002\n" +
-                ">>> SR = 0x0\n",
+                ">>> SR = 0x8\n",
             outContent.toString());
     }
 

--- a/bindings/java/src/test/java/tests/TestSamples.java
+++ b/bindings/java/src/test/java/tests/TestSamples.java
@@ -236,7 +236,7 @@ public class TestSamples implements UnicornConst {
                 ">>> A6 = 0x0		>>> D6 = 0x0\n" +
                 ">>> A7 = 0x0		>>> D7 = 0x0\n" +
                 ">>> PC = 0x10002\n" +
-                ">>> SR = 0x8\n",
+                ">>> SR = 0x0\n",
             outContent.toString());
     }
 

--- a/qemu/target/mips/translate.c
+++ b/qemu/target/mips/translate.c
@@ -30951,6 +30951,7 @@ static void mips_tr_translate_insn(DisasContextBase *dcbase, CPUState *cs)
     dyn_is_slot = tcg_const_i32(tcg_ctx, 0);
     slot_op = tcg_last_op(tcg_ctx);
     tcg_gen_mov_i32(tcg_ctx, tcg_ctx->delay_slot_flag, dyn_is_slot);
+    tcg_temp_free_i32(tcg_ctx, dyn_is_slot);
 
     // Unicorn: trace this instruction on request
     if (HOOK_EXISTS_BOUNDED(uc, UC_HOOK_CODE, ctx->base.pc_next)) {


### PR DESCRIPTION
Fixes #2240

Calls to `tcg_const_i32` end up calling `tcg_temp_alloc` (in `tcd.c:tcg_temp_new_internal`), which allocates a temp var in ctx->temps[]. `tcg_temp_free_i32` should be called to free the allocated temp var.

Without it, ctx->temps will eventually overflow ctx->ops and SEGFAULT.