### PR TITLE
tests: pre-translate the tb in arm_movr12_hang

### DIFF
--- a/tests/regress/arm_movr12_hang.py
+++ b/tests/regress/arm_movr12_hang.py
@@ -26,7 +26,7 @@ class MovHang(regress.RegressTest):
         # svc stops emulation in-band instead. The timeout is only a hang guard,
         # with headroom for a scheduler stall on a loaded machine.
         uc.ctl_request_cache(0x1000)
-        uc.emu_start(0x1000, 0x1008, timeout=10_000)
+        uc.emu_start(0x1000, 0x1008, timeout=10000)
 
         self.assertEqual(0x0, uc.reg_read(UC_ARM_REG_R12))
         self.assertEqual(uc.count, 1)

--- a/tests/regress/arm_movr12_hang.py
+++ b/tests/regress/arm_movr12_hang.py
@@ -5,11 +5,10 @@ from unicorn.arm_const import *
 
 class MovHang(regress.RegressTest):
 
-    # NOTE: This test was failing when workflow was using ubuntu-latest + qemu. Fixed once switched to native arm runner
     def runTest(self):
         uc = Uc(UC_ARCH_ARM, UC_MODE_ARM)
         uc.mem_map(0x1000, 0x1000)
-        uc.mem_write(0x1000, b'\x00\xc0\x00\xe3')  # movw r12, #0
+        uc.mem_write(0x1000, b'\x00\xc0\x00\xe3\x00\x00\x00\xef')  # movw r12, #0 ; svc #0
 
         def hook_block(uc, addr, *args):
             regress.logger.debug('enter block 0x%#06x', addr)
@@ -19,10 +18,15 @@ class MovHang(regress.RegressTest):
         self.assertEqual(0x123, uc.reg_read(UC_ARM_REG_R12))
 
         uc.hook_add(UC_HOOK_BLOCK, hook_block)
+        uc.hook_add(UC_HOOK_INTR, lambda uc, intno, data: uc.emu_stop())
         uc.count = 0
 
-        # print 'block should only run once'
-        uc.emu_start(0x1000, 0x1004, timeout=500)
+        # Translate the block up front so the timeout bounds execution only, not
+        # code generation. A pre-built tb does not carry the `until` exit, so the
+        # svc stops emulation in-band instead. The timeout is only a hang guard,
+        # with headroom for a scheduler stall on a loaded machine.
+        uc.ctl_request_cache(0x1000)
+        uc.emu_start(0x1000, 0x1008, timeout=10_000)
 
         self.assertEqual(0x0, uc.reg_read(UC_ARM_REG_R12))
         self.assertEqual(uc.count, 1)


### PR DESCRIPTION
Fixes the intermittent `arm_movr12_hang` failure on the `macos-14 - x86_64` wheel job (#2383). The 500us timeout bounded TCG code generation as well as execution, and cold codegen is most of that window.

Pre-translate the block with `uc_ctl_request_cache` so the timeout bounds execution only. A pre-built tb does not carry the `until` exit, so the block now ends in `svc` and a `UC_HOOK_INTR` hook stops emulation in-band.

The timeout is also raised to 10ms to cover the risk of a scheduler preemption stalling the thread mid-window. Load is not required for this: the worst off-CPU stall measured on an idle 16-core box was 627 µs, already past the old 500 µs bound, and it reaches tens of ms under contention.

Measured under 2x CPU oversubscription, 1000 runs each: 2.50% failures before, 0% after.

Approach suggested by @PhilippTakacs in #2383.
