### PR TITLE
Honor emu_start until address across TB-chained runs (#2341)

### DIFF
--- a/include/uc_priv.h
+++ b/include/uc_priv.h
@@ -454,12 +454,27 @@ struct uc_context {
     char data[0];         // context
 };
 
+// Whether @addr is an exit address is baked into a TB at translation time, but
+// the TB cache is keyed by address only. So whenever an address is added to or
+// removed from the exit set, drop any cached TB whose translation depended on
+// the old state, forcing re-translation. We invalidate [addr - 1, addr + 1):
+// that covers both the block starting at addr (halt block, see translator.c)
+// and the block that halts on reaching it (ends at addr, see the target
+// translators' uc_addr_is_exit() check).
+static inline void uc_exit_invalidate(uc_engine *uc, uint64_t addr)
+{
+    if (addr != 0 && uc->uc_invalidate_tb) {
+        uc->uc_invalidate_tb(uc, addr - 1, 2);
+    }
+}
+
 // We have to support 32bit system so we can't hold uint64_t on void*
 static inline void uc_add_exit(uc_engine *uc, uint64_t addr)
 {
     uint64_t *new_exit = g_malloc(sizeof(uint64_t));
     *new_exit = addr;
     g_tree_insert(uc->ctl_exits, (gpointer)new_exit, (gpointer)1);
+    uc_exit_invalidate(uc, addr);
 }
 
 // This function has to exist since we would like to accept uint32_t or

--- a/tests/unit/test_x86.c
+++ b/tests/unit/test_x86.c
@@ -2201,6 +2201,59 @@ static void test_x86_mem_hooks_pc_guarantee(void)
     OK(uc_close(uc));
 }
 
+// Regression test for an order-dependent TB-chaining fall-through (#2341).
+// func_a (mov eax, 0xfffffffe; ret) and func_b are laid out back to back, so
+// func_a_end == func_b_start. func_a's `ret` returns to func_a_end, which is
+// also the emu_start `until`, so emulation must stop there. The bug: emulating
+// func_b first cached a non-halting TB at func_a_end (it was not an exit
+// address then); func_a then chained into that stale block and ran past
+// `until` into func_b, faulting at the return slot. Emulating func_a first
+// always worked, so the fault was order-dependent.
+static void test_x86_tb_chain_until_after_chaining(void)
+{
+    uc_engine *uc;
+    char func_a[] = "\xb8\xfe\xff\xff\xff\xc3";
+    // push r15/r14/r13/r12/rbp/rbx; sub rsp,8; mov rax,[0x3000]; test rax,rax;
+    // je .l; nop; .l: mov r13d,0xffffffff; mov eax,r13d; add rsp,8;
+    // pop rbx/rbp/r12/r13/r14/r15; ret
+    char func_b[] = "\x41\x57\x41\x56\x41\x55\x41\x54\x55\x53\x48\x83\xec\x08"
+                    "\x48\xa1\x00\x30\x00\x00\x00\x00\x00\x00\x48\x85\xc0\x74"
+                    "\x01\x90\x41\xbd\xff\xff\xff\xff\xeb\x00\x44\x89\xe8\x48"
+                    "\x83\xc4\x08\x5b\x5d\x41\x5c\x41\x5d\x41\x5e\x41\x5f\xc3";
+    uint64_t func_a_end = code_start + sizeof(func_a) - 1;
+    uint64_t func_b_end = func_a_end + sizeof(func_b) - 1;
+    uint64_t rsp = 0x7ffff0;
+    uint64_t ret_addr, rax, rip;
+
+    OK(uc_open(UC_ARCH_X86, UC_MODE_64, &uc));
+    OK(uc_mem_map(uc, code_start, 0x2000, UC_PROT_ALL)); // func_a, func_b
+    OK(uc_mem_map(uc, 0x3000, 0x1000, UC_PROT_ALL));     // read by func_b
+    OK(uc_mem_map(uc, 0x700000, 0x100000, UC_PROT_ALL)); // stack
+    OK(uc_mem_write(uc, code_start, func_a, sizeof(func_a) - 1));
+    OK(uc_mem_write(uc, func_a_end, func_b, sizeof(func_b) - 1));
+
+    // Emulate func_b first so a non-halting TB is cached at func_a_end. The
+    // seeded return address (== until) lets func_b's `ret` end the run.
+    OK(uc_reg_write(uc, UC_X86_REG_RSP, &rsp));
+    ret_addr = LEINT64(func_b_end);
+    OK(uc_mem_write(uc, rsp, &ret_addr, sizeof(ret_addr)));
+    OK(uc_emu_start(uc, func_a_end, func_b_end, 0, 0));
+
+    // Now run func_a with until == func_a_end. It must stop there, not chain
+    // into the stale block and fall through into func_b.
+    OK(uc_reg_write(uc, UC_X86_REG_RSP, &rsp));
+    ret_addr = LEINT64(func_a_end);
+    OK(uc_mem_write(uc, rsp, &ret_addr, sizeof(ret_addr)));
+    OK(uc_emu_start(uc, code_start, func_a_end, 0, 0));
+
+    OK(uc_reg_read(uc, UC_X86_REG_RAX, &rax));
+    OK(uc_reg_read(uc, UC_X86_REG_RIP, &rip));
+    TEST_CHECK(rax == 0xfffffffe);
+    TEST_CHECK(rip == func_a_end);
+
+    OK(uc_close(uc));
+}
+
 TEST_LIST = {
     {"test_x86_in", test_x86_in},
     {"test_x86_out", test_x86_out},
@@ -2265,4 +2318,6 @@ TEST_LIST = {
     {"test_x86_dr7", test_x86_dr7},
     {"test_x86_hook_block", test_x86_hook_block},
     {"test_x86_mem_hooks_pc_guarantee", test_x86_mem_hooks_pc_guarantee},
+    {"test_x86_tb_chain_until_after_chaining",
+     test_x86_tb_chain_until_after_chaining},
     {NULL, NULL}};

--- a/uc.c
+++ b/uc.c
@@ -1224,6 +1224,14 @@ uc_err uc_emu_start(uc_engine *uc, uint64_t begin, uint64_t until,
     // If UC_CTL_UC_USE_EXITS is set, then the @until param won't have any
     // effect. This is designed for the backward compatibility.
     if (!uc->use_exits) {
+        uint64_t prev = uc->exits[uc->nested_level - 1];
+        // The exit address changed: drop the stale TB at the old exit (so it
+        // is re-translated as a normal instruction) and at the new one (so it
+        // becomes a halting block) -- see uc_exit_invalidate().
+        if (prev != until) {
+            uc_exit_invalidate(uc, prev);
+            uc_exit_invalidate(uc, until);
+        }
         uc->exits[uc->nested_level - 1] = until;
     }
 
@@ -2643,6 +2651,14 @@ static inline gboolean uc_read_exit_iter(gpointer key, gpointer val,
     return false;
 }
 
+static inline gboolean uc_exit_invalidate_tree_iter(gpointer key, gpointer val,
+                                                    gpointer data)
+{
+    uc_exit_invalidate((uc_engine *)data, *(uint64_t *)key);
+
+    return false;
+}
+
 UNICORN_EXPORT
 uc_err uc_ctl(uc_engine *uc, uc_control_type control, ...)
 {
@@ -2777,6 +2793,10 @@ uc_err uc_ctl(uc_engine *uc, uc_control_type control, ...)
             uint64_t *exits = va_arg(args, uint64_t *);
             size_t cnt = va_arg(args, size_t);
 
+            // Drop cached TBs at the exits being removed; uc_add_exit() below
+            // does the same for the ones being added.
+            g_tree_foreach(uc->ctl_exits, uc_exit_invalidate_tree_iter,
+                           (void *)uc);
             g_tree_remove_all(uc->ctl_exits);
 
             for (size_t i = 0; i < cnt; i++) {


### PR DESCRIPTION
Fixes #2341.

Whether an address is an exit (`until`) is decided at translation time and baked into the cached TB, but the TB cache is keyed by address only. A block translated by an earlier `uc_emu_start()` — when the address was an ordinary instruction (e.g. the entry of an adjacent function emulated first) — stays cached as a normal block with no halting code. A later run that makes that address an exit chains straight into the stale block and runs past it. That's why the fault was order-dependent.

## Fix

Invalidate cached TBs at the moment the exit set changes, rather than only at run boundaries: when an exit is added (`uc_add_exit`), replaced (`UC_CTL_UC_EXITS`), or the default `until` address changes (`uc_emu_start`). `uc_exit_invalidate()` drops `[addr-1, addr+1)`, covering both the block starting at the exit and the block that halts on reaching it. `qemu/` is untouched.

The existing post-run cleanup in `resume_all_vcpus()` is kept as-is: it's the "exit deactivated" half, and it's also relied on to flush executed blocks for code-patching-after-run (removing it breaks `test_*_code_patching`).

## Testing

- New self-contained regression in `tests/unit/test_x86.c`: emulates the neighbour function first, then the target with `until` at the shared boundary, and asserts it stops there. Fails with `UC_ERR_FETCH_UNMAPPED` without the fix.
- Full unit suite passes (12/12).
