### PR TITLE
cputlb: set TLB_NOTDIRTY flag only for executable pages

### DIFF
--- a/qemu/accel/tcg/cputlb.c
+++ b/qemu/accel/tcg/cputlb.c
@@ -870,11 +870,16 @@ void tlb_set_page_with_attrs(CPUState *cpu, target_ulong vaddr,
         /*
          * Computing is_clean is expensive; avoid all that unless
          * the page is actually writable.
+         *
+         * The usage of TLB_NOTDIRTY only matters for pages that
+         * could contain TBs, so set TLB_NOTDIRTY only for executable
+         * memory sections.
          */
         if (prot & PAGE_WRITE) {
             if (section->readonly) {
                 write_address |= TLB_DISCARD_WRITE;
-            } else if (cpu_physical_memory_is_clean(iotlb)) {
+            } else if ((section->mr->perms & UC_PROT_EXEC) &&
+                       cpu_physical_memory_is_clean(iotlb)) {
                 write_address |= TLB_NOTDIRTY;
             }
         }

--- a/tests/unit/test_mem.c
+++ b/tests/unit/test_mem.c
@@ -621,6 +621,66 @@ static void test_mem_addr_size_wraparound(void)
     OK(uc_close(uc));
 }
 
+/* SMC test: verifies that a store which overwrites code on
+ * the same page invalidates any cached TBs translated from that
+ * page, so subsequent execution sees the new instructions.
+ */
+static void test_smc(void)
+{
+    uc_engine *uc;
+    uint64_t r_rax;
+    uint64_t r_rsp;
+
+    char code[] = (                    // 00: do_inc_dec:
+        "\x48\xff\xc0"                 // 00:    inc %rax
+        "\xc3"                         // 03:    ret
+        "\xe8\xf7\xff\xff\xff"         // 04: call do_inc_dec
+        "\xc6\x05\xf2\xff\xff\xff\xc8" // 09: movb $0xc8, -0xe(%rip)
+        "\xe8\xeb\xff\xff\xff"         // 16: call do_inc_dec
+    );
+
+    r_rax = 0x1234;
+    r_rsp = 0x5000;
+    OK(uc_open(UC_ARCH_X86, UC_MODE_64, &uc));
+    OK(uc_mem_map  (uc, 0x0,    0x1000, UC_PROT_ALL));                // text
+    OK(uc_mem_map  (uc, 0x4000, 0x1000, UC_PROT_READ|UC_PROT_WRITE)); // stack
+    OK(uc_mem_write(uc, 0x0,    code,   sizeof(code)-1));
+    OK(uc_reg_write(uc, UC_X86_REG_RAX, &r_rax));
+    OK(uc_reg_write(uc, UC_X86_REG_RSP, &r_rsp));
+    OK(uc_emu_start(uc, 0x4, sizeof(code)-1, 0, 0));
+
+    OK(uc_reg_read(uc, UC_X86_REG_RAX, &r_rax));
+    OK(uc_mem_read(uc, 0x0, code, sizeof(code)-1));
+    TEST_CHECK(r_rax == 0x1234);
+    TEST_CHECK((code[2] & 0xFF) == 0xC8);
+
+    OK(uc_close(uc));
+}
+
+/*
+ * Ensures that a code section initially as RW, if marked later as RX
+ * still works as expected
+ */
+static void test_tlbdirty_exec(void)
+{
+    uc_engine *uc;
+    uint32_t eax;
+
+    char code[] = ("\x40"); // inc eax
+    eax = 41;
+    OK(uc_open(UC_ARCH_X86, UC_MODE_32, &uc));
+    OK(uc_reg_write  (uc, UC_X86_REG_EAX, &eax));
+    OK(uc_mem_map    (uc, 0x0, 0x1000, UC_PROT_READ|UC_PROT_WRITE));
+    OK(uc_mem_write  (uc, 0x0, code,   sizeof(code)-1));
+    OK(uc_mem_protect(uc, 0x0, 0x1000, UC_PROT_READ|UC_PROT_EXEC));
+    OK(uc_emu_start  (uc, 0x0, sizeof(code)-1, 0, 0));
+
+    OK(uc_reg_read(uc, UC_X86_REG_EAX, &eax));
+    TEST_CHECK(eax == 42);
+
+    OK(uc_close(uc));
+}
+
 TEST_LIST = {{"test_map_correct", test_map_correct},
              {"test_map_wrapping", test_map_wrapping},
              {"test_mem_protect", test_mem_protect},
@@ -641,4 +701,6 @@ TEST_LIST = {{"test_map_correct", test_map_correct},
              {"test_virtual_to_physical", test_virtual_to_physical},
              {"test_virtual_write", test_virtual_write},
              {"test_mem_addr_size_wraparound", test_mem_addr_size_wraparound},
+             {"test_smc", test_smc},
+             {"test_tlbdirty_exec", test_tlbdirty_exec},
              {NULL, NULL}};


### PR DESCRIPTION
Hi,
While running some micro-benchmarks on my [AIX user-mode emulator], I noticed a simple '[matmul]' was running around ~4x slower than the same benchmark running on QEMU fullsystem/'qemu-system-ppc64'.

A perf profile pointed at the softmmu slow path:
```text
Samples: 133K of event 'cycles:Pu', Event count (approx.): 118136951722
  Children      Self  Command   Shared Object      Symbol
+   51.85%    19.92%  aix-user  libunicorn.so.2    [.] helper_be_stl_mmu_ppc
+   26.16%     7.05%  aix-user  libunicorn.so.2    [.] find_memory_mapping_ppc
+   19.56%     5.60%  aix-user  libunicorn.so.2    [.] notdirty_write.isra.0
+   18.45%    18.28%  aix-user  libunicorn.so.2    [.] flatview_translate_ppc
+   13.68%     0.00%  aix-user  [JIT] tid 2807     [.] 0x00007f8afda25dba
+   13.62%     0.00%  aix-user  [JIT] tid 2807     [.] 0x00007f8afda25d34
+   13.05%     0.00%  aix-user  [JIT] tid 2807     [.] 0x00007f8afda25a91
+   11.18%     0.00%  aix-user  [JIT] tid 2807     [.] 0x00007f8afda25c23
[snip]
```

`helper_be_stl_mmu_ppc()` is the softmmu slow-path store helper, and any store whose inline fast-path tag compare fails ends up here.

This helper function (store_helper) eventually calls the 'notdirty_write' (conditioned to `TLB_NOTDIRTY`) which then invalidates any TBs cached from that page and then clears TLB_NOTDIRTY from the entry, this is expected.

However, upon further inspection, the function `tlb_set_page_with_attrs()` (also in cputlb.c) ORs `TLB_NOTDIRTY` unconditionally for every freshly-filled TLB entry, provided the page has a PROT_WRITE permission. In Qemu, this isn't an issue since the function `cpu_physical_memory_is_clean()` returns a proper value, but on Unicorn it was stubbed out to always true.

Due to this, Unicorn always sets `TLB_NOTDIRTY` regardless if the underlying memory is clean or not, and worse, sets this for every writable page, even if they do not contain TBs.

Conditioning on `UC_PROT_EXEC`, keeps `TLB_NOTDIRTY` only on pages that could contain TBs. After the patch, execution drops from ~30s to ~8s on the matmul, roughly matching qemu-system-ppc64.

**About tests:**
Since this PR is more related to a 'performance-improvement', rather than a proper bug fix, it is hard to write an automated test to verify its correctness.

The test introduced exercises the cached TBs invalidation _after_ the TLB is already filled, which is not quite the same thing as this PR adds, since this PR _avoids_ marking RW/RO pages as NOTDIRTY at the *first* TLB fill, not after. However, it ensures this patch does not inadvertently break SMC on RWX pages.

[matmul]: https://gist.github.com/Theldus/eaedd3c174f8f137b503a1082461e0d7
[AIX user-mode emulator]: https://github.com/Theldus/aix-user