### PR TITLE
target/i386: Decode 0x8f as POP only if ModRM.reg == 0

### DIFF
--- a/qemu/target/i386/translate.c
+++ b/qemu/target/i386/translate.c
@@ -5881,8 +5881,14 @@ static target_ulong disas_insn(DisasContext *s, CPUState *cpu)
         tcg_gen_movi_tl(tcg_ctx, s->T0, val);
         gen_push_v(s, s->T0);
         break;
-    case 0x8f: /* pop Ev */
+    case 0x8f: /* GRP1a */
         modrm = x86_ldub_code(env, s);
+        /* Group 1a is decoded as pop Ev only if modrm.reg == 0.
+         * Other values are either reserved on Intel CPUs,
+         * or refer to XOP opcode maps on AMD CPUs
+         */
+        if ((modrm >> 3) & 7)
+            goto unknown_op;
         mod = (modrm >> 6) & 3;
         ot = gen_pop_T0(s);
         if (mod == 3) {


### PR DESCRIPTION
According to both table A-6 in Volume 2 of Intel 64 and IA-32 Architectures Software Developer's Manual and table A-6 in Volume 3 of AMD64 Architecture Programmer's Manual, opcode 0x8f (group 1a) is decoded as POP only if ModRM.reg == 0.

Currently, Unicorn does not perform this check, which makes it happily execute every group 1a instruction as POP, no matter if it's actually POP or not.

Fix this bug by adding a missing check.