### PR TITLE
target/i386: Fix LOCK prefix handling with BTx instructions

### DIFF
--- a/qemu/target/i386/translate.c
+++ b/qemu/target/i386/translate.c
@@ -7489,6 +7489,9 @@ static target_ulong disas_insn(DisasContext *s, CPUState *cpu)
         op = (modrm >> 3) & 7;
         mod = (modrm >> 6) & 3;
         rm = (modrm & 7) | REX_B(s);
+        /* LOCK BT and register-only forms of LOCK BTS/BTR/BTC are illegal */
+        if ((s->prefix & PREFIX_LOCK) && (mod == 3 || op == 4))
+            goto illegal_op;
         if (mod != 3) {
             s->rip_offset = 1;
             gen_lea_modrm(env, s, modrm);
@@ -7522,6 +7525,9 @@ static target_ulong disas_insn(DisasContext *s, CPUState *cpu)
         reg = ((modrm >> 3) & 7) | rex_r;
         mod = (modrm >> 6) & 3;
         rm = (modrm & 7) | REX_B(s);
+        /* LOCK BT and register-only forms of LOCK BTS/BTR/BTC are illegal */
+        if ((s->prefix & PREFIX_LOCK) && (mod == 3 || op == 0))
+            goto illegal_op;
         gen_op_mov_v_reg(s, MO_32, s->T1, reg);
         if (mod != 3) {
             AddressParts a = gen_lea_modrm_0(env, s, modrm);
@@ -7543,11 +7549,6 @@ static target_ulong disas_insn(DisasContext *s, CPUState *cpu)
         tcg_gen_shl_tl(tcg_ctx, s->tmp0, s->tmp0, s->T1);
         if (s->prefix & PREFIX_LOCK) {
             switch (op) {
-            case 0: /* bt */
-                /* Needs no atomic ops; we surpressed the normal
-                   memory load for LOCK above so do it now.  */
-                gen_op_ld_v(s, ot, s->T0, s->A0);
-                break;
             case 1: /* bts */
                 tcg_gen_atomic_fetch_or_tl(tcg_ctx, s->T0, s->A0, s->tmp0,
                                            s->mem_index, ot | MO_LE);

--- a/tests/unit/test_x86.c
+++ b/tests/unit/test_x86.c
@@ -2656,6 +2656,82 @@ static void test_x86_group_1a(void)
     OK(uc_close(uc));
 }
 
+static void test_x86_lock_bt_mem(void)
+{
+    uc_engine *uc;
+
+    // lock bt [rax], eax
+    char code[] = "\xf0\x0f\xa3\x00";
+
+    uc_common_setup(&uc, UC_ARCH_X86, UC_MODE_64, code, sizeof(code) - 1);
+
+    OK(uc_mem_map(uc, code_start + code_len, 0x1000, UC_PROT_ALL));
+    uc_assert_err(UC_ERR_INSN_INVALID, uc_emu_start(uc, code_start, code_start + sizeof(code) - 1, 0, 0));
+
+    OK(uc_close(uc));
+}
+
+static void test_x86_lock_bt_reg(void)
+{
+    uc_engine *uc;
+
+    // lock bt eax, eax
+    char code[] = "\xf0\x0f\xa3\xc0";
+
+    uc_common_setup(&uc, UC_ARCH_X86, UC_MODE_64, code, sizeof(code) - 1);
+
+    OK(uc_mem_map(uc, code_start + code_len, 0x1000, UC_PROT_ALL));
+    uc_assert_err(UC_ERR_INSN_INVALID, uc_emu_start(uc, code_start, code_start + sizeof(code) - 1, 0, 0));
+
+    OK(uc_close(uc));
+}
+
+static void test_x86_lock_btc_mem(void)
+{
+    uc_engine *uc;
+
+    // lock btc [rax], ebx
+    char code[] = "\xf0\x0f\xbb\x18";
+
+    uc_common_setup(&uc, UC_ARCH_X86, UC_MODE_64, code, sizeof(code) - 1);
+
+    OK(uc_mem_map(uc, code_start + code_len, 0x1000, UC_PROT_ALL));
+
+    char data[1] = "\x80";
+    OK(uc_mem_write(uc, code_start + code_len + 0x800, data, sizeof(data)));
+
+    uint64_t rax = code_start + code_len;
+    uint64_t rbx = 8*0x800+7;
+    OK(uc_reg_write(uc, UC_X86_REG_RAX, &rax));
+    OK(uc_reg_write(uc, UC_X86_REG_RBX, &rbx));
+
+    OK(uc_emu_start(uc, code_start, code_start + sizeof(code) - 1, 0, 0));
+
+    uint64_t rflags = 0;
+    OK(uc_reg_read(uc, UC_X86_REG_RFLAGS, &rflags));
+    TEST_CHECK((rflags & 1) != 0); // RFLAGS.CF must be set
+
+    OK(uc_mem_read(uc, code_start + code_len + 0x800, data, sizeof(data)));
+    TEST_CHECK(data[0] == 0);
+
+    OK(uc_close(uc));
+}
+
+static void test_x86_lock_btc_reg(void)
+{
+    uc_engine *uc;
+
+    // lock btc eax, eax
+    char code[] = "\xf0\x0f\xbb\xc0";
+
+    uc_common_setup(&uc, UC_ARCH_X86, UC_MODE_64, code, sizeof(code) - 1);
+
+    OK(uc_mem_map(uc, code_start + code_len, 0x1000, UC_PROT_ALL));
+    uc_assert_err(UC_ERR_INSN_INVALID, uc_emu_start(uc, code_start, code_start + sizeof(code) - 1, 0, 0));
+
+    OK(uc_close(uc));
+}
+
 TEST_LIST = {
     {"test_x86_in", test_x86_in},
     {"test_x86_out", test_x86_out},
@@ -2734,4 +2810,8 @@ TEST_LIST = {
     {"test_x86_aaa_flags", test_x86_aaa_flags},
     {"test_x86_aas_flags", test_x86_aas_flags},
     {"test_x86_group_1a", test_x86_group_1a},
+    {"test_x86_lock_bt_mem", test_x86_lock_bt_mem},
+    {"test_x86_lock_bt_reg", test_x86_lock_bt_reg},
+    {"test_x86_lock_btc_mem", test_x86_lock_btc_mem},
+    {"test_x86_lock_btc_reg", test_x86_lock_btc_reg},
     {NULL, NULL}};


### PR DESCRIPTION
According to the Intel 64 and IA-32 Software Developer's Manual, LOCK BT and forms of LOCK BTS/BTR/BTC where the destination is not a memory operand raise an invalid opcode (#UD) exception when executed.

Currently, Unicorn does not check for these conditions when decoding BTx instructions. This behavior not only does not match the hardware's behavior, but also allows Unicorn to crash, since in register-only forms, the `s->A0` temp can be used uninitialized (allocated, but not written to), leading to a `tcg fatal error` later because that temp is marked as "dead" and is later used in `temp_load()`, which then calls `tcg_abort();`.

Fix this bug by adding the missing checks.