### PR TITLE
arm: Add missing hflag update after writing PSTATE

### DIFF
--- a/qemu/target/arm/unicorn_aarch64.c
+++ b/qemu/target/arm/unicorn_aarch64.c
@@ -383,6 +383,7 @@ uc_err reg_write(void *_env, int mode, unsigned int regid, const void *value,
         case UC_ARM64_REG_PSTATE:
             CHECK_REG_TYPE(uint32_t);
             pstate_write(env, *(uint32_t *)value);
+            arm_rebuild_hflags(env);
             break;
         case UC_ARM64_REG_TTBR0_EL1:
             CHECK_REG_TYPE(uint64_t);

--- a/tests/unit/test_arm64.c
+++ b/tests/unit/test_arm64.c
@@ -944,6 +944,32 @@ static void test_arm64_pauth_ctl(void)
     OK(uc_close(uc));
 }
 
+static void test_arm64_pstate_hflags_rebuild(void)
+{
+    uc_engine *uc;
+    // mrs x0, currentel
+    char code[] = "\x40\x42\x38\xd5";
+    uint64_t x0 = 0, pstate = 0;
+
+    uc_common_setup(&uc, UC_ARCH_ARM64, UC_MODE_LITTLE_ENDIAN | UC_MODE_ARM,
+                    code, sizeof(code) - 1, UC_CPU_ARM64_MAX);
+
+    // Elevate to EL2 by writing PSTATE. Writing PSTATE must refresh the cached
+    // hflags, otherwise the current exception level stays stale and MRS
+    // CurrentEL (as well as a subsequent ERET) observes the old level.
+    OK(uc_reg_read(uc, UC_ARM64_REG_PSTATE, &pstate));
+    pstate = (pstate & ~0xcUL) | (2UL << 2); // PSTATE.EL = 2 (EL2)
+    OK(uc_reg_write(uc, UC_ARM64_REG_PSTATE, &pstate));
+
+    OK(uc_emu_start(uc, code_start, code_start + sizeof(code) - 1, 0, 1));
+
+    OK(uc_reg_read(uc, UC_ARM64_REG_X0, &x0));
+    // CurrentEL reports the current EL in bits [3:2]; EL2 -> 0x8.
+    TEST_CHECK(x0 == 0x8);
+
+    OK(uc_close(uc));
+}
+
 TEST_LIST = {{"test_arm64_until", test_arm64_until},
              {"test_arm64_code_patching", test_arm64_code_patching},
              {"test_arm64_code_patching_count", test_arm64_code_patching_count},
@@ -965,4 +991,6 @@ TEST_LIST = {{"test_arm64_until", test_arm64_until},
              {"test_arm64_pc_guarantee", test_arm64_pc_guarantee},
              {"test_arm64_pauth_vanilla", test_arm64_pauth_vanilla},
              {"test_arm64_pauth_ctl", test_arm64_pauth_ctl},
+             {"test_arm64_pstate_hflags_rebuild",
+              test_arm64_pstate_hflags_rebuild},
              {NULL, NULL}};


### PR DESCRIPTION
## Summary

Fixes #2333.

`uc_reg_write(UC_ARM64_REG_PSTATE, ...)` called `pstate_write()` but did not refresh `env->hflags`. QEMU caches PSTATE-derived state (current exception level, SP selection, ...) in `hflags`, and `MRS CurrentEL` in particular is materialized as a translate-time constant from the TB flags. So after a user raises the exception level by writing PSTATE, `MRS CurrentEL` and a subsequent `ERET` still observed the stale level.

The fix mirrors the existing `UC_ARM64_REG_CP_REG` case (which already calls `arm_rebuild_hflags()`), and the merged AArch32 counterpart #2268 ("arm: Add missing hflag update after writing xpsr"). The `arm_rebuild_hflags` mechanism itself was introduced for cp-regs in #1844.

## Before / after

Writing PSTATE to elevate to EL2, then executing `MRS X0, CurrentEL`:

* **Before:** `X0 = 0x4` (stale EL1).
* **After:** `X0 = 0x8` (EL2), matching the written PSTATE.

## Testing

Added `test_arm64_pstate_hflags_rebuild` in `tests/unit/test_arm64.c`: it writes PSTATE to EL2 and asserts `MRS CurrentEL` reports EL2. The assertion fails on the unpatched tree (returns EL1) and passes with the fix. The full unit-test suite passes.

## Scope

* The other direct EL1 register writes in this switch (`TTBR0/1`, `MAIR`, `PAR`, `VBAR`) do not feed `hflags`, so they need no rebuild.
* `UC_ARM64_REG_CPACR_EL1` does feed the SVE-related hflags (`SVEEXC_EL`/`ZCR_LEN`); refreshing it is a separate, lower-impact concern that can be handled as a follow-up if desired.
* Issue #2333 also mentions a secondary problem (a `CurrentEL` `raw_read`/`fieldoffset` assert); that is out of scope for this change.
