### PR TITLE
qemu/tcg: fix UC_HOOK_MEM_READ/WRITE on riscv64 host

### DIFF
--- a/qemu/tcg/riscv/tcg-target.inc.c
+++ b/qemu/tcg/riscv/tcg-target.inc.c
@@ -1013,7 +1013,12 @@ static void tcg_out_tlb_load(TCGContext *s, TCGReg addrl,
 
     /* Compare masked address with the TLB entry. */
     label_ptr[0] = s->code_ptr;
-    tcg_out_opc_branch(s, OPC_BNE, TCG_REG_TMP0, TCG_REG_TMP1, 0);
+    /* Unicorn: when memory hooks are present, always branch to slow path */
+    if (tcg_uc_has_hookmem(s)) {
+        tcg_out_opc_branch(s, OPC_BEQ, TCG_REG_ZERO, TCG_REG_ZERO, 0);
+    } else {
+        tcg_out_opc_branch(s, OPC_BNE, TCG_REG_TMP0, TCG_REG_TMP1, 0);
+    }
     /* NOP to allow patching later */
     tcg_out_opc_imm(s, OPC_ADDI, TCG_REG_ZERO, TCG_REG_ZERO, 0);
 


### PR DESCRIPTION
The RISC-V TCG backend's `tcg_out_tlb_load()` unconditionally used `BNE` to branch to the slow path only on TLB misses. When memory hooks (UC_HOOK_MEM_READ/WRITE) are installed, the slow path must always be taken so hooks are invoked on every memory access.

Use `BEQ x0,x0` when `tcg_uc_has_hookmem()` is true, matching the approach used in the ARM32, AArch64, and x86 backends.

Fixes #2124

Tested on riscv64 host and all tests passed.