### PR TITLE
fix: riscv PC advance for compressed instructions and fetch faults

### DIFF
--- a/qemu/accel/tcg/cpu-exec.c
+++ b/qemu/accel/tcg/cpu-exec.c
@@ -391,8 +391,8 @@ static inline bool cpu_handle_exception(CPUState *cpu, int *ret)
         env->active_tc.PC = uc->next_pc;
 #endif
 #if defined(TARGET_RISCV)
-        CPURISCVState *env = &(RISCV_CPU(uc->cpu)->env);
-        env->pc += 4;
+        riscv_cpu_prepare_exception_pc(&(RISCV_CPU(uc->cpu)->env),
+                                       cpu->exception_index);
 #endif
 #if defined(TARGET_SPARC)
         CPUSPARCState *env = &(SPARC_CPU(uc->cpu)->env);

--- a/qemu/riscv32.h
+++ b/qemu/riscv32.h
@@ -1311,6 +1311,7 @@
 #define riscv_cpu_do_unaligned_access riscv_cpu_do_unaligned_access_riscv32
 #define riscv_cpu_tlb_fill riscv_cpu_tlb_fill_riscv32
 #define riscv_cpu_do_interrupt riscv_cpu_do_interrupt_riscv32
+#define riscv_cpu_prepare_exception_pc riscv_cpu_prepare_exception_pc_riscv32
 #define riscv_get_csr_ops riscv_get_csr_ops_riscv32
 #define riscv_set_csr_ops riscv_set_csr_ops_riscv32
 #define riscv_csrrw riscv_csrrw_riscv32

--- a/qemu/riscv64.h
+++ b/qemu/riscv64.h
@@ -1311,6 +1311,7 @@
 #define riscv_cpu_do_unaligned_access riscv_cpu_do_unaligned_access_riscv64
 #define riscv_cpu_tlb_fill riscv_cpu_tlb_fill_riscv64
 #define riscv_cpu_do_interrupt riscv_cpu_do_interrupt_riscv64
+#define riscv_cpu_prepare_exception_pc riscv_cpu_prepare_exception_pc_riscv64
 #define riscv_get_csr_ops riscv_get_csr_ops_riscv64
 #define riscv_set_csr_ops riscv_set_csr_ops_riscv64
 #define riscv_csrrw riscv_csrrw_riscv64

--- a/qemu/target/riscv/cpu.h
+++ b/qemu/target/riscv/cpu.h
@@ -290,6 +290,7 @@ void riscv_cpu_set_virt_enabled(CPURISCVState *env, bool enable);
 bool riscv_cpu_force_hs_excep_enabled(CPURISCVState *env);
 void riscv_cpu_set_force_hs_excep(CPURISCVState *env, bool enable);
 int riscv_cpu_mmu_index(CPURISCVState *env, bool ifetch);
+void riscv_cpu_prepare_exception_pc(CPURISCVState *env, uint32_t cause);
 hwaddr riscv_cpu_get_phys_page_debug(CPUState *cpu, vaddr addr);
 void  riscv_cpu_do_unaligned_access(CPUState *cs, vaddr addr,
                                     MMUAccessType access_type, int mmu_idx,

--- a/qemu/target/riscv/cpu_helper.c
+++ b/qemu/target/riscv/cpu_helper.c
@@ -820,6 +820,59 @@ bool riscv_cpu_tlb_fill(CPUState *cs, vaddr address, int size,
 }
 
 /*
+ * Return true if a synchronous exception carries a faulting address in
+ * env->badaddr (used as the machine trap value, mbadaddr/mtval).
+ */
+static bool riscv_cpu_exception_has_badaddr(target_ulong cause)
+{
+    switch (cause) {
+    case RISCV_EXCP_INST_GUEST_PAGE_FAULT:
+    case RISCV_EXCP_LOAD_GUEST_ACCESS_FAULT:
+    case RISCV_EXCP_STORE_GUEST_AMO_ACCESS_FAULT:
+    case RISCV_EXCP_INST_ADDR_MIS:
+    case RISCV_EXCP_INST_ACCESS_FAULT:
+    case RISCV_EXCP_LOAD_ADDR_MIS:
+    case RISCV_EXCP_STORE_AMO_ADDR_MIS:
+    case RISCV_EXCP_LOAD_ACCESS_FAULT:
+    case RISCV_EXCP_STORE_AMO_ACCESS_FAULT:
+    case RISCV_EXCP_INST_PAGE_FAULT:
+    case RISCV_EXCP_LOAD_PAGE_FAULT:
+    case RISCV_EXCP_STORE_PAGE_FAULT:
+        return true;
+    default:
+        return false;
+    }
+}
+
+/*
+ * Unicorn helper: prepare the PC for a UC_HOOK_INTR callback.  This mirrors
+ * the state riscv_cpu_do_interrupt would have set up (mbadaddr from badaddr
+ * for address-bearing exceptions) and advances the PC past the faulting
+ * instruction.  Instruction fetch faults already hold the faulting address
+ * in env->pc and are left untouched.
+ */
+void riscv_cpu_prepare_exception_pc(CPURISCVState *env, uint32_t cause)
+{
+    if (riscv_cpu_exception_has_badaddr(cause)) {
+        env->mbadaddr = env->badaddr;
+    }
+
+    if (cause == RISCV_EXCP_INST_ADDR_MIS ||
+        cause == RISCV_EXCP_INST_ACCESS_FAULT ||
+        cause == RISCV_EXCP_INST_PAGE_FAULT) {
+        return;
+    }
+
+    /*
+     * Execution-time exception: advance past the faulting instruction.
+     * RISC-V instructions are 16 or 32 bits, selected by the two
+     * least-significant bits of the opcode.
+     */
+    uint16_t op = cpu_lduw_code(env, env->pc);
+    env->pc += ((op & 0x3) == 0x3) ? 4 : 2;
+}
+
+/*
  * Handle Traps
  *
  * Adapted from Spike's processor_t::take_trap.
@@ -844,25 +897,13 @@ void riscv_cpu_do_interrupt(CPUState *cs)
 
     if (!async) {
         /* set tval to badaddr for traps with address information */
-        switch (cause) {
-        case RISCV_EXCP_INST_GUEST_PAGE_FAULT:
-        case RISCV_EXCP_LOAD_GUEST_ACCESS_FAULT:
-        case RISCV_EXCP_STORE_GUEST_AMO_ACCESS_FAULT:
-            force_hs_execp = true;
-            /* fallthrough */
-        case RISCV_EXCP_INST_ADDR_MIS:
-        case RISCV_EXCP_INST_ACCESS_FAULT:
-        case RISCV_EXCP_LOAD_ADDR_MIS:
-        case RISCV_EXCP_STORE_AMO_ADDR_MIS:
-        case RISCV_EXCP_LOAD_ACCESS_FAULT:
-        case RISCV_EXCP_STORE_AMO_ACCESS_FAULT:
-        case RISCV_EXCP_INST_PAGE_FAULT:
-        case RISCV_EXCP_LOAD_PAGE_FAULT:
-        case RISCV_EXCP_STORE_PAGE_FAULT:
+        if (riscv_cpu_exception_has_badaddr(cause)) {
             tval = env->badaddr;
-            break;
-        default:
-            break;
+        }
+        if (cause == RISCV_EXCP_INST_GUEST_PAGE_FAULT ||
+            cause == RISCV_EXCP_LOAD_GUEST_ACCESS_FAULT ||
+            cause == RISCV_EXCP_STORE_GUEST_AMO_ACCESS_FAULT) {
+            force_hs_execp = true;
         }
         /* ecall is dispatched as one cause so translate based on mode */
         if (cause == RISCV_EXCP_U_ECALL) {


### PR DESCRIPTION
`cpu_handle_exception` unconditionally does `env->pc += 4` for RISC-V.  This corrupts the PC for 16-bit compressed instructions and for instruction access/page faults (where `env->pc` already holds the faulting address and must not be advanced).  It also leaves the faulting address unavailable to `UC_HOOK_INTR` callbacks.

Changes:

- Advance `env->pc` by the real instruction size (2 or 4 bytes, determined by the low two opcode bits) for execution-time exceptions.
- Skip the advance for `INST_ADDR_MIS`, `INST_ACCESS_FAULT`, `INST_PAGE_FAULT`.
- Mirror `riscv_cpu_do_interrupt` and set `env->mbadaddr = env->badaddr` for every address-bearing exception, so the callback can recover from e.g. PMP faults.

Verified by booting a RISC-V firmware under Unicorn whose syscall/return path is full of compressed instructions and relies on lazy PMP fault recovery.