### PR TITLE
tests/unit/test_x86.c: Fix and expand `test_x86_vpermilps_null_ptr_call`

### DIFF
--- a/tests/unit/test_x86.c
+++ b/tests/unit/test_x86.c
@@ -3533,15 +3533,27 @@ static void test_x86_ro_segfault(void)
 
 static void test_x86_vpermilps_null_ptr_call(void)
 {
-    char code[] = {
+    char code_modrm_00[] = {
+        0x0f, 0x38, 0x0c, 0x00
+    };
+
+    char code_modrm_ff[] = {
         0x0f, 0x38, 0x0c, 0xff
     };
 
-    uc_engine *uc;
-    uc_common_setup(&uc, UC_ARCH_X86, UC_MODE_64, code, sizeof code - 1);
+    uc_engine *uc = NULL;
+    uc_common_setup(&uc, UC_ARCH_X86, UC_MODE_64, code_modrm_00, sizeof(code_modrm_00));
 
     uc_assert_err(UC_ERR_INSN_INVALID,
-            uc_emu_start(uc, code_start, code_start + sizeof code - 1, 0, 0));
+            uc_emu_start(uc, code_start, code_start + sizeof(code_modrm_00), 0, 0));
+
+    OK(uc_close(uc));
+
+    uc = NULL;
+    uc_common_setup(&uc, UC_ARCH_X86, UC_MODE_64, code_modrm_ff, sizeof(code_modrm_ff));
+
+    uc_assert_err(UC_ERR_INSN_INVALID,
+            uc_emu_start(uc, code_start, code_start + sizeof(code_modrm_ff), 0, 0));
 
     OK(uc_close(uc));
 }


### PR DESCRIPTION
The original variant of that test passed an incorrectly calculated size parameter, which led to `0F 38 0C 00` being executed instead of `0F 38 0C FF`.

This commit fixes that and explicitly tests both variants of the instruction.

(Follow-up to #2399 since it was already merged at the time I discovered this)