### PR TITLE
riscv: keep mstatus.MPP=M after mret on harts without U-mode

### DIFF
--- a/qemu/target/riscv/op_helper.c
+++ b/qemu/target/riscv/op_helper.c
@@ -149,7 +149,8 @@ target_ulong helper_mret(CPURISCVState *env, target_ulong cpu_pc_deb)
         MSTATUS_MIE : MSTATUS_UIE << prev_priv,
         get_field(mstatus, MSTATUS_MPIE));
     mstatus = set_field(mstatus, MSTATUS_MPIE, 1);
-    mstatus = set_field(mstatus, MSTATUS_MPP, PRV_U);
+    mstatus = set_field(mstatus, MSTATUS_MPP,
+                        riscv_has_ext(env, RVU) ? PRV_U : PRV_M);
 #ifdef TARGET_RISCV32
     env->mstatush = set_field(env->mstatush, MSTATUS_MPV, 0);
 #else

--- a/tests/unit/test_riscv.c
+++ b/tests/unit/test_riscv.c
@@ -55,6 +55,30 @@ static void test_riscv64_nop(void)
     OK(uc_close(uc));
 }
 
+static void test_riscv64_mret_without_u(void)
+{
+    uc_engine *uc;
+    const char code[] = "\x73\x00\x20\x30"; // mret
+    uint64_t misa;
+    uint64_t mstatus = 3ULL << 11;
+    uint64_t mepc = code_start + sizeof(code) - 1;
+
+    OK(uc_open(UC_ARCH_RISCV, UC_MODE_RISCV64, &uc));
+    OK(uc_mem_map(uc, code_start, code_len, UC_PROT_ALL));
+    OK(uc_mem_write(uc, code_start, code, sizeof(code) - 1));
+    OK(uc_reg_read(uc, UC_RISCV_REG_MISA, &misa));
+    misa &= ~(1ULL << 20);
+    OK(uc_reg_write(uc, UC_RISCV_REG_MISA, &misa));
+    OK(uc_reg_write(uc, UC_RISCV_REG_MSTATUS, &mstatus));
+    OK(uc_reg_write(uc, UC_RISCV_REG_MEPC, &mepc));
+
+    OK(uc_emu_start(uc, code_start,
+                    code_start + sizeof(code) - 1, 0, 0));
+    OK(uc_reg_read(uc, UC_RISCV_REG_MSTATUS, &mstatus));
+    TEST_CHECK(((mstatus >> 11) & 3) == 3);
+    OK(uc_close(uc));
+}
+
 static void test_riscv32_until_pc_update(void)
 {
     uc_engine *uc;
@@ -911,6 +935,7 @@ static void test_riscv_priv(void)
 TEST_LIST = {
     {"test_riscv32_nop", test_riscv32_nop},
     {"test_riscv64_nop", test_riscv64_nop},
+    {"test_riscv64_mret_without_u", test_riscv64_mret_without_u},
     {"test_riscv32_3steps_pc_update", test_riscv32_3steps_pc_update},
     {"test_riscv64_3steps_pc_update", test_riscv64_3steps_pc_update},
     {"test_riscv64_until_at_page_end", test_riscv64_until_at_page_end},


### PR DESCRIPTION
Fixes #2391

## Problem

`helper_mret` unconditionally writes `mstatus.MPP = PRV_U`. On a hart whose MISA does not include U, the least-privileged supported mode is M, so after `mret` the MPP field must read 3, not 0. The reproducer runs on a locally built no-U model library (default `riscv_any` with RVU cleared; stock E51/U54 keep U as the control).

## Change

`qemu/target/riscv/op_helper.c` `helper_mret` selects `PRV_U` only when `RVU` is present and `PRV_M` otherwise. The focused unit test is `test_riscv64_mret_without_u` in `tests/unit/test_riscv.c`.

## Validation

- Rebased onto `dev` and built the RISC-V targets.
- The public `u034` suite includes the U-clear profile patch and an explicit U-enabled control.
- The no-U witness reads back MPP=M; U-enabled behavior remains unchanged.

Public reproducer and explicit profile setup:
https://github.com/carlosqwqqwq/unicorn-riscv-repros/tree/main/u034
