### PR TITLE
uc_context: tag blobs with a tamper-evident magic

### DIFF
--- a/include/uc_priv.h
+++ b/include/uc_priv.h
@@ -422,6 +422,10 @@ struct uc_struct {
                           // workaround to treat the IT block as a whole block.
     bool init_done;       // Whether the initialization is done.
 
+    // Per-engine seed for tagging uc_context blobs in uc_context_save()
+    // and verifying them in uc_context_restore(). Set in uc_open().
+    uint64_t context_seed;
+
     sigjmp_buf jmp_bufs[UC_MAX_NESTED_LEVEL]; // To support nested uc_emu_start
     int nested_level;                         // Current nested_level
 
@@ -451,6 +455,11 @@ struct uc_context {
     bool ramblock_freed;  // wheter there was a some ramblock freed
     RAMBlock *last_block; // The last element of the ramblock list
     FlatView *fv;         // The current flatview of the memory
+    // Tamper-evidence: set by uc_context_save() to a hash of all the
+    // critical fields above mixed with the engine's context_seed.
+    // uc_context_restore() recomputes the hash and refuses contexts
+    // whose fields have been mutated (or that were never saved).
+    uint64_t save_magic;
     char data[0];         // context
 };
 

--- a/tests/unit/test_ctl.c
+++ b/tests/unit/test_ctl.c
@@ -398,6 +398,97 @@ static void test_noexec(void)
     OK(uc_close(uc));
 }
 
+// Regression test for issue #2320. uc_context_restore() used to trust
+// context_size, fv and last_block from the user-visible struct. Mutating
+// any of them produced a heap-overflow / wild-pointer-deref crash. The
+// save_magic header tag now catches all three tamper cases up front.
+//
+// We mirror the public layout of struct uc_context so the test can poke
+// individual fields without including uc_priv.h.
+struct ctl_test_uc_context_layout {
+    size_t context_size;
+    int    mode;
+    int    arch;
+    int    snapshot_level;
+    unsigned char ramblock_freed;
+    void  *last_block;
+    void  *fv;
+    uint64_t save_magic;
+};
+
+static void test_uc_context_restore_rejects_tampering(void)
+{
+    uc_engine *uc;
+    uc_context *ctx;
+
+    OK(uc_open(UC_ARCH_X86, UC_MODE_64, &uc));
+    OK(uc_mem_map(uc, 0x1000, 0x1000, UC_PROT_ALL));
+    OK(uc_context_alloc(uc, &ctx));
+
+    // 1. Restore from a fresh context (save_magic == 0).
+    uc_assert_err(UC_ERR_ARG, uc_context_restore(uc, ctx));
+
+    // 2. Real save then untampered restore is still the happy path.
+    OK(uc_context_save(uc, ctx));
+    OK(uc_context_restore(uc, ctx));
+
+    // 3. Tamper with context_size between save and restore.
+    {
+        struct ctl_test_uc_context_layout *h =
+            (struct ctl_test_uc_context_layout *)ctx;
+        size_t saved = h->context_size;
+        h->context_size = 0x100000;
+        uc_assert_err(UC_ERR_ARG, uc_context_restore(uc, ctx));
+        h->context_size = saved;
+    }
+
+    // 4. Tamper with fv (only material in MEMORY mode but the magic
+    //    binds it regardless, so a normal CPU-only restore catches it).
+    {
+        struct ctl_test_uc_context_layout *h =
+            (struct ctl_test_uc_context_layout *)ctx;
+        void *saved = h->fv;
+        h->fv = (void *)0xdeadbeefULL;
+        uc_assert_err(UC_ERR_ARG, uc_context_restore(uc, ctx));
+        h->fv = saved;
+    }
+
+    // 5. Tamper with last_block.
+    {
+        struct ctl_test_uc_context_layout *h =
+            (struct ctl_test_uc_context_layout *)ctx;
+        void *saved = h->last_block;
+        h->last_block = (void *)0xdeadbeefULL;
+        uc_assert_err(UC_ERR_ARG, uc_context_restore(uc, ctx));
+        h->last_block = saved;
+    }
+
+    // 6. After undoing all tampers we should still be valid.
+    OK(uc_context_restore(uc, ctx));
+
+    OK(uc_context_free(ctx));
+    OK(uc_close(uc));
+}
+
+// A context saved against one engine must not restore into another
+// engine instance even with the same arch/mode.
+static void test_uc_context_restore_rejects_cross_engine(void)
+{
+    uc_engine *uc1, *uc2;
+    uc_context *ctx;
+
+    OK(uc_open(UC_ARCH_X86, UC_MODE_64, &uc1));
+    OK(uc_open(UC_ARCH_X86, UC_MODE_64, &uc2));
+    OK(uc_context_alloc(uc1, &ctx));
+    OK(uc_context_save(uc1, ctx));
+
+    uc_assert_err(UC_ERR_ARG, uc_context_restore(uc2, ctx));
+
+    OK(uc_context_free(ctx));
+    OK(uc_close(uc1));
+    OK(uc_close(uc2));
+}
+
 TEST_LIST = {
     {"test_uc_ctl_mode", test_uc_ctl_mode},
     {"test_uc_ctl_page_size", test_uc_ctl_page_size},
@@ -416,4 +507,8 @@ TEST_LIST = {
     {"test_uc_emu_stop_set_ip", test_uc_emu_stop_set_ip},
     {"test_tlb_clear", test_tlb_clear},
     {"test_noexec", test_noexec},
+    {"test_uc_context_restore_rejects_tampering",
+     test_uc_context_restore_rejects_tampering},
+    {"test_uc_context_restore_rejects_cross_engine",
+     test_uc_context_restore_rejects_cross_engine},
     {NULL, NULL}};

--- a/uc.c
+++ b/uc.c
@@ -329,6 +329,19 @@ uc_err uc_open(uc_arch arch, uc_mode mode, uc_engine **result)
         uc->errnum = UC_ERR_OK;
         uc->arch = arch;
         uc->mode = mode;
+
+        // Per-engine seed used to tag uc_context blobs in
+        // uc_context_save() and verify them in uc_context_restore().
+        // It just needs to be unguessable by code that can mutate the
+        // user-visible context struct (which lives in the same process),
+        // not cryptographically strong. The engine pointer alone is
+        // hard to predict under ASLR; mixing in a clock value adds a
+        // few more bits and avoids zero-seeds in pathological builds.
+        uc->context_seed = ((uint64_t)(uintptr_t)uc << 1) ^
+                           ((uint64_t)time(NULL) << 32) ^ 0x9E3779B97F4A7C15ULL;
+        if (uc->context_seed == 0) {
+            uc->context_seed = 0x9E3779B97F4A7C15ULL;
+        }
         uc->reg_read = default_reg_read;
         uc->reg_write = default_reg_write;
 
@@ -2254,6 +2267,32 @@ uc_err uc_query(uc_engine *uc, uc_query_type type, size_t *result)
     return UC_ERR_OK;
 }
 
+// Tamper-evidence tag for a uc_context. Recomputed in uc_context_save()
+// and uc_context_restore() from all the fields the restore path will
+// trust; mixing in the engine's per-instance context_seed makes it
+// impractical for code that mutates the public uc_context struct to
+// forge a matching tag without also reading uc_struct (which is opaque).
+static uint64_t uc_context_compute_magic(uc_engine *uc, uc_context *context)
+{
+    uint64_t h = uc->context_seed;
+    h ^= (uint64_t)context->context_size;
+    h ^= ((uint64_t)(uint32_t)context->arch) << 32;
+    h ^= (uint64_t)(uint32_t)context->mode;
+    h ^= (uint64_t)(uintptr_t)context->fv;
+    h ^= (uint64_t)(uintptr_t)context->last_block;
+    h ^= (uint64_t)(uint32_t)context->snapshot_level;
+    h ^= (uint64_t)context->ramblock_freed;
+    // Final mixing step (xorshift) so a single field flip changes
+    // many output bits.
+    h ^= h >> 33;
+    h *= 0xff51afd7ed558ccdULL;
+    h ^= h >> 33;
+    h *= 0xc4ceb9fe1a85ec53ULL;
+    h ^= h >> 33;
+    // 0 is reserved for "never saved", so steer away from it.
+    return h ? h : 0x9E3779B97F4A7C15ULL;
+}
+
 UNICORN_EXPORT
 uc_err uc_context_alloc(uc_engine *uc, uc_context **context)
 {
@@ -2262,12 +2301,16 @@ uc_err uc_context_alloc(uc_engine *uc, uc_context **context)
 
     UC_INIT(uc);
 
-    *_context = g_malloc(size);
+    // Zero-init so save_magic / fv / last_block start at known values
+    // (g_malloc0 is calloc; same as the existing g_malloc + explicit
+    // fv = NULL, just covers the new fields too).
+    *_context = g_malloc0(size);
     if (*_context) {
         (*_context)->context_size = size - sizeof(uc_context);
         (*_context)->arch = uc->arch;
         (*_context)->mode = uc->mode;
-        (*_context)->fv = NULL;
+        // save_magic stays 0; uc_context_restore() reads that as
+        // "never saved" and refuses with UC_ERR_ARG.
         restore_jit_state(uc);
         return UC_ERR_OK;
     } else {
@@ -2330,14 +2373,19 @@ uc_err uc_context_save(uc_engine *uc, uc_context *context)
     if (uc->context_content & UC_CTL_CONTEXT_CPU) {
         if (!uc->context_save) {
             memcpy(context->data, uc->cpu->env_ptr, context->context_size);
+            context->save_magic = uc_context_compute_magic(uc, context);
             restore_jit_state(uc);
             return UC_ERR_OK;
         } else {
             ret = uc->context_save(uc, context);
+            if (ret == UC_ERR_OK) {
+                context->save_magic = uc_context_compute_magic(uc, context);
+            }
             restore_jit_state(uc);
             return ret;
         }
     }
+    context->save_magic = uc_context_compute_magic(uc, context);
     restore_jit_state(uc);
     return ret;
 }
@@ -2586,6 +2634,19 @@ uc_err uc_context_restore(uc_engine *uc, uc_context *context)
 {
     UC_INIT(uc);
     uc_err ret;
+
+    // Refuse contexts that were never populated by uc_context_save() on
+    // this engine, or whose header fields have been mutated since save.
+    // Without this, restoring a fresh / cross-engine / tampered context
+    // propagates wrong sizes or wild host pointers (fv, last_block) into
+    // the engine and crashes inside flatview_copy() / find_ram_offset().
+    if (context->save_magic == 0 ||
+        context->save_magic != uc_context_compute_magic(uc, context) ||
+        context->arch != uc->arch ||
+        context->mode != uc->mode) {
+        restore_jit_state(uc);
+        return UC_ERR_ARG;
+    }
 
     if (uc->context_content & UC_CTL_CONTEXT_MEMORY) {
         uc->snapshot_level = context->snapshot_level;


### PR DESCRIPTION
The struct uc_context that uc_context_alloc() returns is a normal heap allocation handed to the caller. Its public layout exposes context_size, fv and last_block, all of which uc_context_restore() reads back at face value. If anything mutates those bytes between save and restore (which the caller can do trivially because they own the allocation), the restore path produces:

  - a heap-buffer-overflow inside the env memcpy (context_size mutated),
  - a SEGV inside flatview_copy() (fv mutated),
  - or a SEGV inside find_ram_offset_last() on the next RAM op (last_block mutated).

The docs don't promise that a context blob is portable across processes (and the embedded host pointers obviously can't survive that), so the realistic threat model is intra-process: another bug that corrupts the heap region holding the context, or a caller that hands the same context to a different uc_engine. Both turn into a controllable pointer crash on restore.

This commit adds a per-engine context_seed in uc_struct (set at uc_open()) plus a save_magic header field in uc_context. The magic is a hash of context_size / arch / mode / snapshot_level / fv / last_block / ramblock_freed mixed with the engine seed. uc_context_save() recomputes and stores it on success. uc_context_restore() recomputes it from the current (possibly mutated) fields and refuses with UC_ERR_ARG on mismatch.

Catches:
  - restore from a never-saved context (save_magic == 0)
  - cross-engine restore (different engine seed)
  - any mutation of context_size / fv / last_block / arch / mode

uc_context_alloc() now uses g_malloc0() so that the new save_magic field, plus the existing snapshot_level / ramblock_freed / last_block, all start at zero rather than stack/heap garbage.

Adds two regression tests in tests/unit/test_ctl.c covering the four tamper cases above plus the cross-engine case. The non-tampered save -> restore round trip still passes.

Fixes #2320.