### PR TITLE
riscv: gate counter CSRs on mcounteren at every priv version

### DIFF
--- a/qemu/target/riscv/csr.c
+++ b/qemu/target/riscv/csr.c
@@ -458,15 +458,6 @@ static int ctr(CPURISCVState *env, int csrno)
         return -1;
     }
 
-    /*
-     * The counters are always enabled at run time on newer priv specs, as the
-     * CSR has changed from controlling that the counters can be read to
-     * controlling that the counters increment.
-     */
-    if (env->priv_ver > PRIV_VERSION_1_09_1) {
-        return 0;
-    }
-
     if (env->priv < PRV_M) {
         ctr_en &= env->mcounteren;
     }

--- a/tests/unit/test_riscv.c
+++ b/tests/unit/test_riscv.c
@@ -55,6 +55,25 @@ static void test_riscv64_nop(void)
     OK(uc_close(uc));
 }
 
+static void test_riscv64_mcounteren(void)
+{
+    uc_engine *uc;
+    const char code[] = "\x73\x25\x30\xb0"; // csrr a0, hpmcounter3
+    uint64_t mcounteren = 0;
+    uint64_t priv = 0;
+
+    OK(uc_open(UC_ARCH_RISCV, UC_MODE_RISCV64, &uc));
+    OK(uc_mem_map(uc, code_start, code_len, UC_PROT_ALL));
+    OK(uc_mem_write(uc, code_start, code, sizeof(code) - 1));
+    OK(uc_reg_write(uc, UC_RISCV_REG_MCOUNTEREN, &mcounteren));
+    OK(uc_reg_write(uc, UC_RISCV_REG_PRIV, &priv));
+
+    uc_assert_err(UC_ERR_EXCEPTION,
+                  uc_emu_start(uc, code_start,
+                                code_start + sizeof(code) - 1, 0, 0));
+    OK(uc_close(uc));
+}
+
 static void test_riscv32_until_pc_update(void)
 {
     uc_engine *uc;
@@ -911,6 +930,7 @@ static void test_riscv_priv(void)
 TEST_LIST = {
     {"test_riscv32_nop", test_riscv32_nop},
     {"test_riscv64_nop", test_riscv64_nop},
+    {"test_riscv64_mcounteren", test_riscv64_mcounteren},
     {"test_riscv32_3steps_pc_update", test_riscv32_3steps_pc_update},
     {"test_riscv64_3steps_pc_update", test_riscv64_3steps_pc_update},
     {"test_riscv64_until_at_page_end", test_riscv64_until_at_page_end},


### PR DESCRIPTION
Fixes #2387

## Change

Remove the version-based early-success branch from qemu/target/riscv/csr.c:ctr() so the existing mcounteren and scounteren checks apply to every supported privileged-spec version. M-mode access remains unchanged.

## Validation

- Rebased onto dev.
- Added test_riscv64_mcounteren in tests/unit/test_riscv.c.
- The public u009 witness reaches UC_ERR_EXCEPTION on the gated U-mode read.
- The M-mode legal-access control remains functional.

Public reproducer:
https://github.com/carlosqwqqwq/unicorn-riscv-repros/tree/main/u009

Verify that M-mode counter access is unaffected, S/U-mode accesses are gated by `mcounteren`/`scounteren`, and existing counter and CSR tests remain unchanged.
