### PR TITLE
Fixed tcg temp alloc without free in mips tcg translation

### DIFF
--- a/qemu/target/mips/translate.c
+++ b/qemu/target/mips/translate.c
@@ -30951,6 +30951,7 @@ static void mips_tr_translate_insn(DisasContextBase *dcbase, CPUState *cs)
     dyn_is_slot = tcg_const_i32(tcg_ctx, 0);
     slot_op = tcg_last_op(tcg_ctx);
     tcg_gen_mov_i32(tcg_ctx, tcg_ctx->delay_slot_flag, dyn_is_slot);
+    tcg_temp_free_i32(tcg_ctx, dyn_is_slot);
 
     // Unicorn: trace this instruction on request
     if (HOOK_EXISTS_BOUNDED(uc, UC_HOOK_CODE, ctx->base.pc_next)) {

--- a/tests/unit/test_mips.c
+++ b/tests/unit/test_mips.c
@@ -222,6 +222,20 @@ static void test_mips_simple_coredump_2137(void)
     OK(uc_close(uc));
 }
 
+static void test_mips_ctx_temps_overflow(void)
+{
+    uc_engine *uc = NULL;
+    uint64_t base = 0x1000;
+    uc_tb tb;
+
+    OK(uc_open(UC_ARCH_MIPS, UC_MODE_MIPS64, &uc));
+    // Map a page of NOPs (0x00); exercises a potential for a bug when a TB contains
+    // more instructions than temp slots (if temp tcg vars are not freed)
+    uc_mem_map(uc, base, 0x1000, UC_PROT_READ | UC_PROT_EXEC | UC_PROT_WRITE);
+    uc_ctl_request_cache(uc, base, &tb);
+}
+
+
 TEST_LIST = {
     {"test_mips_stop_at_branch", test_mips_stop_at_branch},
     {"test_mips_stop_at_delay_slot", test_mips_stop_at_delay_slot},
@@ -230,8 +244,8 @@ TEST_LIST = {
     {"test_mips_lwx_exception_issue_1314", test_mips_lwx_exception_issue_1314},
     {"test_mips_mips16", test_mips_mips16},
     {"test_mips_mips_fpr", test_mips_mips_fpr},
-    {"test_mips_stop_delay_slot_from_qiling",
-     test_mips_stop_delay_slot_from_qiling},
-     {"test_mips_simple_coredump_2134", test_mips_simple_coredump_2134},
-     {"test_mips_simple_coredump_2137", test_mips_simple_coredump_2137},
+    {"test_mips_stop_delay_slot_from_qiling", test_mips_stop_delay_slot_from_qiling},
+    {"test_mips_simple_coredump_2134", test_mips_simple_coredump_2134},
+    {"test_mips_simple_coredump_2137", test_mips_simple_coredump_2137},
+    {"test_mips_ctx_temps_overflow", test_mips_ctx_temps_overflow},
     {NULL, NULL}};


### PR DESCRIPTION
Fixes #2240

Calls to tcg_const_i32 end up calling tcg_temp_alloc (in tcg.c:tcg_temp_new_internal), which allocates a temp var in ctx->temps[]. tcg_temp_free_i32 should be called to free the allocated temp var.

Without it, ctx->temps will eventually overflow ctx->ops and SEGFAULT.