### PR TITLE
Fix __int128_t redefinition in int128.h !CONFIG_INT128 fallback on Clang/GCC

### DIFF
--- a/.github/workflows/int128-regression.yml
+++ b/.github/workflows/int128-regression.yml
@@ -1,0 +1,41 @@
+name: int128 fallback regression
+
+# Guards the !CONFIG_INT128 fallback in qemu/include/qemu/int128.h against the
+# __int128_t redefinition that broke real Clang builds (e.g. Apple clang on
+# arm64, and the Rust unicorn-engine-sys crate). The existing C-library CI builds
+# on macos-14 (arm64) but via cmake with CONFIG_INT128 defined, so it uses the
+# native path and never compiles the fallback; the Rust-crate CI does not run on
+# Apple Silicon. This job compiles the fallback construct directly on every
+# platform whose compiler exposes the __int128_t builtin — including arm64
+# Apple clang, where the pre-fix guard fails.
+
+on:
+  push:
+    paths:
+      - 'qemu/include/qemu/int128.h'
+      - 'tests/regress/int128_redefinition.c'
+      - '.github/workflows/int128-regression.yml'
+  pull_request:
+    paths:
+      - 'qemu/include/qemu/int128.h'
+      - 'tests/regress/int128_redefinition.c'
+      - '.github/workflows/int128-regression.yml'
+  workflow_dispatch:
+
+jobs:
+  compile:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, name: 'linux-x86_64' }
+          - { os: macos-13,      name: 'macos-x86_64 (Intel clang)' }
+          - { os: macos-14,      name: 'macos-arm64 (Apple clang)' }
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compile + run int128 fallback regression
+        run: |
+          cc -Wall -Wextra -Werror -o int128_regress tests/regress/int128_redefinition.c
+          ./int128_regress

--- a/qemu/include/qemu/int128.h
+++ b/qemu/include/qemu/int128.h
@@ -146,7 +146,18 @@ static inline Int128 bswap128(Int128 a)
 #else /* !CONFIG_INT128 */
 
 typedef struct Int128 Int128;
-#if !(defined(_MSC_VER) && defined(__clang__))
+/*
+ * In the !CONFIG_INT128 fallback, QEMU aliases the reserved builtin name
+ * __int128_t to the struct so fallback code can name it. That is only valid on
+ * compilers that do NOT provide __int128_t as a builtin: emitting it where the
+ * builtin exists is a "typedef redefinition with different types" error. The
+ * builtin is present iff __SIZEOF_INT128__ is defined (GCC/Clang), so gate on
+ * that. This subsumes the earlier clang-cl-only guard (#2251) and fixes the
+ * redefinition seen with regular Clang (e.g. Apple clang on arm64) whenever the
+ * build reaches this fallback. Regression test: tests/regress/int128_redefinition.c
+ * (keep the guard below in sync with it).
+ */
+#if !defined(__SIZEOF_INT128__)
 typedef Int128 __int128_t;
 #endif
 

--- a/tests/regress/int128_redefinition.c
+++ b/tests/regress/int128_redefinition.c
@@ -1,0 +1,43 @@
+/*
+ * Regression guard for the __int128_t redefinition in
+ * qemu/include/qemu/int128.h (the "#else / !CONFIG_INT128" fallback).
+ *
+ * In that fallback QEMU aliases the reserved builtin name __int128_t to its
+ * struct Int128 so fallback code can name the type. That is only valid on
+ * compilers that do NOT provide __int128_t as a builtin; on GCC/Clang (where
+ * __SIZEOF_INT128__ is defined) emitting the alias is a "typedef redefinition
+ * with different types" error. It bit real Clang builds (e.g. Apple clang on
+ * arm64, and the Rust unicorn-engine-sys crate) whenever the build reached the
+ * fallback. int128.h now gates the alias on !defined(__SIZEOF_INT128__), which
+ * subsumes the earlier clang-cl-only guard from PR #2251.
+ *
+ * This test reproduces the exact construct so CI compilers that DO have the
+ * __int128_t builtin (every Linux/macOS runner) keep compiling it. Compiled
+ * with -Werror, the pre-fix clang-cl-only guard fails here on such compilers.
+ * Keep the guard below in sync with int128.h's fallback typedef.
+ */
+
+#include <stdint.h>
+
+typedef struct Int128 Int128;
+#if !defined(__SIZEOF_INT128__)
+/* Only aliased when the compiler lacks the __int128_t builtin (e.g. MSVC). */
+typedef Int128 __int128_t;
+#endif
+
+struct Int128 {
+    uint64_t lo;
+    int64_t hi;
+};
+
+int main(void)
+{
+    /*
+     * On a compiler with the builtin, __int128_t still names the 128-bit type
+     * (the struct alias above was correctly skipped). Exercise both so the file
+     * fails to compile if the guard ever redefines the builtin again.
+     */
+    Int128 fallback = { 1, 2 };
+    __int128_t native = ((__int128_t)fallback.hi << 64) | fallback.lo;
+    return native == (((__int128_t)2 << 64) | 1) ? 0 : 1;
+}


### PR DESCRIPTION
## Problem

Building QEMU's `int128.h` fails on Clang/GCC whenever the build reaches the
`!CONFIG_INT128` fallback:

```
qemu/include/qemu/int128.h:150:16: error: typedef redefinition with different types
    ('Int128' (aka 'struct Int128') vs '__int128')
typedef Int128 __int128_t;
```

The fallback aliases the **reserved builtin name** `__int128_t` to `struct Int128`
so fallback code can name the type. That is only valid on compilers that do *not*
provide `__int128_t` as a builtin. On GCC/Clang the builtin always exists (when
128-bit ints are supported), so the alias is a redefinition error.

This bit two real setups:
- **Apple clang on arm64** (macOS), and
- the Rust **`unicorn-engine-sys`** crate's vendored build (its cmake path ends up
  without `CONFIG_INT128`, so it compiles the fallback — and fails on any modern
  clang/gcc).

#2251 added the current guard `#if !(defined(_MSC_VER) && defined(__clang__))`,
but that only covers **clang-cl**; regular Clang/GCC still hit the redefinition.

## Fix

Gate the alias on `!defined(__SIZEOF_INT128__)`. `__SIZEOF_INT128__` is the standard
macro that is defined **iff** the compiler provides the 128-bit builtin, so:
- GCC/Clang (incl. clang-cl): builtin present → alias skipped (uses the builtin) ✅
- MSVC: no builtin → alias emitted (as before) ✅

This subsumes #2251 and fixes the general case.

## Validation

- `tests/regress/int128_redefinition.c` — a self-contained reproduction of the
  fallback construct. It **fails to compile with the old guard** on any
  `__int128`-capable compiler and compiles cleanly with the fix (verified on Apple
  clang / arm64, producing the exact error above pre-fix).
- `.github/workflows/int128-regression.yml` — compiles + runs that test on
  `macos-14` (Apple Silicon, arm64 clang), `macos-13` (Intel) and Linux.

**Why a new job:** existing CI never exercises this fallback on arm64 clang — the
C-library CI builds on `macos-14` via cmake with `CONFIG_INT128` defined (native
path, fallback not compiled), and the Rust-crate CI (`Crate-publishing.yml`) does
not run on Apple Silicon.

Happy to drop the test/CI or fold it into an existing workflow if maintainers prefer.