### PR TITLE
target/mips: fix spurious EXCP_RI under UC_TLB_VIRTUAL after a delay-slot TLB fill

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -42,7 +42,7 @@ ldr x0, [x1] <--- exception here and PC sync-ed here
 <details>
   <summary>For version >= 2.1.4 </summary>
 
-We should always have valid PC all the time. Please report an issue for your case.
+We should always have valid PC all the time, with one documented exception: inside a `UC_HOOK_TLB_FILL` callback the CPU registers (including PC) are *not* rolled back to the faulting instruction. See [the `UC_TLB_VIRTUAL` question below](#is-there-anyway-to-disable-softmmu-to-speed-up-execution) for details. Otherwise, please report an issue for your case.
 
 </details>
 
@@ -134,6 +134,10 @@ Starting from 2.0.2, Unicorn will emulate the MMU depending on the emulated arch
 Therefore, if you still prefer the previous `paddr = vaddr` simple mapping, we have a simple experimental MMU implementation that can be switched on by: `uc_ctl_tlb_mode(uc, UC_TLB_VIRTUAL)`. With this mode, you could also add a `UC_HOOK_TLB_FILL` hook to manage the TLB. When a virtual address is not cached, the hook will be called. Besides, users are allowed to flush the tlb with `uc_ctl_flush_tlb`.
 
 In theory, `UC_TLB_VIRTUAL` will achieve better performance as it skips all MMU details, though not benchmarked.
+
+The `UC_HOOK_TLB_FILL` callback is given the faulting *virtual* address and the access type, and returns the mapping for that page (physical address and permissions), or `false` to reject it. Decide the mapping from the address argument passed to the hook — **not** from the CPU registers. Unlike most hooks, the registers (including PC) are not guaranteed to be rolled back to the faulting instruction while the callback runs: on a successful fill the faulting access is resumed in place, so rolling the state back here would leak into the resumed execution (on MIPS, for example, it re-applies branch-delay-slot flags and raises a spurious Reserved Instruction exception). Keeping this off the register-restore path also avoids per-fill overhead.
+
+When the hook returns `false` — or when no hook is installed and a virtual address cannot be translated — `uc_emu_start` stops and returns `UC_ERR_MMU_READ`, `UC_ERR_MMU_WRITE`, or `UC_ERR_MMU_FETCH` depending on the access type. You can then read the faulting virtual address with `uc_ctl_get_invalid_addr(uc, &addr)`.
 
 ## Something is wrong - I would like to dig deeper
 

--- a/qemu/softmmu/unicorn_vtlb.c
+++ b/qemu/softmmu/unicorn_vtlb.c
@@ -67,7 +67,26 @@ bool unicorn_fill_tlb(CPUState *cs, vaddr address, int size,
     struct hook *hook;
     HOOK_FOREACH_VAR_DECLARE;
 
-    cpu_restore_state(cs, retaddr, false);
+    /*
+     * Unicorn: Do NOT unconditionally restore CPU state here.
+     *
+     * cpu_restore_state() rolls env back to the instruction boundary of the
+     * faulting access (it calls the target restore_state_to_opc()). On a
+     * successful fill the faulting access is then resumed in place inside the
+     * same TB, so any env mutation done here leaks into the continued
+     * execution. On MIPS this is fatal: restore_state_to_opc() re-applies the
+     * branch-delay hflags (MIPS_HFLAG_B / MIPS_HFLAG_BDS32 etc.) that were
+     * saved for a delay-slot instruction. Those bits are normally never present
+     * in the runtime hflags (they live only in the per-insn start data), so
+     * nothing ever clears them again, and the next TB (the branch target) is
+     * then translated as if it were sitting in a delay slot, raising a spurious
+     * EXCP_RI ("branch in delay / forbidden slot").
+     *
+     * The CPU own tlb_fill handlers (e.g. mips_cpu_tlb_fill) only restore
+     * state on the exception path. We mirror that: the exception path below
+     * restores via cpu_loop_exit_restore(), and the TLB_FILL hooks only need
+     * the faulting address (passed explicitly), not rolled-back register state.
+     */
 
     HOOK_FOREACH(uc, hook, UC_HOOK_TLB_FILL) {
         if (hook->to_delete) {

--- a/tests/unit/test_mips.c
+++ b/tests/unit/test_mips.c
@@ -222,7 +222,83 @@ static void test_mips_simple_coredump_2137(void)
     OK(uc_close(uc));
 }
 
+// Identity virtual-TLB fill hook: maps every virtual page to the same physical
+// address with full permissions.
+static bool test_mips_vtlb_identity_cb(uc_engine *uc, uint64_t addr,
+                                       uc_mem_type type, uc_tlb_entry *result,
+                                       void *user_data)
+{
+    result->paddr = addr;
+    result->perms = UC_PROT_ALL;
+    return true;
+}
+
+// Regression for issue #2272: under UC_TLB_VIRTUAL, a branch whose target is
+// itself a branch -- with a memory access in the first branch's delay slot,
+// forcing a TLB fill -- must not raise a spurious Reserved Instruction
+// exception. This mirrors glibc's __libc_setup_tls program-header (PT_TLS)
+// scan. The delay-slot load triggers unicorn_fill_tlb(), whose unconditional
+// cpu_restore_state() used to re-apply the branch-delay hflags into the live
+// env, so the branch-target block was decoded as if it sat in a delay slot.
+//
+// Note: this exercises the case where a UC_HOOK_TLB_FILL hook is registered
+// (how a soft-MMU front-end such as Qiling drives the virtual TLB), which the
+// permission-only change in PR #2273 does not address.
+static void test_mips_virtual_tlb_branch_in_delay_slot_2272(void)
+{
+    uc_engine *uc;
+    uc_hook hook;
+    // big-endian MIPS64:
+    //         li     $a1, 7
+    //         b      L_bne          # delay slot is the load below
+    //         lw     $v1, 0($v0)
+    // L_top:  sltu   $v1, $v0, $a0
+    //         beqz   $v1, L_exit
+    //         nop
+    //         lw     $v1, 0($v0)
+    // L_bne:  bne    $v1, $a1, L_top
+    //         daddiu $v0, $v0, 56   # delay slot
+    //         daddiu $v0, $v0, -56
+    // L_exit: jr     $ra
+    //         nop
+    char code[] = "\x24\x05\x00\x07\x10\x00\x00\x05\x8c\x43\x00\x00"
+                  "\x00\x44\x18\x2b\x10\x60\x00\x05\x00\x00\x00\x00"
+                  "\x8c\x43\x00\x00\x14\x65\xff\xfb\x64\x42\x00\x38"
+                  "\x64\x42\xff\xc8\x03\xe0\x00\x08\x00\x00\x00\x00";
+    const uint64_t data_base = 0x20000000;
+    uint64_t r_v0 = data_base;
+    uint64_t r_a0 = data_base + 56 * 4; // scan 4 program-header-sized entries
+    uint64_t r_a1 = 7;
+    uint64_t r_v1 = 0;
+    // a PT_TLS (type == 7) entry at index 3; earlier entries are type 0
+    char tls_type[] = "\x00\x00\x00\x07";
+
+    OK(uc_open(UC_ARCH_MIPS, UC_MODE_MIPS64 | UC_MODE_BIG_ENDIAN, &uc));
+    OK(uc_ctl_tlb_mode(uc, UC_TLB_VIRTUAL));
+    OK(uc_hook_add(uc, &hook, UC_HOOK_TLB_FILL, test_mips_vtlb_identity_cb, NULL,
+                   1, 0));
+    OK(uc_mem_map(uc, code_start, code_len, UC_PROT_ALL));
+    OK(uc_mem_write(uc, code_start, code, sizeof(code) - 1));
+    OK(uc_mem_map(uc, data_base, 0x1000, UC_PROT_ALL));
+    OK(uc_mem_write(uc, data_base + 56 * 3, tls_type, sizeof(tls_type) - 1));
+
+    OK(uc_reg_write(uc, UC_MIPS_REG_V0, &r_v0));
+    OK(uc_reg_write(uc, UC_MIPS_REG_A0, &r_a0));
+    OK(uc_reg_write(uc, UC_MIPS_REG_A1, &r_a1));
+
+    // Before the fix this raised a spurious EXCP_RI; with the fix it runs the
+    // scan to completion and finds the PT_TLS entry.
+    OK(uc_emu_start(uc, code_start, code_start + 0x28, 0, 0));
+
+    OK(uc_reg_read(uc, UC_MIPS_REG_V1, &r_v1)); // matched program-header type
+    TEST_CHECK(r_v1 == 7);
+
+    OK(uc_close(uc));
+}
+
 TEST_LIST = {
+    {"test_mips_virtual_tlb_branch_in_delay_slot_2272",
+     test_mips_virtual_tlb_branch_in_delay_slot_2272},
     {"test_mips_stop_at_branch", test_mips_stop_at_branch},
     {"test_mips_stop_at_delay_slot", test_mips_stop_at_delay_slot},
     {"test_mips_el_ori", test_mips_el_ori},


### PR DESCRIPTION
Fixes #2272.

### Symptom

Under `UC_TLB_VIRTUAL`, a memory access in a branch **delay slot** raises a spurious
`EXCP_RI` ("Reserved Instruction / branch in delay-forbidden slot") on the branch
*target*, aborting emulation. The MIPS repro is glibc's `__libc_setup_tls` PT_TLS
program-header scan, whose loop body ends in a branch whose delay-slot load forces a
TLB fill.

### Root cause

`unicorn_fill_tlb()` called `cpu_restore_state(cs, retaddr, false)` unconditionally.
`cpu_restore_state()` → `restore_state_to_opc()` rolls `env` back to the instruction
boundary of the faulting access, and on MIPS that re-applies the per-insn *start*
hflags. For a delay-slot instruction those include the branch hflags
(`MIPS_HFLAG_B` / `MIPS_HFLAG_BDS32` / …), which are only ever meant to exist during
translation, never in the live runtime hflags.

That rollback is fine on the paths `cpu_restore_state()` was designed for — the CPU is
about to *leave* the run loop (raise an exception, or read the exact PC then exit), so
the transient hflags are re-derived on the next entry and never observed. But on a
**successful** TLB fill the faulting access is resumed *in place* inside the same TB.
Nothing clears the leaked bits, so the next TB — the branch target — is translated as
if it sat in a delay slot, and MIPS raises `EXCP_RI`.

### Fix

Remove the unconditional `cpu_restore_state()` from the fill path. The exception path
still restores via `cpu_loop_exit_restore()` (in `raise_mmu_exception()`), mirroring the
CPUs' own `*_cpu_tlb_fill` handlers, which only restore on the exception path. The
`UC_HOOK_TLB_FILL` callback is invoked with the faulting page/type and the entry to
fill; it does not consume rolled-back register state.

This also removes a per-fill `cpu_restore_state()` from the hot path, which is exactly
the change requested for performance reasons in #2342.

Note on the earlier wording: I originally justified this as "the TLB_FILL callback only
needs the faulting address." That over-generalized — per the FAQ and #2342/#2049, hooks
are normally expected to see a synced PC. The accurate framing is the one above: the
restore is *unconditional on a resume-in-place path*, where it corrupts live `env` state
regardless of whether any hook is registered.

Note on #2273: it also targets #2272 but changes only the no-hook fallback path's
permissions; it does not fix the case where a `UC_HOOK_TLB_FILL` hook is registered
(verified — the RI still fires). This fix covers both paths and is orthogonal to #2273.

### Answer to "can a `UC_HOOK_MEM_*_UNMAPPED` hook trigger a similar bug?"

Yes — and it is not specific to the virtual TLB. The MEM hook paths in `cputlb.c`
(`UC_HOOK_MEM_READ`/`WRITE` and the `*_UNMAPPED` variants) also call
`cpu_restore_state(uc->cpu, retaddr, false)` before invoking the hook, and after a
`*_UNMAPPED` hook maps the page and returns `true` the faulting access likewise resumes
*in place*. So the same delay-slot hflag leak occurs.

I reproduced it in the **ordinary soft-MMU (no `UC_TLB_VIRTUAL`)**: a delay-slot load
that faults, serviced by a `UC_HOOK_MEM_READ_UNMAPPED` callback that maps the page and
returns `true`, resumes with the leaked hflags and raises `EXCP_RI` (intno 20 via
`UC_HOOK_INTR`; `UC_ERR_EXCEPTION` otherwise). Pre-mapping the page so no hook fires
makes the same program complete correctly — isolating the cause to the hook-triggered
`cpu_restore_state()`. Standalone failing repro (kept out of this PR): #2352.

The important difference: those MEM paths call `cpu_restore_state()` *deliberately*, to
honour the "synced PC in hooks" contract, and are already gated (`!synced &&
!skip_sync_pc_on_exit`). They can't simply drop the call the way the vtlb fill can.
The proper fix for that class is lower-level — clearing the transient branch hflags
after a resume-in-place restore (in `restore_state_to_opc()` / its MIPS callers) so the
contract and correctness both hold. That's a broader change than this regression fix, so
I've kept it out of this PR; happy to open a follow-up if you agree with the direction.

### Test

Adds `test_mips_virtual_tlb_branch_in_delay_slot_2272` in `tests/unit/test_mips.c`,
exercising the `UC_HOOK_TLB_FILL` path (how a soft-MMU front-end such as Qiling drives
the virtual TLB).



---

Downstream tracking: qilingframework/qiling#1645 (Qiling MIPS64 real-ELF/glibc support gates its CI tests on this fix).
