### PR TITLE
Add error handling for tcg temps overflow

### DIFF
--- a/qemu/accel/tcg/translate-all.c
+++ b/qemu/accel/tcg/translate-all.c
@@ -1752,6 +1752,11 @@ TranslationBlock *tb_gen_code(CPUState *cpu,
     tcg_ctx->tb_cflags = cflags;
  tb_overflow:
 
+    gen_code_size = sigsetjmp(tcg_ctx->jmp_trans, 0);
+    if (unlikely(gen_code_size != 0)) {
+        goto error_return;
+    }
+
     tcg_func_start(tcg_ctx);
 
     tcg_ctx->cpu = env_cpu(env);
@@ -1774,6 +1779,7 @@ TranslationBlock *tb_gen_code(CPUState *cpu,
 
     gen_code_size = tcg_gen_code(tcg_ctx, tb);
     if (unlikely(gen_code_size < 0)) {
+ error_return:
         switch (gen_code_size) {
         case -1:
             /*
@@ -1785,6 +1791,9 @@ TranslationBlock *tb_gen_code(CPUState *cpu,
              * flush the TBs, allocate a new TB, re-initialize it per
              * above, and re-do the actual code generation.
              */
+            qemu_log_mask(CPU_LOG_TB_OP | CPU_LOG_TB_OP_OPT,
+                          "Restarting code generation for "
+                          "code_gen_buffer overflow\n");
             goto buffer_overflow;
 
         case -2:
@@ -1795,11 +1804,20 @@ TranslationBlock *tb_gen_code(CPUState *cpu,
              * in the tcg backend.
              *
              * Try again with half as many insns as we attempted this time.
+             * Use the TB instruction count as calculated within
+             * gen_intermediate_code, as long as it is > 0 (error case), otherwise
+             * use the last calculated max. The icount will never be greater than
+             * the last max_insns, so this will not invoke an infinite loop.
+             * 
              * If a single insn overflows, there's a bug somewhere...
              */
-            max_insns = tb->icount;
+            max_insns = tb->icount > 0 ? tb->icount : max_insns;
             assert(max_insns > 1);
             max_insns /= 2;
+            qemu_log_mask(CPU_LOG_TB_OP | CPU_LOG_TB_OP_OPT,
+                          "Restarting code generation with "
+                          "smaller translation block (max %d insns)\n",
+                          max_insns);
             goto tb_overflow;
 
         default:

--- a/qemu/include/tcg/tcg.h
+++ b/qemu/include/tcg/tcg.h
@@ -818,6 +818,9 @@ struct TCGContext {
 
     // loongarch 
     bool use_lsx_instructions;
+
+    /* Exit to translator on overflow. */
+    sigjmp_buf jmp_trans;
 };
 
 static inline size_t temp_idx(TCGContext *tcg_ctx, TCGTemp *ts)

--- a/qemu/tcg/tcg.c
+++ b/qemu/tcg/tcg.c
@@ -291,6 +291,12 @@ static void set_jmp_reset_offset(TCGContext *s, int which)
     assert(s->tb_jmp_reset_offset[which] == off);
 }
 
+/* Signal overflow, starting over with fewer guest insns. */
+static void QEMU_NORETURN tcg_raise_tb_overflow(TCGContext *s)
+{
+    siglongjmp(s->jmp_trans, -2);
+}
+
 #include "tcg-target.inc.c"
 
 /* compare a pointer @ptr and a tb_tc @s */
@@ -896,18 +902,23 @@ void tcg_func_start(TCGContext *s)
     QSIMPLEQ_INIT(&s->labels);
 }
 
-static inline TCGTemp *tcg_temp_alloc(TCGContext *s)
+static TCGTemp *tcg_temp_alloc(TCGContext *s)
 {
     int n = s->nb_temps++;
-    tcg_debug_assert(n < TCG_MAX_TEMPS);
+
+    if (n >= TCG_MAX_TEMPS) {
+        /* Signal overflow, starting over with fewer guest insns. */
+        tcg_raise_tb_overflow(s);
+    }
     return memset(&s->temps[n], 0, sizeof(TCGTemp));
 }
 
-static inline TCGTemp *tcg_global_alloc(TCGContext *s)
+static TCGTemp *tcg_global_alloc(TCGContext *s)
 {
     TCGTemp *ts;
 
     tcg_debug_assert(s->nb_globals == s->nb_temps);
+    tcg_debug_assert(s->nb_globals < TCG_MAX_TEMPS);
     s->nb_globals++;
     ts = tcg_temp_alloc(s);
     ts->temp_global = 1;
@@ -3049,6 +3060,11 @@ static void temp_load(TCGContext *s, TCGTemp *ts, TCGRegSet desired_regs,
         ts->mem_coherent = 0;
         break;
     case TEMP_VAL_MEM:
+        // if mem_allocated is false, ts->mem_base == 0x0 and will
+        //  trigger a null ptr deref. Allocate the frame.
+        if (!ts->mem_allocated) {
+            temp_allocate_frame(s, ts);
+        }
         reg = tcg_reg_alloc(s, desired_regs, allocated_regs,
                             preferred_regs, ts->indirect_base);
         tcg_out_ld(s, ts->type, reg, ts->mem_base->reg, ts->mem_offset);

--- a/tests/unit/test_mips.c
+++ b/tests/unit/test_mips.c
@@ -222,6 +222,18 @@ static void test_mips_simple_coredump_2137(void)
     OK(uc_close(uc));
 }
 
+static void test_mips_overflow_tcg_temps(void)
+{
+    uc_engine *uc = NULL;
+    uint64_t base = 0x1000;
+    uc_tb tb;
+
+    OK(uc_open(UC_ARCH_MIPS, UC_MODE_MIPS64, &uc));
+    OK(uc_mem_map(uc, base, 0x1000, UC_PROT_READ | UC_PROT_EXEC | UC_PROT_WRITE));
+    OK(uc_ctl_request_cache(uc, base, &tb));
+    OK(uc_close(uc));
+}
+
 TEST_LIST = {
     {"test_mips_stop_at_branch", test_mips_stop_at_branch},
     {"test_mips_stop_at_delay_slot", test_mips_stop_at_delay_slot},
@@ -234,4 +246,5 @@ TEST_LIST = {
      test_mips_stop_delay_slot_from_qiling},
      {"test_mips_simple_coredump_2134", test_mips_simple_coredump_2134},
      {"test_mips_simple_coredump_2137", test_mips_simple_coredump_2137},
+    {"test_mips_overflow_tcg_temps", test_mips_overflow_tcg_temps},
     {NULL, NULL}};


### PR DESCRIPTION
Related to #2240, this adds further error handling for cases where tcg_ctx->temps could be overflowed within `tcg_temp_alloc`. In addition, it adds a guard for a potential null ptr deref within `temp_load` when ts->mem_base is NULL, by allocating the frame.

Similar fixes were added in upstream qemu:
* https://github.com/qemu/qemu/commit/e139bc4b1772575e1f2dcf8e3dbe1df2b684ef1f 
* https://github.com/qemu/qemu/commit/ae30e86661b0f48562cd95918d37cbeec5d02262 
* https://github.com/qemu/qemu/commit/db6b7d0c6936cd209e3e8d95aea61ad29ceef5e6

When applying the fix for the temps overflow, it exposed a potential for a null ptr deref on `ts->mem_base->reg` (`ts->mem_base` is NULL):
```
[#0] 0x7ffff724bce5 → temp_load(s=0x55555556e040, ts=0x5555555703f0, desired_regs=0xffff, allocated_regs=0x30, preferred_regs=0x40)
[#1] 0x7ffff724c0ef → tcg_reg_alloc_mov(s=0x55555556e040, op=0x555555565240)
[#2] 0x7ffff724da14 → tcg_gen_code_mips64el(s=0x55555556e040, tb=0x7fffb6200040)
[#3] 0x7ffff72792a5 → tb_gen_code_mips64el(cpu=0x5555555a46e0, pc=0x1000, cs_base=0x0, flags=0x10000038, cflags=0xff000000)
[#4] 0x7ffff7277f09 → uc_gen_tb(uc=0x555555560770, addr=0x1000, out_tb=0x7fffffffd160)
[#5] 0x7ffff69e7848 → uc_ctl(uc=0x555555560770, control=3355443208)
[#6] 0x55555555b4ea → test_mips_overflow_tcg_temps()
[#7] 0x555555557c2f → acutest_do_run_(test=0x55555555ec00 <acutest_list_+160>, index=0x0)
[#8] 0x555555558060 → acutest_run_(test=0x55555555ec00 <acutest_list_+160>, index=0x0, master_index=0xa)
[#9] 0x5555555594ad → main(argc=0x2, argv=0x7fffffffd3a8)

                 // s=0x00007fffffffcd18  →  [...]  →  0x0000000000000000, ts=0x00007fffffffcd10  →  [...]  →  0x0000004000000200
 → 3065          tcg_out_ld(s, ts->type, reg, ts->mem_base->reg, ts->mem_offset);
 
 gef>  p *ts
$3 = {
  reg = TCG_REG_EAX,
  val_type = TEMP_VAL_MEM,
  base_type = TCG_TYPE_I32,
  type = TCG_TYPE_I32,
  fixed_reg = 0x0,
  indirect_reg = 0x0,
  indirect_base = 0x0,
  mem_coherent = 0x0,
  mem_allocated = 0x0,
  temp_global = 0x0,
  temp_local = 0x1,
  temp_allocated = 0x0,
  val = 0x0,
  mem_base = 0x0,
  mem_offset = 0x0,
  name = 0x0,
  state = 0x0,
  state_ptr = 0x555555670a24
}
```

I traced through the allocation of the temps, and I can see where `val_type=TEMP_VAL_MEM` and `mem_allocated=0`, as well as when `mem_allocated=1`, which happens within `tcg_global_mem_new_internal` or `temp_allocate_frame`. For whatever reason, those don't seem to be getting called in this case, but are being used. Not sure why this error hasn't already happened with some other test, but it was identified upstream and I applied the same fix, which does indeed solve the problem.

@PhilippTakacs I reused the test from #2305, with the proper `OK()` checks. When these two get merged, want to just overwrite the other one with this one while fixing the merge conflict? Or would you prefer to have two different tests?