### PR TITLE
riscv: reject odd instruction addresses at fetch time

### DIFF
--- a/qemu/target/riscv/translate.c
+++ b/qemu/target/riscv/translate.c
@@ -849,7 +849,13 @@ static void riscv_tr_translate_insn(DisasContextBase *dcbase, CPUState *cpu)
     bool insn_hook = false;
 
     // Unicorn: end address tells us to stop emulation
-    if (uc_addr_is_exit(uc, ctx->base.pc_next)) {
+    if (ctx->base.pc_next & 1) {
+        /*
+         * IALIGN=16: an odd instruction address is always misaligned,
+         * even with the C extension.
+         */
+        gen_exception_inst_addr_mis(ctx);
+    } else if (uc_addr_is_exit(uc, ctx->base.pc_next)) {
         // Unicorn: We have to exit current execution here.
         dcbase->is_jmp = DISAS_UC_EXIT;
     } else {

--- a/tests/unit/test_riscv.c
+++ b/tests/unit/test_riscv.c
@@ -55,6 +55,19 @@ static void test_riscv64_nop(void)
     OK(uc_close(uc));
 }
 
+static void test_riscv64_odd_pc(void)
+{
+    uc_engine *uc;
+    const char code[] = "\x13\x00\x00\x00"; // nop
+
+    uc_common_setup(&uc, UC_ARCH_RISCV, UC_MODE_RISCV64, code,
+                    sizeof(code) - 1);
+    uc_assert_err(UC_ERR_EXCEPTION,
+                  uc_emu_start(uc, code_start + 1,
+                                code_start + sizeof(code) - 1, 0, 0));
+    OK(uc_close(uc));
+}
+
 static void test_riscv32_until_pc_update(void)
 {
     uc_engine *uc;
@@ -911,6 +924,7 @@ static void test_riscv_priv(void)
 TEST_LIST = {
     {"test_riscv32_nop", test_riscv32_nop},
     {"test_riscv64_nop", test_riscv64_nop},
+    {"test_riscv64_odd_pc", test_riscv64_odd_pc},
     {"test_riscv32_3steps_pc_update", test_riscv32_3steps_pc_update},
     {"test_riscv64_3steps_pc_update", test_riscv64_3steps_pc_update},
     {"test_riscv64_until_at_page_end", test_riscv64_until_at_page_end},


### PR DESCRIPTION
Fixes #2390

## Problem

IALIGN=16 forbids instruction addresses with bit 0 set (even with the C extension). Unicorn accepts an externally supplied odd PC at the emulator entry and fetches at that address; branch-target checks in `trans_rvi.inc.c` do not cover the entry path.

## Change

`qemu/target/riscv/translate.c` `riscv_tr_translate_insn`: when `ctx->base.pc_next & 1`, raise `RISCV_EXCP_INST_ADDR_MIS` before any fetch. The focused unit test is `test_riscv64_odd_pc` in `tests/unit/test_riscv.c`.

## Validation

- Rebased onto `dev`.
- The public U54 witness traps before the first fetch.
- Aligned entry and legal compressed/32-bit controls remain functional.

Public reproducer:
https://github.com/carlosqwqqwq/unicorn-riscv-repros/tree/main/u025
