### PR TITLE
handle unmapped until address correct

### DIFF
--- a/qemu/accel/tcg/translate-all.c
+++ b/qemu/accel/tcg/translate-all.c
@@ -1132,10 +1132,14 @@ static void uc_tb_flush(struct uc_struct *uc) {
 static void uc_invalidate_tb(struct uc_struct *uc, uint64_t start_addr, size_t len) 
 {
     tb_page_addr_t start, end;
+    uint64_t invalid_addr = uc->invalid_addr;
+    int invalid_error = uc->invalid_error;
 
     uc->nested_level++;
     if (sigsetjmp(uc->jmp_bufs[uc->nested_level - 1], 0) != 0) {
         // We a get cpu fault in get_page_addr_code, ignore it.
+        uc->invalid_addr = invalid_addr;
+        uc->invalid_error = invalid_error;
         uc->nested_level--;
         return;
     }
@@ -1150,6 +1154,12 @@ static void uc_invalidate_tb(struct uc_struct *uc, uint64_t start_addr, size_t l
     start = get_page_addr_code(uc->cpu->env_ptr, start_addr) & (target_ulong)(-1);
 
     uc->nested_level--;
+
+    if (start == -1) {
+        uc->invalid_addr = invalid_addr;
+        uc->invalid_error = invalid_error;
+        return;
+    }
 
     // For 32bit target.
     end = (start + len) & (target_ulong)(-1);

--- a/tests/unit/test_ctl.c
+++ b/tests/unit/test_ctl.c
@@ -429,6 +429,35 @@ static void test_add_block_hook(void)
     OK(uc_close(uc));
 }
 
+static bool test_unmapped_end_tlb_fill_hook(uc_engine *uc, uint64_t addr,
+                                            uc_mem_type type,
+                                            uc_tlb_entry *result,
+                                            void *user_data)
+{
+    return false;
+}
+
+static void test_unmapped_end(void)
+{
+    uc_engine *uc;
+    uc_hook syscall_hook;
+    uc_hook tlb_hook;
+    /* nop
+     * syscall
+     */
+    char code[] = "\x90\x0F\x05";
+
+    uc_common_setup(&uc, UC_ARCH_X86, UC_MODE_64, code, sizeof(code) - 1);
+    OK(uc_ctl_tlb_mode(uc, UC_TLB_VIRTUAL));
+    OK(uc_hook_add(uc, &tlb_hook, UC_HOOK_TLB_FILL,
+                   test_unmapped_end_tlb_fill_hook, NULL, 0, code_start - 1));
+    OK(uc_hook_add(uc, &syscall_hook, UC_HOOK_INSN,
+                   &test_add_block_hook_syscall_cb, NULL, 1, 0,
+                   UC_X86_INS_SYSCALL));
+    OK(uc_emu_start(uc, code_start, 1, 0, 0));
+    OK(uc_close(uc));
+}
+
 TEST_LIST = {
     {"test_uc_ctl_mode", test_uc_ctl_mode},
     {"test_uc_ctl_page_size", test_uc_ctl_page_size},
@@ -448,4 +477,5 @@ TEST_LIST = {
     {"test_tlb_clear", test_tlb_clear},
     {"test_noexec", test_noexec},
     {"test_add_block_hook", test_add_block_hook},
+    {"test_unmapped_end", test_unmapped_end},
     {NULL, NULL}};


### PR DESCRIPTION
To implement the util/end parameter a special instruction is placed at this address. After the execution the corresponding TB is cleared because the until parameter might change. To find the correct tb the mmu is used. Without this change the mmu might override the invalid_error and invalid_addr.