### PR TITLE
fix: zero-extend tricore ld.bu(#2348)

### DIFF
--- a/qemu/target/tricore/translate.c
+++ b/qemu/target/tricore/translate.c
@@ -5293,7 +5293,7 @@ static void decode_bo_addrmode_ld_post_pre_base(DisasContext *ctx)
         tcg_gen_addi_tl(tcg_ctx, tcg_ctx->cpu_gpr_a[r2], tcg_ctx->cpu_gpr_a[r2], off10);
         break;
     case OPC2_32_BO_LD_BU_PREINC:
-        gen_ld_preincr(ctx, tcg_ctx->cpu_gpr_d[r1], tcg_ctx->cpu_gpr_a[r2], off10, MO_SB);
+        gen_ld_preincr(ctx, tcg_ctx->cpu_gpr_d[r1], tcg_ctx->cpu_gpr_a[r2], off10, MO_UB);
         break;
     case OPC2_32_BO_LD_D_SHORTOFF:
         CHECK_REG_PAIR(r1);

--- a/tests/unit/test_tricore.c
+++ b/tests/unit/test_tricore.c
@@ -1,6 +1,42 @@
 #include "unicorn_test.h"
 
-const uint64_t code_start = 0x1000;
-const uint64_t code_len = 0x4000;
+const uint64_t code_start = 0x10000;
+const uint64_t code_len = 0x10000;
 
-TEST_LIST = {{NULL, NULL}};
+static void uc_common_setup(uc_engine **uc, uc_arch arch, uc_mode mode,
+                            const char *code, uint64_t size)
+{
+    OK(uc_open(arch, mode, uc));
+    OK(uc_mem_map(*uc, code_start, code_len, UC_PROT_ALL));
+    OK(uc_mem_write(*uc, code_start, code, size));
+}
+
+static void test_tricore_ld_bu_preinc(void)
+{
+    uc_engine *uc;
+    char code[] = "\x09\x2f\x41\x04"; // ld.bu d15, [+a2]0x1
+    const uint64_t data_addr = 0x20000;
+    uint32_t d15 = 0;
+    uint32_t a2 = data_addr;
+    uint8_t data = 0xbc;
+
+    uc_common_setup(&uc, UC_ARCH_TRICORE, UC_MODE_LITTLE_ENDIAN, code,
+                    sizeof(code) - 1);
+    OK(uc_mem_map(uc, data_addr, 0x10000, UC_PROT_ALL));
+    OK(uc_mem_write(uc, data_addr + 1, &data, sizeof(data)));
+    OK(uc_reg_write(uc, UC_TRICORE_REG_A2, &a2));
+
+    OK(uc_emu_start(uc, code_start, code_start + sizeof(code) - 1, 0, 1));
+
+    OK(uc_reg_read(uc, UC_TRICORE_REG_D15, &d15));
+    OK(uc_reg_read(uc, UC_TRICORE_REG_A2, &a2));
+
+    TEST_CHECK(a2 == data_addr + 1);
+    TEST_CHECK(d15 == 0x000000bc);
+
+    OK(uc_close(uc));
+}
+
+TEST_LIST = {
+    {"test_tricore_ld_bu_preinc", test_tricore_ld_bu_preinc},
+    {NULL, NULL}};


### PR DESCRIPTION
close https://github.com/unicorn-engine/unicorn/issues/2348

## verify

```python
from unicorn import *
from unicorn.tricore_const import *
CODE=b"\x09\x2f\x41\x04"  # ld.bu d15, [+a2]0x1
CODE_ADDR=0x10000
DATA_ADDR=0x20000

mu=Uc(UC_ARCH_TRICORE, UC_MODE_LITTLE_ENDIAN)
mu.mem_map(CODE_ADDR, 0x10000)
mu.mem_map(DATA_ADDR, 0x10000)
mu.mem_write(CODE_ADDR, CODE)
mu.mem_write(DATA_ADDR + 1, b"\xbc")
mu.reg_write(UC_TRICORE_REG_A2, DATA_ADDR)
mu.emu_start(CODE_ADDR, CODE_ADDR + len(CODE), count=1)

d15=mu.reg_read(UC_TRICORE_REG_D15)
a2=mu.reg_read(UC_TRICORE_REG_A2)

print(f"D15=0x{d15:08x}")
print(f"A2=0x{a2:08x}")
assert d15 == 0x000000bc
assert a2 == DATA_ADDR + 1
```

Expected output:

```bash
D15=0x000000bc
A2=0x00020001
```

Also tests https://github.com/unicorn-engine/unicorn/issues/2348:

Output:

```bash
ld.bu d0,[a15]      -> 0x00000080
ld.bu d15,[+a2]0x1  -> 0x000000BC
```