### PR TITLE
docs: fix documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Unicorn offers some unparalleled features:
 - Multi-architecture: ARM, ARM64 (ARMv8), M68K, MIPS, PowerPC, RISCV, SPARC, S390X, TriCore and X86 (16, 32, 64-bit)
 - Clean/simple/lightweight/intuitive architecture-neutral API
 - Implemented in pure C language, with bindings for Crystal, Clojure, Visual Basic, Perl, Rust, Ruby, Python, Java, .NET, Go, Delphi/Free Pascal, Haskell, Pharo, Lua and Zig.
-- Native support for Windows & *nix (with Mac OSX, Linux, Android, *BSD & Solaris confirmed)
+- Native support for Windows & *nix (with Mac OS X, Linux, Android, *BSD & Solaris confirmed)
 - High performance via Just-In-Time compilation
 - Support for fine-grained instrumentation at various levels
 - Thread-safety by design

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -4,7 +4,7 @@ To download/update the Unicorn Go bindings, run:
 
 A very basic usage example follows
 
-_(Does not handle most errors for brevity. Please see sample.go for a more hygenic example):_
+_(Does not handle most errors for brevity. Please see sample.go for a more hygienic example):_
 
     package main
 

--- a/docs/COMPILE.md
+++ b/docs/COMPILE.md
@@ -1,6 +1,6 @@
 This HOWTO introduces how to build Unicorn2 natively on Linux/Mac/Windows or cross-build to Windows from Linux host.
 
-Note: By default, CMake will build both the shared and static libraries while only static libraries are built if unicorn is used as a Cmake subdirectory. In most cases, you don't need to care about which kind of library to build. ONLY use `BUILD_SHARED_LIBS=no`if you know what you are doing.
+Note: By default, CMake will build both the shared and static libraries while only static libraries are built if Unicorn is used as a CMake subdirectory. In most cases, you don't need to care about which kind of library to build. ONLY use `BUILD_SHARED_LIBS=no` if you know what you are doing.
 
 ## Native build on Linux/macOS
 
@@ -49,7 +49,7 @@ Note, other generators like `Ninja` and `Visual Studio 16 2019` would also work.
 ```bash
 mkdir build; cd build
 cmake .. -G "Visual Studio 16 2019" -A "win32" -DCMAKE_BUILD_TYPE=Release
-msbuild unicorn.sln -p:Plaform=Win32 -p:Configuration=Release
+msbuild unicorn.sln -p:Platform=Win32 -p:Configuration=Release
 ```
 
 ## Cross build with NDK

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -125,7 +125,7 @@ To provide end users with simple API, Unicorn does lots of dirty hacks within qe
 
 Yes, it’s possible but that is not Unicorn’s goal and there is no simple switch in qemu to disable softmmu.
 
-Starting from 2.0.2, Unicorn will emulate the MMU depending on the emulated architecture without further hacks. That said, Unicorn offers the full ability of the target MMU implementation. While this enables more possibilities of Uncorn, it has a few drawbacks:
+Starting from 2.0.2, Unicorn will emulate the MMU depending on the emulated architecture without further hacks. That said, Unicorn offers the full ability of the target MMU implementation. While this enables more possibilities of Unicorn, it has a few drawbacks:
 
 - As previous question points out already, some memory regions are not writable/executable.
 - You have to always check architecture-specific registers to confirm MMU status.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-Documention of Unicorn engine.
+Documentation of Unicorn engine.
 
 * How to compile & install Unicorn.
 
@@ -12,6 +12,6 @@ Documention of Unicorn engine.
 
 	http://unicorn-engine.org/docs/beyond_qemu.html
 
-* Uncorn-Engine Documentation
+* Unicorn-Engine Documentation
 
 	https://github.com/kabeor/Unicorn-Engine-Documentation


### PR DESCRIPTION
Hello maintainer:

This PR just fix some typos in the documentation.

Resubmit from https://github.com/unicorn-engine/unicorn/pull/2351